### PR TITLE
feat: :sparkles: authenticated catalog covers via Coil + thumbnail-rel parsing

### DIFF
--- a/app/src/main/java/io/theficos/ereader/EReaderApp.kt
+++ b/app/src/main/java/io/theficos/ereader/EReaderApp.kt
@@ -1,9 +1,11 @@
 package io.theficos.ereader
 
 import android.app.Application
+import coil.ImageLoader
+import coil.ImageLoaderFactory
 import io.theficos.ereader.di.AppContainer
 
-class EReaderApp : Application() {
+class EReaderApp : Application(), ImageLoaderFactory {
     lateinit var container: AppContainer
         private set
 
@@ -11,4 +13,9 @@ class EReaderApp : Application() {
         super.onCreate()
         container = AppContainer(this)
     }
+
+    override fun newImageLoader(): ImageLoader =
+        ImageLoader.Builder(this)
+            .okHttpClient(container.opdsHttp.okHttp)
+            .build()
 }

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -20,7 +20,7 @@ class AppContainer(context: Context) {
 
     val credentialStore: CalibreCredentialStore = CalibreCredentialStore(appContext)
 
-    private val opdsHttp = OpdsHttpClient(credentialStore)
+    val opdsHttp = OpdsHttpClient(credentialStore)
     val opdsClient: OpdsClient = OpdsClient(opdsHttp.okHttp)
     val bookDownloader: BookDownloader = BookDownloader(
         okHttp = opdsHttp.okHttp,

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt
@@ -26,6 +26,9 @@ class OpdsClient(
             // Readium silently drops links whose href contains template chars like `{searchTerms}`,
             // so we always look for rel="search" ourselves from the raw XML.
             val searchLink = parseSearchLink(bytes, absoluteUrl)
+            // Readium also drops opds:image/thumbnail links unless a sibling opds:image link
+            // is present, so we pull cover hrefs from the raw XML and join by acquisition href.
+            val coversByEpubHref = parseCoverHrefs(bytes, absoluteUrl)
             OpdsFeed(
                 title = feed.metadata.title,
                 navigation = feed.navigation.map { link ->
@@ -39,17 +42,12 @@ class OpdsClient(
                         link.rels.contains("http://opds-spec.org/acquisition") &&
                             link.mediaType.toString() == "application/epub+zip"
                     } ?: return@mapNotNull null
-                    val imageLinks = pub.subcollections["images"].orEmpty().flatMap { it.links }
-                    val coverLink = imageLinks.firstOrNull { link ->
-                        link.rels.contains("http://opds-spec.org/image")
-                    } ?: imageLinks.firstOrNull { link ->
-                        link.rels.contains("http://opds-spec.org/image/thumbnail")
-                    } ?: imageLinks.firstOrNull()
+                    val absoluteEpubHref = absolutize(absoluteUrl, epubLink.href.toString())
                     OpdsPublication(
                         title = pub.metadata.title.orEmpty(),
                         author = pub.metadata.authors.firstOrNull()?.name,
-                        epubDownloadHref = absolutize(absoluteUrl, epubLink.href.toString()),
-                        coverUrl = coverLink?.href?.toString()?.let { absolutize(absoluteUrl, it) },
+                        epubDownloadHref = absoluteEpubHref,
+                        coverUrl = coversByEpubHref[absoluteEpubHref],
                     )
                 },
                 searchLink = searchLink,
@@ -62,6 +60,41 @@ class OpdsClient(
         // otherwise URL resolution percent-encodes the braces and the substitution misses.
         val rawTemplate = if (link.isDescription) fetchSearchTemplate(link.href) else link.href
         return absolutize(link.baseUrl, applyTemplate(rawTemplate, query))
+    }
+
+    private fun parseCoverHrefs(bytes: ByteArray, feedUrl: String): Map<String, String> {
+        val doc = runCatching {
+            DocumentBuilderFactory.newInstance()
+                .apply { isNamespaceAware = true }
+                .newDocumentBuilder()
+                .parse(ByteArrayInputStream(bytes))
+        }.getOrNull() ?: return emptyMap()
+        val entries = doc.getElementsByTagNameNS("http://www.w3.org/2005/Atom", "entry")
+        val result = mutableMapOf<String, String>()
+        for (i in 0 until entries.length) {
+            val entry = entries.item(i) as org.w3c.dom.Element
+            val links = entry.getElementsByTagNameNS("http://www.w3.org/2005/Atom", "link")
+            var epubHref: String? = null
+            var thumbnailHref: String? = null
+            var imageHref: String? = null
+            for (j in 0 until links.length) {
+                val el = links.item(j) as org.w3c.dom.Element
+                val rel = el.getAttribute("rel")
+                val href = el.getAttribute("href").takeIf { it.isNotBlank() } ?: continue
+                when (rel) {
+                    "http://opds-spec.org/acquisition" -> {
+                        if (el.getAttribute("type") == "application/epub+zip") epubHref = href
+                    }
+                    "http://opds-spec.org/image/thumbnail" -> thumbnailHref = href
+                    "http://opds-spec.org/image" -> imageHref = href
+                }
+            }
+            val cover = thumbnailHref ?: imageHref
+            if (epubHref != null && cover != null) {
+                result[absolutize(feedUrl, epubHref)] = absolutize(feedUrl, cover)
+            }
+        }
+        return result
     }
 
     private fun parseSearchLink(bytes: ByteArray, feedUrl: String): OpdsSearchLink? {

--- a/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
+++ b/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
@@ -42,6 +42,10 @@ class OpdsClientTest {
                         .setBody(resource("/opds/catalog-with-direct-search.xml"))
                     "/opds/osd" -> MockResponse().setHeader("Content-Type", "application/opensearchdescription+xml")
                         .setBody(resource("/opds/opensearch.xml"))
+                    "/opds/both" -> MockResponse().setHeader("Content-Type", "application/atom+xml")
+                        .setBody(resource("/opds/catalog-feed-thumbnail-and-image.xml"))
+                    "/opds/thumb-only" -> MockResponse().setHeader("Content-Type", "application/atom+xml")
+                        .setBody(resource("/opds/catalog-feed-thumbnail-only.xml"))
                     else -> MockResponse().setResponseCode(404)
                 }
             }
@@ -109,6 +113,27 @@ class OpdsClientTest {
         assertThat(resolved).contains("/opds/search/tolkien")
         assertThat(resolved).doesNotContain("{")
         assertThat(resolved).doesNotContain("startIndex={")
+    }
+
+    @Test fun `cover prefers thumbnail rel when both rels present`() = runTest {
+        val feed = client.fetch(server.url("/opds/both").toString())
+        val pub = feed.publications.single()
+        assertThat(pub.coverUrl).isNotNull()
+        assertThat(pub.coverUrl).endsWith("/opds/cover/42/thumb")
+    }
+
+    @Test fun `cover uses thumbnail rel when only thumbnail is present`() = runTest {
+        val feed = client.fetch(server.url("/opds/thumb-only").toString())
+        val pub = feed.publications.single()
+        assertThat(pub.coverUrl).isNotNull()
+        assertThat(pub.coverUrl).endsWith("/opds/cover/42/thumb")
+    }
+
+    @Test fun `cover falls back to full-size image rel when thumbnail is absent`() = runTest {
+        val feed = client.fetch(server.url("/opds/new").toString())
+        val pub = feed.publications.single()
+        assertThat(pub.coverUrl).isNotNull()
+        assertThat(pub.coverUrl).endsWith("/opds/cover/42")
     }
 
 }

--- a/data/opds/src/test/resources/opds/catalog-feed-thumbnail-and-image.xml
+++ b/data/opds/src/test/resources/opds/catalog-feed-thumbnail-and-image.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:dc="http://purl.org/dc/terms/">
+  <id>urn:calibre-web:both</id>
+  <title>Both Rels</title>
+  <updated>2026-04-26T00:00:00Z</updated>
+  <link rel="self" href="/opds/both" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+  <entry>
+    <title>The Sample Book</title>
+    <id>urn:calibre-web:42</id>
+    <updated>2026-04-26T00:00:00Z</updated>
+    <author><name>Jane Doe</name></author>
+    <dc:identifier>urn:uuid:550e8400-e29b-41d4-a716-446655440000</dc:identifier>
+    <link rel="http://opds-spec.org/acquisition" href="/opds/download/42/epub" type="application/epub+zip"/>
+    <link rel="http://opds-spec.org/image" href="/opds/cover/42" type="image/jpeg"/>
+    <link rel="http://opds-spec.org/image/thumbnail" href="/opds/cover/42/thumb" type="image/jpeg"/>
+  </entry>
+</feed>

--- a/data/opds/src/test/resources/opds/catalog-feed-thumbnail-only.xml
+++ b/data/opds/src/test/resources/opds/catalog-feed-thumbnail-only.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:dc="http://purl.org/dc/terms/">
+  <id>urn:calibre-web:thumb-only</id>
+  <title>Thumb Only</title>
+  <updated>2026-04-26T00:00:00Z</updated>
+  <link rel="self" href="/opds/thumb-only" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+  <entry>
+    <title>The Sample Book</title>
+    <id>urn:calibre-web:42</id>
+    <updated>2026-04-26T00:00:00Z</updated>
+    <author><name>Jane Doe</name></author>
+    <dc:identifier>urn:uuid:550e8400-e29b-41d4-a716-446655440000</dc:identifier>
+    <link rel="http://opds-spec.org/acquisition" href="/opds/download/42/epub" type="application/epub+zip"/>
+    <link rel="http://opds-spec.org/image/thumbnail" href="/opds/cover/42/thumb" type="image/jpeg"/>
+  </entry>
+</feed>

--- a/docs/superpowers/plans/2026-05-07-catalog-covers.md
+++ b/docs/superpowers/plans/2026-05-07-catalog-covers.md
@@ -1,0 +1,342 @@
+# Catalog Covers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make catalog covers actually load by wiring Coil to the auth-enabled OPDS `OkHttpClient`, and prefer `rel="…/image/thumbnail"` over `rel="…/image"` for grid-sized requests.
+
+**Architecture:** Two narrowly-scoped changes. (1) `EReaderApp` implements `coil.ImageLoaderFactory` and builds an `ImageLoader` with the existing `OpdsHttpClient.okHttp`, so Coil inherits `BasicAuthInterceptor`. (2) `OpdsClient` reorders the cover-link selection so the thumbnail rel wins when both are present. `CoverImage` is unchanged.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Coil 2.7 (`io.coil-kt:coil-compose`), OkHttp, Robolectric + MockWebServer + Truth for tests, Gradle via `scripts/dgradle` (Docker).
+
+**Spec:** `docs/superpowers/specs/2026-05-07-catalog-covers-design.md`
+
+**Branch:** `feature/catalog-covers-auth` (already created)
+
+**Build/test rule:** Always use `scripts/dgradle …` from the repo root; never the host `./gradlew`.
+
+---
+
+## File Structure
+
+Files this plan creates or modifies:
+
+- **Modify** `data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt` — reorder image-rel preference (lines 42–47).
+- **Create** `data/opds/src/test/resources/opds/catalog-feed-thumbnail-and-image.xml` — fixture: entry exposing both rels.
+- **Create** `data/opds/src/test/resources/opds/catalog-feed-thumbnail-only.xml` — fixture: entry exposing only the thumbnail rel.
+- **Modify** `data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt` — extend dispatcher with the two new fixtures, add three parser tests.
+- **Modify** `app/src/main/java/io/theficos/ereader/di/AppContainer.kt` — promote `opdsHttp` from `private` to public so the `Application` can read its `okHttp`.
+- **Modify** `app/src/main/java/io/theficos/ereader/EReaderApp.kt` — implement `coil.ImageLoaderFactory`.
+
+The existing fixture `catalog-feed.xml` (image-only) stays as-is, preserving the existing `coverUrl` assertion. The new fixtures are additive.
+
+---
+
+## Task 1: Add OPDS test fixtures for both-rels and thumbnail-only cases
+
+**Files:**
+- Create: `data/opds/src/test/resources/opds/catalog-feed-thumbnail-and-image.xml`
+- Create: `data/opds/src/test/resources/opds/catalog-feed-thumbnail-only.xml`
+
+These fixtures back the parser tests in Task 2. No code changes yet.
+
+- [ ] **Step 1: Create the both-rels fixture**
+
+Write `data/opds/src/test/resources/opds/catalog-feed-thumbnail-and-image.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:dc="http://purl.org/dc/terms/">
+  <id>urn:calibre-web:both</id>
+  <title>Both Rels</title>
+  <updated>2026-04-26T00:00:00Z</updated>
+  <link rel="self" href="/opds/both" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+  <entry>
+    <title>The Sample Book</title>
+    <id>urn:calibre-web:42</id>
+    <updated>2026-04-26T00:00:00Z</updated>
+    <author><name>Jane Doe</name></author>
+    <dc:identifier>urn:uuid:550e8400-e29b-41d4-a716-446655440000</dc:identifier>
+    <link rel="http://opds-spec.org/acquisition" href="/opds/download/42/epub" type="application/epub+zip"/>
+    <link rel="http://opds-spec.org/image" href="/opds/cover/42" type="image/jpeg"/>
+    <link rel="http://opds-spec.org/image/thumbnail" href="/opds/cover/42/thumb" type="image/jpeg"/>
+  </entry>
+</feed>
+```
+
+- [ ] **Step 2: Create the thumbnail-only fixture**
+
+Write `data/opds/src/test/resources/opds/catalog-feed-thumbnail-only.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:dc="http://purl.org/dc/terms/">
+  <id>urn:calibre-web:thumb-only</id>
+  <title>Thumb Only</title>
+  <updated>2026-04-26T00:00:00Z</updated>
+  <link rel="self" href="/opds/thumb-only" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+  <entry>
+    <title>The Sample Book</title>
+    <id>urn:calibre-web:42</id>
+    <updated>2026-04-26T00:00:00Z</updated>
+    <author><name>Jane Doe</name></author>
+    <dc:identifier>urn:uuid:550e8400-e29b-41d4-a716-446655440000</dc:identifier>
+    <link rel="http://opds-spec.org/acquisition" href="/opds/download/42/epub" type="application/epub+zip"/>
+    <link rel="http://opds-spec.org/image/thumbnail" href="/opds/cover/42/thumb" type="image/jpeg"/>
+  </entry>
+</feed>
+```
+
+- [ ] **Step 3: Stage the fixtures (no commit yet)**
+
+Run: `git add data/opds/src/test/resources/opds/catalog-feed-thumbnail-and-image.xml data/opds/src/test/resources/opds/catalog-feed-thumbnail-only.xml`
+
+We commit fixtures together with the parser change in Task 3 so the repository never contains "fixtures referenced by no test."
+
+---
+
+## Task 2: Write failing parser tests
+
+**Files:**
+- Modify: `data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt`
+
+Add the two new fixtures to the `MockWebServer` dispatcher and add three new tests covering the rel-preference rules:
+
+1. Both rels present → thumbnail wins.
+2. Thumbnail only → thumbnail returned (regression guard).
+3. Image only → image returned. *Already covered* by the existing `fetch acquisition feed extracts cover URL` test against `catalog-feed.xml`. No new test needed for this case, but verify the existing test still passes after Task 3.
+
+- [ ] **Step 1: Extend the dispatcher with the new fixture paths**
+
+In `OpdsClientTest.kt`, in the `setUp()` method's `dispatcher` `when (path) { … }` block, add two more branches **before** the `else` branch:
+
+```kotlin
+"/opds/both" -> MockResponse().setHeader("Content-Type", "application/atom+xml")
+    .setBody(resource("/opds/catalog-feed-thumbnail-and-image.xml"))
+"/opds/thumb-only" -> MockResponse().setHeader("Content-Type", "application/atom+xml")
+    .setBody(resource("/opds/catalog-feed-thumbnail-only.xml"))
+```
+
+The `resource(...)` helper already exists at line 53 of the file.
+
+- [ ] **Step 2: Add the three parser tests**
+
+Append these three `@Test` functions to `OpdsClientTest` (immediately before the final closing `}`):
+
+```kotlin
+@Test fun `cover prefers thumbnail rel when both rels present`() = runTest {
+    val feed = client.fetch(server.url("/opds/both").toString())
+    val pub = feed.publications.single()
+    assertThat(pub.coverUrl).isNotNull()
+    assertThat(pub.coverUrl).endsWith("/opds/cover/42/thumb")
+}
+
+@Test fun `cover uses thumbnail rel when only thumbnail is present`() = runTest {
+    val feed = client.fetch(server.url("/opds/thumb-only").toString())
+    val pub = feed.publications.single()
+    assertThat(pub.coverUrl).isNotNull()
+    assertThat(pub.coverUrl).endsWith("/opds/cover/42/thumb")
+}
+
+@Test fun `cover falls back to full-size image rel when thumbnail is absent`() = runTest {
+    // catalog-feed.xml exposes only rel="…/image"; the existing extracts-cover-URL test
+    // also covers this case, but we keep an explicit assertion here so the rel-preference
+    // contract is fully spelled out by tests in one place.
+    val feed = client.fetch(server.url("/opds/new").toString())
+    val pub = feed.publications.single()
+    assertThat(pub.coverUrl).isNotNull()
+    assertThat(pub.coverUrl).endsWith("/opds/cover/42")
+}
+
+```
+
+- [ ] **Step 3: Run the new tests and verify they fail**
+
+Run: `scripts/dgradle :data:opds:test --tests 'io.theficos.ereader.data.opds.OpdsClientTest.cover*'`
+
+Expected:
+- `cover prefers thumbnail rel when both rels present` → **FAIL**: assertion expects URL ending `/thumb`, actual ends with `/opds/cover/42` (because the current parser prefers `image` over `image/thumbnail`).
+- `cover uses thumbnail rel when only thumbnail is present` → **PASS** (current parser falls through to thumbnail in this case).
+- `cover falls back to full-size image rel when thumbnail is absent` → **PASS** (current parser already handles this).
+
+If the first test passes, the parser already behaves correctly and Task 3 is unnecessary — stop and report. If a different test fails unexpectedly, debug the fixture or dispatcher wiring before proceeding.
+
+---
+
+## Task 3: Reorder image-rel preference in `OpdsClient`
+
+**Files:**
+- Modify: `data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt:42-47`
+
+- [ ] **Step 1: Edit the cover-link selection block**
+
+In `OpdsClient.kt`, replace the block at lines 42–47:
+
+```kotlin
+                    val imageLinks = pub.subcollections["images"].orEmpty().flatMap { it.links }
+                    val coverLink = imageLinks.firstOrNull { link ->
+                        link.rels.contains("http://opds-spec.org/image")
+                    } ?: imageLinks.firstOrNull { link ->
+                        link.rels.contains("http://opds-spec.org/image/thumbnail")
+                    } ?: imageLinks.firstOrNull()
+```
+
+with:
+
+```kotlin
+                    val imageLinks = pub.subcollections["images"].orEmpty().flatMap { it.links }
+                    val coverLink = imageLinks.firstOrNull { link ->
+                        link.rels.contains("http://opds-spec.org/image/thumbnail")
+                    } ?: imageLinks.firstOrNull { link ->
+                        link.rels.contains("http://opds-spec.org/image")
+                    } ?: imageLinks.firstOrNull()
+```
+
+Only the order of the first two `firstOrNull` checks changes. The third (any-image fallback) is unchanged.
+
+- [ ] **Step 2: Run the parser tests, expect all green**
+
+Run: `scripts/dgradle :data:opds:test --tests 'io.theficos.ereader.data.opds.OpdsClientTest'`
+
+Expected: all `OpdsClientTest` tests pass, including the previously-failing `cover prefers thumbnail rel when both rels present`.
+
+- [ ] **Step 3: Run the full data:opds test suite to catch regressions**
+
+Run: `scripts/dgradle :data:opds:test`
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit the parser change with its tests and fixtures**
+
+```bash
+git add data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt \
+        data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt \
+        data/opds/src/test/resources/opds/catalog-feed-thumbnail-and-image.xml \
+        data/opds/src/test/resources/opds/catalog-feed-thumbnail-only.xml
+git commit -m "feat: :sparkles: prefer OPDS thumbnail rel over full image for catalog covers"
+```
+
+(Repo style is gitmoji + conventional commits — see `feature/catalog-covers-auth`'s parent `main` history.)
+
+---
+
+## Task 4: Wire Coil to the OPDS `OkHttpClient`
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/di/AppContainer.kt:23` (`private val opdsHttp` → `val opdsHttp`)
+- Modify: `app/src/main/java/io/theficos/ereader/EReaderApp.kt`
+
+No new unit test — the wiring is exercised by manual verification (Step 5). Coil's `ImageLoaderFactory` is its supported, lazy-resolved hook; no further plumbing is needed.
+
+- [ ] **Step 1: Expose `opdsHttp` from `AppContainer`**
+
+In `app/src/main/java/io/theficos/ereader/di/AppContainer.kt`, change line 23 from:
+
+```kotlin
+    private val opdsHttp = OpdsHttpClient(credentialStore)
+```
+
+to:
+
+```kotlin
+    val opdsHttp = OpdsHttpClient(credentialStore)
+```
+
+No other changes to `AppContainer`. Existing callers (`opdsClient`, `bookDownloader`, `syncClient`) use `opdsHttp.okHttp` from inside the class and are unaffected.
+
+- [ ] **Step 2: Make `EReaderApp` an `ImageLoaderFactory`**
+
+Replace the entire contents of `app/src/main/java/io/theficos/ereader/EReaderApp.kt`:
+
+```kotlin
+package io.theficos.ereader
+
+import android.app.Application
+import coil.ImageLoader
+import coil.ImageLoaderFactory
+import io.theficos.ereader.di.AppContainer
+
+class EReaderApp : Application(), ImageLoaderFactory {
+    lateinit var container: AppContainer
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        container = AppContainer(this)
+    }
+
+    override fun newImageLoader(): ImageLoader =
+        ImageLoader.Builder(this)
+            .okHttpClient(container.opdsHttp.okHttp)
+            .build()
+}
+```
+
+Coil resolves `ImageLoaderFactory` lazily on first `AsyncImage` use (well after `onCreate()` has run), so the `lateinit` initialization order is safe. The `coil-compose` artifact already on the classpath transitively provides `coil.ImageLoader` and `coil.ImageLoaderFactory`.
+
+- [ ] **Step 3: Build the debug APK to confirm the module compiles**
+
+Run: `scripts/dgradle :app:assembleDebug`
+
+Expected: BUILD SUCCESSFUL with `app/build/outputs/apk/debug/app-debug.apk` produced. If it fails on missing imports, double-check that `coil.ImageLoader` and `coil.ImageLoaderFactory` resolve — both ship in `io.coil-kt:coil-compose:2.7.0` via the transitive `coil-base` / `coil-core` dependency, and no `build.gradle.kts` change is needed.
+
+- [ ] **Step 4: Run the relevant unit-test suites to catch regressions**
+
+Run: `scripts/dgradle :app:testDebugUnitTest :data:opds:test`
+
+Expected: BUILD SUCCESSFUL. We deliberately scope to these modules — full-repo `test` is slower and not informative for this change.
+
+- [ ] **Step 5: Manual verification on a real device/emulator**
+
+This step requires a calibre-web instance with Basic auth and at least one book whose cover is served behind that auth. The agent should describe — but not perform — this step if no such environment is available, and ask the user to do it.
+
+1. Install the freshly-built debug APK on a connected device or running emulator: `scripts/dgradle :app:installDebug` (or `adb install -r app/build/outputs/apk/debug/app-debug.apk`).
+2. Launch the app, sign in to the calibre-web instance, navigate into a non-empty acquisition feed.
+3. **Expected:** real cover artwork populates the 2-column grid for entries that ship a cover. Entries with no cover link still show the gradient + initials fallback.
+4. **Negative check:** sign out (or clear credentials), reopen the catalog. Auth fails; covers fall back to gradient + initials. (This confirms covers are travelling through the authenticated client and aren't being served unauthenticated.)
+5. **Sub-feed check:** navigate into a category and confirm covers populate post-navigation, not only on the root feed.
+
+If covers still show only fallbacks despite a working auth, the most likely root cause is that the `ImageLoaderFactory` is not being picked up — confirm `EReaderApp` is the `android:name` of the application in `AndroidManifest.xml`. (It already is in this repo, but the check costs nothing.)
+
+- [ ] **Step 6: Commit the wiring change**
+
+```bash
+git add app/src/main/java/io/theficos/ereader/EReaderApp.kt \
+        app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+git commit -m "feat: :sparkles: route Coil image loads through authenticated OPDS OkHttp client"
+```
+
+---
+
+## Task 5: Final verification + push
+
+- [ ] **Step 1: Re-run the targeted test suites once more on the final state**
+
+Run: `scripts/dgradle :app:testDebugUnitTest :data:opds:test`
+
+Expected: BUILD SUCCESSFUL. This guards against a working-tree edit between commits.
+
+- [ ] **Step 2: Inspect the branch's commit history**
+
+Run: `git log --oneline main..HEAD`
+
+Expected: three commits on `feature/catalog-covers-auth` —
+
+1. `docs: :memo: design for authenticated catalog cover loading` (already present)
+2. `feat: :sparkles: prefer OPDS thumbnail rel over full image for catalog covers`
+3. `feat: :sparkles: route Coil image loads through authenticated OPDS OkHttp client`
+
+- [ ] **Step 3: Stop and ask the user before pushing**
+
+Do **not** run `git push` automatically. Report the branch state and ask the user whether to push and/or open a PR.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:**
+  - "Coil `ImageLoader` wired to the OPDS `OkHttpClient`" → Task 4.
+  - "Prefer thumbnail rel in the OPDS parser" → Task 3.
+  - Spec's required parser test cases (both rels, image-only, thumbnail-only, neither, no images) → Task 2 covers both-rels and thumbnail-only; image-only is the existing test against `catalog-feed.xml` (deliberately re-asserted in the new third test). The "neither but generic image link" and "no images at all" cases aren't materially affected by the rel reorder (the third `firstOrNull()` fallback and `null` fallthrough are unchanged), so we don't add fixtures for them — adding tests for un-touched code paths is YAGNI.
+  - Manual verification (auth-on, auth-off, sub-feed) → Task 4 Step 5.
+- **Placeholder scan:** every code/XML block is complete; every command has expected output. No "TBD" / "appropriate error handling" / "fill in details".
+- **Type/name consistency:** `opdsHttp` (property name) and `okHttp` (its field) match `OpdsHttpClient` and `AppContainer` exactly; `ImageLoader` / `ImageLoaderFactory` imports match Coil 2.7's `coil.*` package; rel strings match the constants already in `OpdsClient.kt`.

--- a/docs/superpowers/specs/2026-05-07-catalog-covers-design.md
+++ b/docs/superpowers/specs/2026-05-07-catalog-covers-design.md
@@ -1,0 +1,132 @@
+# Catalog covers: authenticated loading + thumbnail-first parsing
+
+Date: 2026-05-07
+Status: Approved (design)
+
+## Problem
+
+The catalog UI already renders a `CoverImage` per publication in a 2-column
+grid, and `OpdsClient` already extracts an `image`/`image/thumbnail` link into
+`OpdsPublication.coverUrl`. In practice users see only the gradient+initials
+fallback, never the real cover art.
+
+Root cause: Coil is not configured with the auth-enabled OPDS `OkHttpClient`.
+With no `ImageLoaderFactory` registered on the `Application`, Coil uses its
+default singleton, which has no `BasicAuthInterceptor`. Cover requests to a
+calibre-web instance therefore return 401 and the `error =` branch of
+`SubcomposeAsyncImage` falls back to initials.
+
+A secondary issue: when a feed exposes both `rel="…/image"` and
+`rel="…/image/thumbnail"`, the parser currently prefers full-resolution. For a
+2-column grid the thumbnail is the appropriate choice and saves bandwidth.
+
+## Goals
+
+- Covers visible in the catalog grid for auth-protected calibre-web feeds.
+- Use the lightweight thumbnail link when the server provides one.
+- No regression for feeds that only emit one of the two image rels.
+
+## Non-goals
+
+- Custom placeholder shimmer, prefetching, image transformations.
+- Per-host auth strategies (the OPDS client already encapsulates this).
+- Re-styling `CoverImage` or the catalog grid layout.
+- Offline cover storage beyond Coil's default disk cache.
+
+## Design
+
+### Change 1 — Coil `ImageLoader` wired to the OPDS `OkHttpClient`
+
+`EReaderApp` (`app/src/main/java/io/theficos/ereader/EReaderApp.kt`)
+implements `coil.ImageLoaderFactory`. Its `newImageLoader()` builds an
+`ImageLoader` against the existing `OpdsHttpClient.okHttp` instance held by
+`AppContainer`, so every Coil request inherits `BasicAuthInterceptor` (and any
+future auth additions) automatically.
+
+`AppContainer` currently keeps `opdsHttp` private; expose either `opdsHttp` or
+its `okHttp` property so `EReaderApp.newImageLoader()` can read it.
+Construction order is unchanged: `AppContainer` is built in
+`Application.onCreate()` before any composition runs, and Coil reads
+`ImageLoaderFactory` lazily on first `AsyncImage` use, so there is no race.
+
+Coil's default memory and disk caches are sufficient. No custom cache config.
+
+`CoverImage` is unchanged. It already:
+
+- Accepts `Any?` as `source`.
+- Renders a gradient+initials fallback on `loading` and `error`.
+- Crops with `ContentScale.Crop` at a 2:3 aspect ratio.
+
+### Change 2 — Prefer thumbnail rel in the OPDS parser
+
+In `data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt`
+(currently lines 37–53), reorder the cover-link selection:
+
+1. `rel="http://opds-spec.org/image/thumbnail"` — preferred for list/grid use.
+2. `rel="http://opds-spec.org/image"` — full-resolution fallback.
+3. First image link of any rel — last-ditch fallback (unchanged).
+
+URL absolutization (`absolutize(absoluteUrl, …)`) is unchanged. No other
+fields on `OpdsPublication` are affected.
+
+## Testing
+
+### Unit tests (`data/opds`)
+
+Add a parser test fixture covering:
+
+- Feed entry with **both** `image` and `image/thumbnail` → `coverUrl` is the
+  thumbnail href.
+- Feed entry with **only** `image` → `coverUrl` is the `image` href.
+- Feed entry with **only** `image/thumbnail` → `coverUrl` is the thumbnail
+  href (regression guard).
+- Feed entry with **neither** but a generic image link → `coverUrl` is that
+  link's href.
+- Feed entry with **no images at all** → `coverUrl` is `null`.
+
+### Manual verification
+
+- Point the app at a calibre-web instance that requires Basic auth and exposes
+  cover thumbnails. Browse the catalog and confirm real covers populate the
+  grid (not the gradient fallback).
+- Sign out / clear credentials, reopen the catalog, confirm covers fall back
+  to gradient+initials (auth correctly fails — no spurious caching of the
+  authenticated bytes under an unauthenticated identity).
+- Browse a sub-feed (after navigating into a category) to confirm the same
+  works post-navigation, not only on the root feed.
+
+No UI tests required — `CoverImage` and `CatalogScreen` are not modified.
+
+## Risks and edge cases
+
+- **Coil singleton init timing.** Coil reads `ImageLoaderFactory` lazily, so
+  the factory is consulted on first `AsyncImage` use — well after
+  `Application.onCreate()`. No special handling needed.
+- **Cross-host thumbnails.** A few OPDS servers serve thumbnails on a
+  separate, unauthenticated host. The shared interceptor only adds the
+  `Authorization` header when a credential is stored, and external hosts
+  ignore the header gracefully, so a single shared `OkHttpClient` is fine.
+- **Coil disk cache and credential changes.** Coil keys cache entries on URL.
+  If two users sign in to the same calibre-web URL on the same device, the
+  second user could see the first user's cached thumbnail. Acceptable: cover
+  images are not sensitive, and the cache lives only on-device. Document but
+  do not mitigate.
+
+## Files touched
+
+- `app/src/main/java/io/theficos/ereader/EReaderApp.kt` — implement
+  `ImageLoaderFactory`.
+- `app/src/main/java/io/theficos/ereader/di/AppContainer.kt` — expose
+  `opdsHttp` (or its `okHttp`) for reuse by the image loader.
+- `data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt` —
+  reorder image-rel preference.
+- `data/opds/src/test/...` — new parser tests for the rel-preference cases
+  above (test directory and existing test class to be located during
+  implementation).
+
+## Out of scope / follow-ups
+
+- Cover prefetching as the user scrolls.
+- Negotiating thumbnail size with servers that support `?width=` parameters.
+- A shared `ImageLoader` instance in `AppContainer` for non-`AsyncImage`
+  callers (none exist today).

--- a/docs/superpowers/specs/2026-05-07-catalog-covers-design.md
+++ b/docs/superpowers/specs/2026-05-07-catalog-covers-design.md
@@ -57,17 +57,28 @@ Coil's default memory and disk caches are sufficient. No custom cache config.
 - Renders a gradient+initials fallback on `loading` and `error`.
 - Crops with `ContentScale.Crop` at a 2:3 aspect ratio.
 
-### Change 2 — Prefer thumbnail rel in the OPDS parser
+### Change 2 — Cover extraction from raw entry XML, with thumbnail preference
 
-In `data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt`
-(currently lines 37–53), reorder the cover-link selection:
+The original sketch was to reorder Readium's image-rel preference. On
+investigation Readium's OPDS model has a stronger quirk: it groups image
+links into a `pub.subcollections["images"]` collection only when
+`opds:image` is present, and silently drops `opds:image/thumbnail` if it
+appears alone. Reordering rels therefore can't fix the thumbnail-only case.
 
-1. `rel="http://opds-spec.org/image/thumbnail"` — preferred for list/grid use.
+Instead, replace the Readium-driven cover extraction with a small XML-level
+scan, mirroring the existing `parseSearchLink` workaround in the same file
+(which exists for the analogous Readium quirk around `{searchTerms}`
+templates). The scan walks each `<entry>`, collects its image and
+acquisition `<link>` rels, and joins back to Readium's parsed publications
+using the unique acquisition href.
+
+Rel preference within an entry:
+
+1. `rel="http://opds-spec.org/image/thumbnail"` — preferred for list/grid.
 2. `rel="http://opds-spec.org/image"` — full-resolution fallback.
-3. First image link of any rel — last-ditch fallback (unchanged).
 
-URL absolutization (`absolutize(absoluteUrl, …)`) is unchanged. No other
-fields on `OpdsPublication` are affected.
+URL absolutization (`absolutize(absoluteUrl, …)`) is reused unchanged. No
+other fields on `OpdsPublication` are affected.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Wire Coil's `ImageLoader` to the existing OPDS `OkHttpClient` via an `ImageLoaderFactory` on `EReaderApp`, so cover requests inherit the `BasicAuthInterceptor`. Without this, calibre-web cover requests 401'd silently and the catalog grid only ever showed the gradient/initials fallback.
- Replace the Readium-routed cover-link extraction in `OpdsClient` with a small XML scan over each `<entry>`, joined back to publications by acquisition href. Readium's OPDS model populates `pub.subcollections["images"]` only when `opds:image` is present and silently drops `opds:image/thumbnail` when it appears alone — reordering rels couldn't fix the thumbnail-only case. The new scan prefers `opds:image/thumbnail` over `opds:image` (saves bandwidth on a 2-col grid) and mirrors the existing `parseSearchLink` workaround in the same file.
- Spec and implementation plan checked in under `docs/superpowers/`.

## Test plan
- [x] `scripts/dgradle :data:opds:testDebugUnitTest` — new parser tests cover both-rels (thumbnail wins), thumbnail-only, image-only fallback; existing tests unchanged.
- [x] `scripts/dgradle :app:testDebugUnitTest`
- [x] `scripts/dgradle :app:assembleDebug` produces a working APK.
- [x] Sideload + manual: covers populate the catalog grid against an authenticated calibre-web instance; missing covers fall back to the calibre-web placeholder (server-served).