### PR TITLE
:sparkles: Reader & library feature pack

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -13,6 +13,7 @@ import io.theficos.ereader.data.sync.SyncDependencies
 import io.theficos.ereader.data.sync.SyncOrchestrator
 import io.theficos.ereader.reader.ReaderPreferencesStore
 import io.theficos.ereader.reader.ReadiumFactory
+import io.theficos.ereader.ui.library.LibraryPreferencesStore
 import java.io.File
 
 class AppContainer(context: Context) {
@@ -34,6 +35,7 @@ class AppContainer(context: Context) {
     val syncStateDao = db.syncStateDao()
     val readiumFactory = ReadiumFactory(appContext)
     val readerPreferencesStore = ReaderPreferencesStore(appContext)
+    val libraryPreferencesStore = LibraryPreferencesStore(appContext)
 
     val syncClient: SyncClient = SyncClient(
         baseUrlProvider = { credentialStore.get()?.baseUrl },

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -13,6 +13,7 @@ import io.theficos.ereader.data.sync.SyncDependencies
 import io.theficos.ereader.data.sync.SyncOrchestrator
 import io.theficos.ereader.reader.ReaderPreferencesStore
 import io.theficos.ereader.reader.ReadiumFactory
+import io.theficos.ereader.ui.catalog.CatalogPreferencesStore
 import io.theficos.ereader.ui.library.LibraryPreferencesStore
 import java.io.File
 
@@ -36,6 +37,7 @@ class AppContainer(context: Context) {
     val readiumFactory = ReadiumFactory(appContext)
     val readerPreferencesStore = ReaderPreferencesStore(appContext)
     val libraryPreferencesStore = LibraryPreferencesStore(appContext)
+    val catalogPreferencesStore = CatalogPreferencesStore(appContext)
 
     val syncClient: SyncClient = SyncClient(
         baseUrlProvider = { credentialStore.get()?.baseUrl },

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -35,7 +35,13 @@ fun AppNavGraph(container: AppContainer) {
                 )
             }
             val catVm = remember {
-                CatalogViewModel(container.opdsClient, container.bookDownloader, container.documentRepository, container.credentialStore)
+                CatalogViewModel(
+                    client = container.opdsClient,
+                    downloader = container.bookDownloader,
+                    docs = container.documentRepository,
+                    credentialStore = container.credentialStore,
+                    syncStateDao = container.syncStateDao,
+                )
             }
             val setVm = remember {
                 SettingsViewModel(

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -41,6 +41,7 @@ fun AppNavGraph(container: AppContainer) {
                     docs = container.documentRepository,
                     credentialStore = container.credentialStore,
                     syncStateDao = container.syncStateDao,
+                    catalogPreferencesStore = container.catalogPreferencesStore,
                 )
             }
             val setVm = remember {

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -31,6 +31,7 @@ fun AppNavGraph(container: AppContainer) {
                     progress = container.progressRepository,
                     syncOrchestrator = container.syncOrchestrator,
                     booksDir = container.booksDir,
+                    libraryPreferencesStore = container.libraryPreferencesStore,
                 )
             }
             val catVm = remember {

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogPreferencesStore.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogPreferencesStore.kt
@@ -1,0 +1,29 @@
+package io.theficos.ereader.ui.catalog
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class CatalogPreferencesStore(context: Context) {
+    private val prefs = context.applicationContext
+        .getSharedPreferences("catalog_prefs", Context.MODE_PRIVATE)
+
+    private val _flow = MutableStateFlow(load())
+    val flow: StateFlow<CatalogSort> = _flow.asStateFlow()
+
+    fun update(sort: CatalogSort) {
+        prefs.edit().putString(KEY_SORT, sort.name).apply()
+        _flow.value = sort
+    }
+
+    private fun load(): CatalogSort {
+        val raw = prefs.getString(KEY_SORT, CatalogSort.AUTHOR.name)
+            ?: CatalogSort.AUTHOR.name
+        return runCatching { CatalogSort.valueOf(raw) }.getOrDefault(CatalogSort.AUTHOR)
+    }
+
+    private companion object {
+        const val KEY_SORT = "catalog_sort"
+    }
+}

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
@@ -28,14 +28,15 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -51,6 +52,7 @@ import io.theficos.ereader.data.opds.OpdsPublication
 import io.theficos.ereader.ui.components.CoverImage
 import io.theficos.ereader.ui.components.SectionLabel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CatalogScreen(
     viewModel: CatalogViewModel,
@@ -58,7 +60,7 @@ fun CatalogScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val downloadedUrls by viewModel.downloadedUrls.collectAsState()
-    LaunchedEffect(Unit) { if (state == CatalogUiState.Idle) viewModel.loadRoot() }
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
 
     val canGoBack = (state as? CatalogUiState.Loaded)?.canGoBack == true
     BackHandler(enabled = canGoBack) { viewModel.back() }
@@ -73,14 +75,20 @@ fun CatalogScreen(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.align(Alignment.Center).padding(24.dp),
             )
-            is CatalogUiState.Loaded -> Loaded(
-                state = s,
-                downloadedUrls = downloadedUrls,
-                onNavigate = viewModel::load,
-                onBack = viewModel::back,
-                onSearch = viewModel::search,
-                onDownload = viewModel::download,
-            )
+            is CatalogUiState.Loaded -> PullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = { viewModel.refresh() },
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                Loaded(
+                    state = s,
+                    downloadedUrls = downloadedUrls,
+                    onNavigate = viewModel::load,
+                    onBack = viewModel::back,
+                    onSearch = viewModel::search,
+                    onDownload = viewModel::download,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -61,6 +62,7 @@ fun CatalogScreen(
     val state by viewModel.state.collectAsState()
     val downloadedUrls by viewModel.downloadedUrls.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val context = LocalContext.current
 
     val canGoBack = (state as? CatalogUiState.Loaded)?.canGoBack == true
     BackHandler(enabled = canGoBack) { viewModel.back() }
@@ -86,7 +88,7 @@ fun CatalogScreen(
                     onNavigate = viewModel::load,
                     onBack = viewModel::back,
                     onSearch = viewModel::search,
-                    onDownload = viewModel::download,
+                    onDownload = { pub -> viewModel.download(pub, context) },
                 )
             }
         }

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
@@ -1,8 +1,12 @@
 package io.theficos.ereader.ui.catalog
 
+import android.content.Intent
+import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,13 +37,17 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -95,6 +103,7 @@ fun CatalogScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 private fun Loaded(
     state: CatalogUiState.Loaded,
@@ -104,6 +113,9 @@ private fun Loaded(
     onSearch: (String) -> Unit,
     onDownload: (OpdsPublication) -> Unit,
 ) {
+    val context = LocalContext.current
+    var menuFor by remember { mutableStateOf<OpdsPublication?>(null) }
+
     LazyVerticalGrid(
         columns = GridCells.Fixed(2),
         contentPadding = PaddingValues(16.dp),
@@ -144,9 +156,11 @@ private fun Loaded(
                 val downloaded = pub.epubDownloadHref in downloadedUrls
                 val downloading = state.downloading == pub.epubDownloadHref
                 Column(
-                    modifier = Modifier.clickable(enabled = !downloading) {
-                        if (!downloaded) onDownload(pub)
-                    },
+                    modifier = Modifier.combinedClickable(
+                        enabled = !downloading,
+                        onClick = { if (!downloaded) onDownload(pub) },
+                        onLongClick = { if (pub.webUrl != null) menuFor = pub },
+                    ),
                 ) {
                     Box {
                         CoverImage(
@@ -206,6 +220,38 @@ private fun Loaded(
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )
+                    }
+                }
+            }
+        }
+    }
+
+    menuFor?.let { pub ->
+        val sheetState = rememberModalBottomSheetState()
+        ModalBottomSheet(
+            onDismissRequest = { menuFor = null },
+            sheetState = sheetState,
+        ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(bottom = 24.dp)) {
+                Text(
+                    text = pub.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                )
+                pub.webUrl?.let { url ->
+                    TextButton(
+                        onClick = {
+                            context.startActivity(
+                                Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            )
+                            menuFor = null
+                        },
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    ) {
+                        Text("Open in calibre-web", modifier = Modifier.fillMaxWidth())
                     }
                 }
             }

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -31,7 +32,10 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Sort
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -85,19 +89,24 @@ fun CatalogScreen(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.align(Alignment.Center).padding(24.dp),
             )
-            is CatalogUiState.Loaded -> PullToRefreshBox(
-                isRefreshing = isRefreshing,
-                onRefresh = { viewModel.refresh() },
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                Loaded(
-                    state = s,
-                    downloadedUrls = downloadedUrls,
-                    onNavigate = viewModel::load,
-                    onBack = viewModel::back,
-                    onSearch = viewModel::search,
-                    onDownload = { pub -> viewModel.download(pub, context) },
-                )
+            is CatalogUiState.Loaded -> {
+                val sort by viewModel.sort.collectAsState()
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = { viewModel.refresh() },
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    Loaded(
+                        state = s,
+                        downloadedUrls = downloadedUrls,
+                        sort = sort,
+                        onSort = viewModel::setSort,
+                        onNavigate = viewModel::load,
+                        onBack = viewModel::back,
+                        onSearch = viewModel::search,
+                        onDownload = { pub -> viewModel.download(pub, context) },
+                    )
+                }
             }
         }
     }
@@ -108,6 +117,8 @@ fun CatalogScreen(
 private fun Loaded(
     state: CatalogUiState.Loaded,
     downloadedUrls: Set<String>,
+    sort: CatalogSort,
+    onSort: (CatalogSort) -> Unit,
     onNavigate: (String) -> Unit,
     onBack: () -> Unit,
     onSearch: (String) -> Unit,
@@ -115,6 +126,9 @@ private fun Loaded(
 ) {
     val context = LocalContext.current
     var menuFor by remember { mutableStateOf<OpdsPublication?>(null) }
+    val publications = remember(state.feed.publications, sort) {
+        applyCatalogSort(state.feed.publications, sort)
+    }
 
     LazyVerticalGrid(
         columns = GridCells.Fixed(2),
@@ -148,18 +162,22 @@ private fun Loaded(
             item(span = { GridItemSpan(maxLineSpan) }) { SectionLabel("Sections") }
             navigationItems(state, onNavigate)
         }
-        if (state.feed.publications.isNotEmpty()) {
+        if (publications.isNotEmpty()) {
             item(span = { GridItemSpan(maxLineSpan) }) {
-                SectionLabel("Books · ${state.feed.publications.size}")
+                CatalogBooksHeader(
+                    count = publications.size,
+                    sort = sort,
+                    onSort = onSort,
+                )
             }
-            itemsIndexed(state.feed.publications, key = { _, p -> p.epubDownloadHref }) { _, pub ->
+            itemsIndexed(publications, key = { _, p -> p.epubDownloadHref }) { _, pub ->
                 val downloaded = pub.epubDownloadHref in downloadedUrls
                 val downloading = state.downloading == pub.epubDownloadHref
                 Column(
                     modifier = Modifier.combinedClickable(
                         enabled = !downloading,
                         onClick = { if (!downloaded) onDownload(pub) },
-                        onLongClick = { if (pub.webUrl != null) menuFor = pub },
+                        onLongClick = { menuFor = pub },
                     ),
                 ) {
                     Box {
@@ -240,11 +258,11 @@ private fun Loaded(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
                 )
-                pub.webUrl?.let { url ->
+                if (pub.webUrl != null) {
                     TextButton(
                         onClick = {
                             context.startActivity(
-                                Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                                Intent(Intent.ACTION_VIEW, Uri.parse(pub.webUrl))
                                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                             )
                             menuFor = null
@@ -253,6 +271,65 @@ private fun Loaded(
                     ) {
                         Text("Open in calibre-web", modifier = Modifier.fillMaxWidth())
                     }
+                } else {
+                    Text(
+                        text = "No detail link in this feed entry",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private val catalogSortLabels: List<Pair<CatalogSort, String>> = listOf(
+    CatalogSort.AUTHOR to "Author",
+    CatalogSort.TITLE to "Title",
+    CatalogSort.AS_SHOWN to "As shown",
+)
+
+private fun applyCatalogSort(list: List<OpdsPublication>, by: CatalogSort): List<OpdsPublication> = when (by) {
+    CatalogSort.AUTHOR -> list.sortedWith(
+        compareBy<OpdsPublication> { it.author?.lowercase() ?: "￿" }
+            .thenBy { it.title.lowercase() }
+    )
+    CatalogSort.TITLE -> list.sortedBy { it.title.lowercase() }
+    CatalogSort.AS_SHOWN -> list
+}
+
+@Composable
+private fun CatalogBooksHeader(
+    count: Int,
+    sort: CatalogSort,
+    onSort: (CatalogSort) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SectionLabel("Books · $count", modifier = Modifier.weight(1f))
+        var sortMenuOpen by rememberSaveable { mutableStateOf(false) }
+        Box {
+            IconButton(onClick = { sortMenuOpen = true }) {
+                Icon(Icons.Filled.Sort, contentDescription = "Sort")
+            }
+            DropdownMenu(
+                expanded = sortMenuOpen,
+                onDismissRequest = { sortMenuOpen = false },
+            ) {
+                catalogSortLabels.forEach { (key, label) ->
+                    DropdownMenuItem(
+                        text = { Text(label) },
+                        leadingIcon = if (sort == key) {
+                            { Icon(Icons.Filled.Check, contentDescription = null) }
+                        } else null,
+                        onClick = {
+                            onSort(key)
+                            sortMenuOpen = false
+                        },
+                    )
                 }
             }
         }

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogSort.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogSort.kt
@@ -1,0 +1,3 @@
+package io.theficos.ereader.ui.catalog
+
+enum class CatalogSort { AUTHOR, TITLE, AS_SHOWN }

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
@@ -1,15 +1,18 @@
 package io.theficos.ereader.ui.catalog
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.theficos.ereader.auth.CalibreCredentialStore
 import io.theficos.ereader.core.identity.extractIdentity
 import io.theficos.ereader.data.local.DocumentRepository
+import io.theficos.ereader.data.local.db.SyncStateDao
 import io.theficos.ereader.data.opds.BookDownloader
 import io.theficos.ereader.data.opds.OpdsClient
 import io.theficos.ereader.data.opds.OpdsFeed
 import io.theficos.ereader.data.opds.OpdsPublication
+import io.theficos.ereader.data.sync.SyncEnqueuer
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +29,9 @@ class CatalogViewModel(
     private val downloader: BookDownloader,
     private val docs: DocumentRepository,
     private val credentialStore: CalibreCredentialStore,
+    private val syncStateDao: SyncStateDao,
+    private val syncEnqueuer: (Context) -> Unit =
+        { ctx -> SyncEnqueuer.enqueue(ctx, expedited = true, replaceExisting = true) },
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<CatalogUiState>(CatalogUiState.Idle)
@@ -111,7 +117,7 @@ class CatalogViewModel(
         }
     }
 
-    fun download(pub: OpdsPublication) {
+    fun download(pub: OpdsPublication, context: Context) {
         val current = _state.value as? CatalogUiState.Loaded ?: return
         viewModelScope.launch {
             _state.value = current.copy(downloading = pub.epubDownloadHref, progress = 0f)
@@ -142,6 +148,16 @@ class CatalogViewModel(
                     coverFile?.delete()
                 }
             }.onSuccess {
+                // The book that just landed may have server-side progress that an
+                // earlier pull silently dropped (no local doc to attach to). Reset the
+                // progress sync cursor so the next pull re-fetches every row from
+                // epoch 0; the now-present local doc lets it attach. Best-effort —
+                // a failure here doesn't roll back the already-successful download,
+                // but is logged so the silent re-attach gap is visible in logcat.
+                runCatching { syncStateDao.clearAll() }
+                    .onFailure { Log.w("CatalogViewModel", "clearAll failed; progress re-attach deferred", it) }
+                runCatching { syncEnqueuer(context) }
+                    .onFailure { Log.w("CatalogViewModel", "syncEnqueuer failed; will retry on next manual sync", it) }
                 _state.value = current.copy(downloading = null, progress = 0f, lastDownloaded = pub.title)
             }.onFailure {
                 Log.e("CatalogViewModel", "download failed for ${pub.epubDownloadHref}", it)

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -30,11 +31,25 @@ class CatalogViewModel(
     private val _state = MutableStateFlow<CatalogUiState>(CatalogUiState.Idle)
     val state: StateFlow<CatalogUiState> = _state.asStateFlow()
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
     private val backStack = ArrayDeque<Pair<String, OpdsFeed>>()
 
     val downloadedUrls: StateFlow<Set<String>> = docs.observeLibrary()
         .map { list -> list.map { it.downloadUrl }.toSet() }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
+
+    init {
+        viewModelScope.launch {
+            credentialStore.flow
+                .map { it?.baseUrl }
+                .distinctUntilChanged()
+                .collect { baseUrl ->
+                    if (!baseUrl.isNullOrBlank()) loadRoot()
+                }
+        }
+    }
 
     fun loadRoot() {
         val baseUrl = credentialStore.get()?.baseUrl
@@ -44,6 +59,19 @@ class CatalogViewModel(
         }
         backStack.clear()
         load("${baseUrl.trimEnd('/')}/opds")
+    }
+
+    fun refresh() {
+        val current = _state.value as? CatalogUiState.Loaded ?: return loadRoot()
+        _isRefreshing.value = true
+        viewModelScope.launch {
+            runCatching { client.fetch(current.url) }
+                .onSuccess { feed ->
+                    _state.value = CatalogUiState.Loaded(current.url, feed, canGoBack = backStack.isNotEmpty())
+                }
+                .onFailure { _state.value = CatalogUiState.Error(it.message ?: "Fetch failed") }
+            _isRefreshing.value = false
+        }
     }
 
     fun load(url: String) {

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
@@ -30,6 +30,7 @@ class CatalogViewModel(
     private val docs: DocumentRepository,
     private val credentialStore: CalibreCredentialStore,
     private val syncStateDao: SyncStateDao,
+    private val catalogPreferencesStore: CatalogPreferencesStore,
     private val syncEnqueuer: (Context) -> Unit =
         { ctx -> SyncEnqueuer.enqueue(ctx, expedited = true, replaceExisting = true) },
 ) : ViewModel() {
@@ -39,6 +40,10 @@ class CatalogViewModel(
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    val sort: StateFlow<CatalogSort> = catalogPreferencesStore.flow
+
+    fun setSort(next: CatalogSort) = catalogPreferencesStore.update(next)
 
     private val backStack = ArrayDeque<Pair<String, OpdsFeed>>()
 

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryPreferencesStore.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryPreferencesStore.kt
@@ -1,0 +1,29 @@
+package io.theficos.ereader.ui.library
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class LibraryPreferencesStore(context: Context) {
+    private val prefs = context.applicationContext
+        .getSharedPreferences("library_prefs", Context.MODE_PRIVATE)
+
+    private val _flow = MutableStateFlow(load())
+    val flow: StateFlow<LibrarySort> = _flow.asStateFlow()
+
+    fun update(sort: LibrarySort) {
+        prefs.edit().putString(KEY_SORT, sort.name).apply()
+        _flow.value = sort
+    }
+
+    private fun load(): LibrarySort {
+        val raw = prefs.getString(KEY_SORT, LibrarySort.RECENTLY_READ.name)
+            ?: LibrarySort.RECENTLY_READ.name
+        return runCatching { LibrarySort.valueOf(raw) }.getOrDefault(LibrarySort.RECENTLY_READ)
+    }
+
+    private companion object {
+        const val KEY_SORT = "library_sort"
+    }
+}

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
@@ -17,8 +17,11 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Sort
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -29,6 +32,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -41,10 +45,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.theficos.ereader.core.model.Document
@@ -76,6 +83,8 @@ fun LibraryScreen(
     var pendingDelete by remember { mutableStateOf<Document?>(null) }
     var pendingRestart by remember { mutableStateOf<Document?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
+    var searchActive by rememberSaveable { mutableStateOf(false) }
+    val query by viewModel.query.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -86,7 +95,7 @@ fun LibraryScreen(
         }
     }
 
-    if (items.isEmpty()) {
+    if (items.isEmpty() && !searchActive && query.isBlank()) {
         EmptyState(modifier = Modifier.padding(contentPadding))
         return
     }
@@ -110,7 +119,10 @@ fun LibraryScreen(
                         color = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.weight(1f),
                     )
-                    var sortMenuOpen by remember { mutableStateOf(false) }
+                    IconButton(onClick = { searchActive = true }) {
+                        Icon(Icons.Filled.Search, contentDescription = "Search")
+                    }
+                    var sortMenuOpen by rememberSaveable { mutableStateOf(false) }
                     val currentSort by viewModel.sort.collectAsState()
                     Box {
                         IconButton(onClick = { sortMenuOpen = true }) {
@@ -142,7 +154,29 @@ fun LibraryScreen(
                 }
             }
             item(span = { GridItemSpan(maxLineSpan) }) {
-                SectionLabel("Library · ${items.size}")
+                if (searchActive) {
+                    OutlinedTextField(
+                        value = query,
+                        onValueChange = { viewModel.setQuery(it) },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = { Text("Search library") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.None,
+                            imeAction = ImeAction.Search,
+                        ),
+                        trailingIcon = {
+                            IconButton(onClick = {
+                                viewModel.setQuery("")
+                                searchActive = false
+                            }) {
+                                Icon(Icons.Filled.Close, contentDescription = "Close search")
+                            }
+                        },
+                    )
+                } else {
+                    SectionLabel("Library · ${items.size}")
+                }
             }
             itemsIndexed(items, key = { _, r -> r.document.id }) { _, row ->
                 Column(
@@ -186,6 +220,16 @@ fun LibraryScreen(
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.padding(top = 6.dp),
+                    )
+                }
+            }
+            if (searchActive && query.isNotBlank() && items.isEmpty()) {
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    Text(
+                        text = "No matches in your library",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(16.dp),
                     )
                 }
             }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
@@ -11,15 +11,25 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Sort
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.SnackbarHost
@@ -42,6 +52,13 @@ import io.theficos.ereader.data.sync.SyncEnqueuer
 import io.theficos.ereader.ui.components.CoverImage
 import io.theficos.ereader.ui.components.SectionLabel
 import io.theficos.ereader.ui.theme.Lora
+
+private val sortLabels: List<Pair<LibrarySort, String>> = listOf(
+    LibrarySort.RECENTLY_READ to "Recently read",
+    LibrarySort.RECENTLY_ADDED to "Recently added",
+    LibrarySort.TITLE to "Title",
+    LibrarySort.AUTHOR to "Author",
+)
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -83,11 +100,41 @@ fun LibraryScreen(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item(span = { GridItemSpan(maxLineSpan) }) {
-                Text(
-                    text = "Quire",
-                    style = MaterialTheme.typography.displaySmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Quire",
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
+                    var sortMenuOpen by remember { mutableStateOf(false) }
+                    val currentSort by viewModel.sort.collectAsState()
+                    Box {
+                        IconButton(onClick = { sortMenuOpen = true }) {
+                            Icon(Icons.Filled.Sort, contentDescription = "Sort")
+                        }
+                        DropdownMenu(
+                            expanded = sortMenuOpen,
+                            onDismissRequest = { sortMenuOpen = false },
+                        ) {
+                            sortLabels.forEach { (key, label) ->
+                                DropdownMenuItem(
+                                    text = { Text(label) },
+                                    leadingIcon = if (currentSort == key) {
+                                        { Icon(Icons.Filled.Check, contentDescription = null) }
+                                    } else null,
+                                    onClick = {
+                                        viewModel.setSort(key)
+                                        sortMenuOpen = false
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
             }
             cont?.let { row ->
                 item(span = { GridItemSpan(maxLineSpan) }) {
@@ -104,14 +151,35 @@ fun LibraryScreen(
                         onLongClick = { menuFor = row.document },
                     ),
                 ) {
-                    CoverImage(
-                        source = row.document.coverPath,
-                        title = row.document.title,
-                        author = row.document.author,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(2f / 3f),
-                    )
+                    Box(modifier = Modifier.fillMaxWidth()) {
+                        CoverImage(
+                            source = row.document.coverPath,
+                            title = row.document.title,
+                            author = row.document.author,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(2f / 3f),
+                        )
+                        if (row.finishedAt != null) {
+                            Surface(
+                                shape = CircleShape,
+                                color = MaterialTheme.colorScheme.tertiaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .padding(6.dp)
+                                    .size(24.dp),
+                            ) {
+                                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                                    Icon(
+                                        imageVector = Icons.Filled.Check,
+                                        contentDescription = "Finished",
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                }
+                            }
+                        }
+                    }
                     Text(
                         text = row.document.title,
                         style = MaterialTheme.typography.titleMedium,

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibrarySort.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibrarySort.kt
@@ -1,0 +1,3 @@
+package io.theficos.ereader.ui.library
+
+enum class LibrarySort { RECENTLY_READ, RECENTLY_ADDED, TITLE, AUTHOR }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
@@ -33,9 +33,14 @@ class LibraryViewModel(
     private val progress: ProgressRepository,
     private val syncOrchestrator: SyncOrchestrator,
     private val booksDir: File,
+    private val libraryPreferencesStore: LibraryPreferencesStore,
     private val nowMillis: () -> Long = System::currentTimeMillis,
     private val syncEnqueuer: (Context) -> Unit = { SyncEnqueuer.enqueue(it, expedited = true, replaceExisting = true) },
 ) : ViewModel() {
+
+    val sort: StateFlow<LibrarySort> = libraryPreferencesStore.flow
+
+    fun setSort(next: LibrarySort) = libraryPreferencesStore.update(next)
 
     private val rows: StateFlow<List<LibraryRow>> =
         docs.observeLibrary()
@@ -49,17 +54,20 @@ class LibraryViewModel(
                         document = d,
                         percent = p?.percent ?: 0.0,
                         progressUpdatedAt = p?.updatedAt ?: 0L,
+                        finishedAt = p?.finishedAt,
                     )
                 }
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    val items: StateFlow<List<LibraryRow>> = rows
+    val items: StateFlow<List<LibraryRow>> = combine(rows, sort) { list, by ->
+        applySort(list, by)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val continueReading: StateFlow<LibraryRow?> = rows
         .map { list ->
             list
-                .filter { it.percent in 0.0001..0.9999 }
+                .filter { it.percent > 0.0001 && it.finishedAt == null }
                 .maxByOrNull { it.progressUpdatedAt }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
@@ -102,10 +110,24 @@ class LibraryViewModel(
             }
         }
     }
+
+    private fun applySort(list: List<LibraryRow>, by: LibrarySort): List<LibraryRow> = when (by) {
+        LibrarySort.RECENTLY_READ -> list.sortedWith(
+            compareByDescending<LibraryRow> { it.progressUpdatedAt }
+                .thenBy { it.document.title.lowercase() }
+        )
+        LibrarySort.RECENTLY_ADDED -> list.sortedByDescending { it.document.id }
+        LibrarySort.TITLE -> list.sortedBy { it.document.title.lowercase() }
+        LibrarySort.AUTHOR -> list.sortedWith(
+            compareBy<LibraryRow> { it.document.author?.lowercase() ?: "￿" }
+                .thenBy { it.document.title.lowercase() }
+        )
+    }
 }
 
 data class LibraryRow(
     val document: Document,
     val percent: Double,
     val progressUpdatedAt: Long,
+    val finishedAt: Long? = null,
 )

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -42,6 +43,11 @@ class LibraryViewModel(
 
     fun setSort(next: LibrarySort) = libraryPreferencesStore.update(next)
 
+    private val _query = kotlinx.coroutines.flow.MutableStateFlow("")
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    fun setQuery(next: String) { _query.value = next }
+
     private val rows: StateFlow<List<LibraryRow>> =
         docs.observeLibrary()
             .flatMapLatest { docList ->
@@ -60,8 +66,15 @@ class LibraryViewModel(
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    val items: StateFlow<List<LibraryRow>> = combine(rows, sort) { list, by ->
-        applySort(list, by)
+    val items: StateFlow<List<LibraryRow>> = combine(rows, sort, _query) { list, by, q ->
+        val sorted = applySort(list, by)
+        if (q.isBlank()) sorted else {
+            val needle = q.trim().lowercase()
+            sorted.filter { row ->
+                row.document.title.lowercase().contains(needle) ||
+                    (row.document.author?.lowercase()?.contains(needle) == true)
+            }
+        }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val continueReading: StateFlow<LibraryRow?> = rows

--- a/app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt
@@ -6,10 +6,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -78,6 +80,26 @@ fun FontSettingsSheet(
                         Text(f.name.replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() })
                     }
                 }
+            }
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Tap to turn pages", style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        "Tap left or right edges to flip pages",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = prefs.tapNavigationEnabled,
+                    onCheckedChange = { onChange(prefs.copy(tapNavigationEnabled = it)) },
+                )
             }
         }
     }

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
@@ -1,7 +1,9 @@
 package io.theficos.ereader.ui.reader
 
+import android.app.Activity
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -56,6 +58,14 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    val activity = LocalContext.current as Activity
+    DisposableEffect(activity) {
+        activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            activity.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
     }
 
     LaunchedEffect(Unit) { viewModel.load() }

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
@@ -4,8 +4,10 @@ import android.app.Activity
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,6 +38,7 @@ import io.theficos.ereader.reader.ReaderPreferences
 import io.theficos.ereader.reader.toEpubPreferences
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.shared.publication.Locator
@@ -86,16 +89,38 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
                     initialLocator = s.initialLocator,
                     preferences = preferences,
                     onLocator = viewModel::publishLocator,
+                    onNavigatorReady = viewModel::bindNavigator,
                 )
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .fillMaxHeight()
-                        .fillMaxWidth(0.34f)
-                        .pointerInput(Unit) {
-                            detectTapGestures(onTap = { viewModel.toggleChrome() })
-                        }
-                )
+                if (preferences.tapNavigationEnabled) {
+                    Row(modifier = Modifier.fillMaxSize()) {
+                        Box(
+                            modifier = Modifier
+                                .weight(0.33f)
+                                .fillMaxHeight()
+                                .tapPassthrough { viewModel.pageBackward() }
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(0.34f)
+                                .fillMaxHeight()
+                                .tapPassthrough { viewModel.toggleChrome() }
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(0.33f)
+                                .fillMaxHeight()
+                                .tapPassthrough { viewModel.pageForward() }
+                        )
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .fillMaxHeight()
+                            .fillMaxWidth(0.34f)
+                            .tapPassthrough { viewModel.toggleChrome() }
+                    )
+                }
 
                 ReaderTopBar(
                     visible = chromeVisible,
@@ -130,6 +155,7 @@ private fun ReaderContent(
     initialLocator: Locator?,
     preferences: ReaderPreferences,
     onLocator: (Locator) -> Unit,
+    onNavigatorReady: (EpubNavigatorFragment?) -> Unit,
 ) {
     val activity = LocalContext.current as FragmentActivity
     val containerId = rememberSaveable { View.generateViewId() }
@@ -164,6 +190,7 @@ private fun ReaderContent(
             .replace(containerId, nav, tag)
             .commitNow()
         fragment = nav
+        onNavigatorReady(nav)
 
         val job = activity.lifecycleScope.launch {
             nav.currentLocator.collect { onLocator(it) }
@@ -172,6 +199,7 @@ private fun ReaderContent(
         onDispose {
             job.cancel()
             fragment = null
+            onNavigatorReady(null)
             fm.beginTransaction()
                 .remove(nav)
                 .commitNowAllowingStateLoss()
@@ -180,5 +208,37 @@ private fun ReaderContent(
 
     LaunchedEffect(preferences) {
         fragment?.submitPreferences(preferences.toEpubPreferences())
+    }
+}
+
+/**
+ * Tap detector that does NOT consume the down event, so swipes and other drag
+ * gestures still reach the underlying view (Readium's navigator AndroidView).
+ * Only the up event is consumed, and only when the gesture qualifies as a tap
+ * (no movement past touchSlop, finished within long-press timeout).
+ */
+private fun Modifier.tapPassthrough(onTap: () -> Unit): Modifier = this.pointerInput(Unit) {
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        val touchSlop = viewConfiguration.touchSlop
+        val up = withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
+            val pointerId = down.id
+            while (true) {
+                val event = awaitPointerEvent()
+                val change = event.changes.firstOrNull { it.id == pointerId }
+                    ?: return@withTimeoutOrNull null
+                if (!change.pressed) return@withTimeoutOrNull change
+                val dx = change.position.x - down.position.x
+                val dy = change.position.y - down.position.y
+                if (kotlin.math.hypot(dx.toDouble(), dy.toDouble()) > touchSlop) {
+                    return@withTimeoutOrNull null
+                }
+            }
+            @Suppress("UNREACHABLE_CODE") null
+        }
+        if (up != null) {
+            up.consume()
+            onTap()
+        }
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
@@ -8,9 +8,14 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemGestures
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -92,7 +97,14 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
                     onNavigatorReady = viewModel::bindNavigator,
                 )
                 if (preferences.tapNavigationEnabled) {
-                    Row(modifier = Modifier.fillMaxSize()) {
+                    // Inset by the system-gesture strip on each edge so left/right swipes
+                    // from the very edge still trigger Android's predictive back instead of
+                    // being captured by the tap zones.
+                    Row(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .windowInsetsPadding(WindowInsets.systemGestures.only(WindowInsetsSides.Horizontal))
+                    ) {
                         Box(
                             modifier = Modifier
                                 .weight(0.33f)

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
@@ -1,21 +1,15 @@
 package io.theficos.ereader.ui.reader
 
 import android.app.Activity
+import android.content.Context
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
+import android.widget.FrameLayout
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.systemGestures
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,7 +23,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.FragmentActivity
@@ -43,7 +36,6 @@ import io.theficos.ereader.reader.ReaderPreferences
 import io.theficos.ereader.reader.toEpubPreferences
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.shared.publication.Locator
@@ -95,44 +87,10 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
                     preferences = preferences,
                     onLocator = viewModel::publishLocator,
                     onNavigatorReady = viewModel::bindNavigator,
+                    onPrev = viewModel::pageBackward,
+                    onNext = viewModel::pageForward,
+                    onToggleChrome = viewModel::toggleChrome,
                 )
-                if (preferences.tapNavigationEnabled) {
-                    // Inset by the system-gesture strip on each edge so left/right swipes
-                    // from the very edge still trigger Android's predictive back instead of
-                    // being captured by the tap zones.
-                    Row(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .windowInsetsPadding(WindowInsets.systemGestures.only(WindowInsetsSides.Horizontal))
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .weight(0.33f)
-                                .fillMaxHeight()
-                                .tapPassthrough { viewModel.pageBackward() }
-                        )
-                        Box(
-                            modifier = Modifier
-                                .weight(0.34f)
-                                .fillMaxHeight()
-                                .tapPassthrough { viewModel.toggleChrome() }
-                        )
-                        Box(
-                            modifier = Modifier
-                                .weight(0.33f)
-                                .fillMaxHeight()
-                                .tapPassthrough { viewModel.pageForward() }
-                        )
-                    }
-                } else {
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .fillMaxHeight()
-                            .fillMaxWidth(0.34f)
-                            .tapPassthrough { viewModel.toggleChrome() }
-                    )
-                }
 
                 ReaderTopBar(
                     visible = chromeVisible,
@@ -168,6 +126,9 @@ private fun ReaderContent(
     preferences: ReaderPreferences,
     onLocator: (Locator) -> Unit,
     onNavigatorReady: (EpubNavigatorFragment?) -> Unit,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    onToggleChrome: () -> Unit,
 ) {
     val activity = LocalContext.current as FragmentActivity
     val containerId = rememberSaveable { View.generateViewId() }
@@ -177,13 +138,27 @@ private fun ReaderContent(
     AndroidView(
         modifier = Modifier.fillMaxSize(),
         factory = { ctx ->
-            FragmentContainerView(ctx).apply {
-                id = containerId
+            ReaderTapDispatcher(ctx).apply {
                 layoutParams = ViewGroup.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.MATCH_PARENT,
                 )
+                addView(
+                    FragmentContainerView(ctx).apply {
+                        id = containerId
+                        layoutParams = ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                        )
+                    }
+                )
             }
+        },
+        update = { wrapper ->
+            wrapper.onPrev = onPrev
+            wrapper.onNext = onNext
+            wrapper.onToggleChrome = onToggleChrome
+            wrapper.tapNavigationEnabled = preferences.tapNavigationEnabled
         },
     )
 
@@ -224,33 +199,41 @@ private fun ReaderContent(
 }
 
 /**
- * Tap detector that does NOT consume the down event, so swipes and other drag
- * gestures still reach the underlying view (Readium's navigator AndroidView).
- * Only the up event is consumed, and only when the gesture qualifies as a tap
- * (no movement past touchSlop, finished within long-press timeout).
+ * Wraps the Readium [FragmentContainerView] and detects single taps via a
+ * [GestureDetector] at the View layer. Tap events fire navigation callbacks;
+ * swipes, long-presses and edge gestures flow naturally to children (the
+ * Readium WebView gets its swipe-to-page) and to Android's system gesture
+ * handler (predictive back). Compose overlays were tried first and don't
+ * coexist with the WebView's gesture handling — see commit history.
  */
-private fun Modifier.tapPassthrough(onTap: () -> Unit): Modifier = this.pointerInput(Unit) {
-    awaitEachGesture {
-        val down = awaitFirstDown(requireUnconsumed = false)
-        val touchSlop = viewConfiguration.touchSlop
-        val up = withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
-            val pointerId = down.id
-            while (true) {
-                val event = awaitPointerEvent()
-                val change = event.changes.firstOrNull { it.id == pointerId }
-                    ?: return@withTimeoutOrNull null
-                if (!change.pressed) return@withTimeoutOrNull change
-                val dx = change.position.x - down.position.x
-                val dy = change.position.y - down.position.y
-                if (kotlin.math.hypot(dx.toDouble(), dy.toDouble()) > touchSlop) {
-                    return@withTimeoutOrNull null
+private class ReaderTapDispatcher(context: Context) : FrameLayout(context) {
+    var onPrev: () -> Unit = {}
+    var onNext: () -> Unit = {}
+    var onToggleChrome: () -> Unit = {}
+    var tapNavigationEnabled: Boolean = true
+
+    private val gesture = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
+        override fun onSingleTapUp(e: MotionEvent): Boolean {
+            val w = width.toFloat()
+            if (w <= 0f) return false
+            val frac = e.x / w
+            if (tapNavigationEnabled) {
+                when {
+                    frac < 0.33f -> onPrev()
+                    frac > 0.67f -> onNext()
+                    else -> onToggleChrome()
                 }
+            } else if (frac in 0.33f..0.67f) {
+                onToggleChrome()
             }
-            @Suppress("UNREACHABLE_CODE") null
+            return true
         }
-        if (up != null) {
-            up.consume()
-            onTap()
-        }
+    })
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        // Observe the event for tap recognition without consuming — children
+        // (Readium's WebView) still receive every touch they need for swipe.
+        gesture.onTouchEvent(ev)
+        return super.dispatchTouchEvent(ev)
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt
@@ -72,8 +72,14 @@ class ReaderViewModel(
             }
             val savedProgress = progress.get(doc.id)
             val initialLocator = savedProgress?.locator?.let { ProgressTracker.parseOrNull(it) }
+            val lastSpineHref = publication.readingOrder.lastOrNull()?.url()
             _state.value = ReaderUiState.Open(doc, publication, initialLocator, savedProgress)
-            tracker.attach(documentId = doc.id, locatorUpdates = locatorUpdates)
+            tracker.attach(
+                documentId = doc.id,
+                locatorUpdates = locatorUpdates,
+                lastSpineHref = lastSpineHref,
+                initialFinishedAt = savedProgress?.finishedAt,
+            )
         }
     }
 

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import java.io.File
@@ -57,6 +58,20 @@ class ReaderViewModel(
         save = { progress.save(it) },
         scope = viewModelScope,
     )
+
+    private var navigator: EpubNavigatorFragment? = null
+
+    fun bindNavigator(nav: EpubNavigatorFragment?) {
+        navigator = nav
+    }
+
+    fun pageForward() {
+        viewModelScope.launch { navigator?.goForward() }
+    }
+
+    fun pageBackward() {
+        viewModelScope.launch { navigator?.goBackward() }
+    }
 
     fun load() {
         viewModelScope.launch {

--- a/app/src/test/java/io/theficos/ereader/ui/catalog/CatalogViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/catalog/CatalogViewModelTest.kt
@@ -121,6 +121,9 @@ class CatalogViewModelTest {
             docs = docs,
             credentialStore = credentialStore,
             syncStateDao = db.syncStateDao(),
+            catalogPreferencesStore = CatalogPreferencesStore(
+                androidx.test.core.app.ApplicationProvider.getApplicationContext()
+            ),
             syncEnqueuer = { enqueueCount++ },
         )
 

--- a/app/src/test/java/io/theficos/ereader/ui/catalog/CatalogViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/catalog/CatalogViewModelTest.kt
@@ -1,0 +1,163 @@
+package io.theficos.ereader.ui.catalog
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.auth.CalibreCredentialStore
+import io.theficos.ereader.data.local.DocumentRepository
+import io.theficos.ereader.data.local.db.EReaderDatabase
+import io.theficos.ereader.data.local.db.SyncStateEntity
+import io.theficos.ereader.data.opds.BookDownloader
+import io.theficos.ereader.data.opds.OpdsClient
+import io.theficos.ereader.data.opds.OpdsPublication
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import okio.Buffer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class CatalogViewModelTest {
+    private lateinit var server: MockWebServer
+    private lateinit var db: EReaderDatabase
+    private lateinit var docs: DocumentRepository
+    private lateinit var booksDir: File
+    private lateinit var context: Context
+    private lateinit var credentialStore: CalibreCredentialStore
+    private lateinit var opdsClient: OpdsClient
+    private lateinit var downloader: BookDownloader
+    private var enqueueCount = 0
+
+    @Before fun setUp() {
+        FakeAndroidKeyStore.setup()
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        context = ApplicationProvider.getApplicationContext()
+        server = MockWebServer().apply { start() }
+        db = Room.inMemoryDatabaseBuilder(context, EReaderDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        docs = DocumentRepository(db.documentDao())
+        // Unique books dir per run; cleaned up in tearDown.
+        booksDir = File.createTempFile("books", "").apply {
+            delete(); mkdirs()
+        }
+        val okHttp = OkHttpClient()
+        opdsClient = OpdsClient(okHttp)
+        downloader = BookDownloader(okHttp, booksDir)
+        // Don't store credentials; init's collect block only loads when baseUrl is non-blank,
+        // so leaving the store empty avoids any spurious feed fetch.
+        credentialStore = CalibreCredentialStore(context)
+        credentialStore.clear()
+        enqueueCount = 0
+    }
+
+    @After fun tearDown() {
+        db.close()
+        server.shutdown()
+        booksDir.deleteRecursively()
+        Dispatchers.resetMain()
+    }
+
+    private fun feedXml(epubUrl: String): String = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:dc="http://purl.org/dc/terms/">
+          <id>urn:test:feed</id>
+          <title>Test Feed</title>
+          <updated>2026-05-09T00:00:00Z</updated>
+          <link rel="self" href="/opds" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+          <entry>
+            <title>Test Book</title>
+            <id>urn:test:1</id>
+            <updated>2026-05-09T00:00:00Z</updated>
+            <author><name>Test Author</name></author>
+            <dc:identifier>urn:uuid:11111111-1111-1111-1111-111111111111</dc:identifier>
+            <link rel="http://opds-spec.org/acquisition" href="$epubUrl" type="application/epub+zip"/>
+          </entry>
+        </feed>
+    """.trimIndent()
+
+    @Test fun `successful download clears progress sync cursor and enqueues sync`() = runTest {
+        // Prime the cursor; it must be wiped after the download completes.
+        db.syncStateDao().set(SyncStateEntity(tableName = "progress", lastPulledAt = 12345L))
+        assertThat(db.syncStateDao().lastPulled("progress")).isEqualTo(12345L)
+
+        val epubBytes = "fake-epub-bytes".toByteArray()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(req: RecordedRequest): MockResponse {
+                val path = req.path?.substringBefore('?')
+                return when (path) {
+                    "/opds" -> MockResponse()
+                        .setHeader("Content-Type", "application/atom+xml")
+                        .setBody(feedXml(server.url("/book.epub").toString()))
+                    "/book.epub" -> MockResponse()
+                        .setHeader("Content-Type", "application/epub+zip")
+                        .setBody(Buffer().write(epubBytes))
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        val vm = CatalogViewModel(
+            client = opdsClient,
+            downloader = downloader,
+            docs = docs,
+            credentialStore = credentialStore,
+            syncStateDao = db.syncStateDao(),
+            syncEnqueuer = { enqueueCount++ },
+        )
+
+        // Drive into Loaded state so download()'s state guard passes. The OPDS
+        // fetch suspends on Dispatchers.IO (real), which advanceUntilIdle won't
+        // drain — Turbine awaits the real emission instead.
+        vm.load(server.url("/opds").toString())
+        var publication: OpdsPublication? = null
+        vm.state.test {
+            // Initial Idle, then Loading, then Loaded. Skip until Loaded.
+            var s = awaitItem()
+            while (s !is CatalogUiState.Loaded) s = awaitItem()
+            assertThat(s.feed.publications).hasSize(1)
+            publication = s.feed.publications[0]
+            cancelAndIgnoreRemainingEvents()
+        }
+        val pub = checkNotNull(publication) { "Loaded state never produced a publication" }
+
+        vm.download(pub, context)
+        // The success branch flips lastDownloaded; await that to know the
+        // coroutine has finished its work (including the cursor wipe + enqueue).
+        vm.state.test {
+            var s = awaitItem()
+            while (s !is CatalogUiState.Loaded || s.lastDownloaded == null) {
+                // If the failure branch runs first, surface it.
+                if (s is CatalogUiState.Loaded && s.error != null) {
+                    error("Download failed unexpectedly: ${s.error}")
+                }
+                s = awaitItem()
+            }
+            assertThat(s.lastDownloaded).isEqualTo(pub.title)
+            assertThat(s.error).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Phase 7 invariants: cursor wiped and sync enqueued exactly once.
+        assertThat(db.syncStateDao().lastPulled("progress")).isNull()
+        assertThat(enqueueCount).isEqualTo(1)
+    }
+}

--- a/app/src/test/java/io/theficos/ereader/ui/catalog/FakeAndroidKeyStore.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/catalog/FakeAndroidKeyStore.kt
@@ -1,0 +1,95 @@
+package io.theficos.ereader.ui.catalog
+
+import java.security.Key
+import java.security.KeyStore
+import java.security.KeyStoreSpi
+import java.security.Provider
+import java.security.SecureRandom
+import java.security.Security
+import java.security.cert.Certificate
+import java.security.spec.AlgorithmParameterSpec
+import java.util.Date
+import java.util.Enumeration
+import java.util.concurrent.ConcurrentHashMap
+import javax.crypto.KeyGeneratorSpi
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Mirror of `auth`'s `FakeAndroidKeyStore` test helper. We copy it here because
+ * Robolectric tests in this module exercise [io.theficos.ereader.auth.CalibreCredentialStore]
+ * (via [io.theficos.ereader.ui.catalog.CatalogViewModel])—which requires an
+ * "AndroidKeyStore" provider—and the auth module's test sources aren't visible.
+ */
+internal object FakeAndroidKeyStore {
+
+    @Volatile private var installed = false
+
+    fun setup() {
+        if (installed) return
+        synchronized(this) {
+            if (installed) return
+            Security.removeProvider("AndroidKeyStore")
+            Security.insertProviderAt(FakeProvider(), 1)
+            installed = true
+        }
+    }
+
+    private class FakeProvider : Provider(
+        "AndroidKeyStore", 1.0,
+        "In-memory AndroidKeyStore for Robolectric tests"
+    ) {
+        init {
+            putService(Service(this, "KeyStore", "AndroidKeyStore",
+                FakeKeyStoreSpi::class.java.name, emptyList(), emptyMap()))
+            putService(Service(this, "KeyGenerator", "AES",
+                FakeAesKeyGeneratorSpi::class.java.name, emptyList(), emptyMap()))
+        }
+    }
+
+    class FakeKeyStoreSpi : KeyStoreSpi() {
+        private data class Entry(val key: Key, val certs: Array<Certificate>?)
+        private val store = ConcurrentHashMap<String, Entry>()
+        override fun engineGetKey(alias: String, password: CharArray?): Key? = store[alias]?.key
+        override fun engineGetCertificateChain(alias: String): Array<Certificate>? = store[alias]?.certs
+        override fun engineGetCertificate(alias: String): Certificate? = store[alias]?.certs?.firstOrNull()
+        override fun engineGetCreationDate(alias: String): Date = Date()
+        override fun engineSetKeyEntry(
+            alias: String, key: Key, password: CharArray?, chain: Array<out Certificate>?
+        ) { store[alias] = Entry(key, chain?.let { @Suppress("UNCHECKED_CAST") (it as Array<Certificate>) }) }
+        override fun engineSetKeyEntry(
+            alias: String, key: ByteArray, chain: Array<out Certificate>?
+        ) = throw UnsupportedOperationException("raw key bytes not supported")
+        override fun engineSetCertificateEntry(alias: String, cert: Certificate) {
+            store[alias] = Entry(cert.publicKey, arrayOf(cert))
+        }
+        override fun engineDeleteEntry(alias: String) { store.remove(alias) }
+        override fun engineAliases(): Enumeration<String> = java.util.Collections.enumeration(store.keys)
+        override fun engineContainsAlias(alias: String): Boolean = store.containsKey(alias)
+        override fun engineSize(): Int = store.size
+        override fun engineIsKeyEntry(alias: String): Boolean = store[alias]?.key != null
+        override fun engineIsCertificateEntry(alias: String): Boolean = false
+        override fun engineGetCertificateAlias(cert: Certificate): String? = null
+        override fun engineStore(stream: java.io.OutputStream?, password: CharArray?) = Unit
+        override fun engineLoad(stream: java.io.InputStream?, password: CharArray?) = Unit
+        override fun engineLoad(param: KeyStore.LoadStoreParameter?) = Unit
+    }
+
+    class FakeAesKeyGeneratorSpi : KeyGeneratorSpi() {
+        private var keySize = 256
+        private var random: SecureRandom = SecureRandom()
+        override fun engineInit(random: SecureRandom) { this.random = random }
+        override fun engineInit(params: AlgorithmParameterSpec?, random: SecureRandom?) {
+            if (random != null) this.random = random
+        }
+        override fun engineInit(keysize: Int, random: SecureRandom?) {
+            this.keySize = keysize
+            if (random != null) this.random = random
+        }
+        override fun engineGenerateKey(): SecretKey {
+            val bytes = ByteArray(keySize / 8)
+            random.nextBytes(bytes)
+            return SecretKeySpec(bytes, "AES")
+        }
+    }
+}

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryPreferencesStoreTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryPreferencesStoreTest.kt
@@ -1,0 +1,42 @@
+package io.theficos.ereader.ui.library
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class LibraryPreferencesStoreTest {
+
+    private fun fresh() = LibraryPreferencesStore(ApplicationProvider.getApplicationContext()).also {
+        it.update(LibrarySort.RECENTLY_READ)
+    }
+
+    @Test fun `default sort is RECENTLY_READ when nothing is stored`() {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        ctx.getSharedPreferences("library_prefs", android.content.Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        val store = LibraryPreferencesStore(ctx)
+        assertThat(store.flow.value).isEqualTo(LibrarySort.RECENTLY_READ)
+    }
+
+    @Test fun `sort round-trips through update and reload`() {
+        val store1 = fresh()
+        store1.update(LibrarySort.AUTHOR)
+        assertThat(store1.flow.value).isEqualTo(LibrarySort.AUTHOR)
+
+        val store2 = LibraryPreferencesStore(ApplicationProvider.getApplicationContext())
+        assertThat(store2.flow.value).isEqualTo(LibrarySort.AUTHOR)
+    }
+
+    @Test fun `unknown stored value falls back to default`() {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        ctx.getSharedPreferences("library_prefs", android.content.Context.MODE_PRIVATE)
+            .edit().putString("library_sort", "NONSENSE").apply()
+        val store = LibraryPreferencesStore(ctx)
+        assertThat(store.flow.value).isEqualTo(LibrarySort.RECENTLY_READ)
+    }
+}

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
@@ -179,6 +179,55 @@ class LibraryViewModelTest {
         }
     }
 
+    @Test fun `query filters by title case-insensitively`() = runTest {
+        seed("h1", "Alpha", "Auth")
+        seed("h2", "BRAVO", "Auth")
+        seed("h3", "Charlie", "Auth")
+        vm.setSort(LibrarySort.TITLE)
+        vm.setQuery("bra")
+        vm.items.test {
+            var final = awaitItem()
+            while (final.size != 1 || final.firstOrNull()?.document?.title != "BRAVO") {
+                final = awaitItem()
+            }
+            assertThat(final.map { it.document.title }).containsExactly("BRAVO")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `query filters by author`() = runTest {
+        seed("h1", "Alpha", "King")
+        seed("h2", "Bravo", "Tolkien")
+        vm.setSort(LibrarySort.TITLE)
+        vm.setQuery("tolk")
+        vm.items.test {
+            var final = awaitItem()
+            while (final.size != 1 || final.firstOrNull()?.document?.title != "Bravo") {
+                final = awaitItem()
+            }
+            assertThat(final.map { it.document.title }).containsExactly("Bravo")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `clearing query restores full list`() = runTest {
+        seed("h1", "Alpha", null)
+        seed("h2", "Bravo", null)
+        vm.setSort(LibrarySort.TITLE)
+        vm.setQuery("alpha")
+        vm.items.test {
+            var filtered = awaitItem()
+            while (filtered.size != 1 || filtered.firstOrNull()?.document?.title != "Alpha") {
+                filtered = awaitItem()
+            }
+            vm.setQuery("")
+            var final = awaitItem()
+            while (final.size < 2) final = awaitItem()
+            assertThat(final).hasSize(2)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     @Test fun `finished books are excluded from continueReading`() = runTest {
         seed("h1", "InProgress", null, percent = 0.5, updatedAt = 100L)
         seed("h2", "Finished", null, percent = 0.99, updatedAt = 200L, finishedAt = 200L)

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
@@ -12,7 +12,13 @@ import io.theficos.ereader.data.local.db.DocumentEntity
 import io.theficos.ereader.data.local.db.EReaderDatabase
 import io.theficos.ereader.data.sync.SyncClient
 import io.theficos.ereader.data.sync.SyncOrchestrator
+import io.theficos.ereader.core.model.Progress as DomainProgress
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -24,6 +30,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = android.app.Application::class)
 class LibraryViewModelTest {
@@ -35,6 +42,7 @@ class LibraryViewModelTest {
     private lateinit var vm: LibraryViewModel
 
     @Before fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
         server = MockWebServer().also { it.start() }
         db = Room.inMemoryDatabaseBuilder(
             ApplicationProvider.getApplicationContext(), EReaderDatabase::class.java
@@ -57,11 +65,12 @@ class LibraryViewModelTest {
             progress = progress,
             syncOrchestrator = orchestrator,
             booksDir = File("/dev/null"),
+            libraryPreferencesStore = LibraryPreferencesStore(ApplicationProvider.getApplicationContext()),
             nowMillis = { 999L },
         )
     }
 
-    @After fun tearDown() { db.close(); server.shutdown() }
+    @After fun tearDown() { db.close(); server.shutdown(); Dispatchers.resetMain() }
 
     private suspend fun seedDoc(file: File): Document {
         val id = db.documentDao().insert(DocumentEntity(
@@ -125,5 +134,61 @@ class LibraryViewModelTest {
         assertThat(tmp.exists()).isTrue()
         assertThat(db.documentDao().findById(doc.id)).isNotNull()
         tmp.delete()
+    }
+
+    private suspend fun seed(
+        contentHash: String, title: String, author: String?,
+        percent: Double = 0.0, updatedAt: Long = 0L, finishedAt: Long? = null,
+    ): Long {
+        val docId = db.documentDao().insert(DocumentEntity(
+            metadataId = contentHash, contentHash = contentHash, title = title, author = author,
+            downloadUrl = "u", localPath = "p", coverPath = null, downloadedAt = 0,
+        ))
+        if (percent > 0.0 || finishedAt != null) {
+            progress.save(DomainProgress(
+                documentId = docId, locator = "loc", percent = percent,
+                updatedAt = updatedAt, finishedAt = finishedAt,
+            ))
+        }
+        return docId
+    }
+
+    @Test fun `default sort is RECENTLY_READ ordering by progressUpdatedAt desc`() = runTest {
+        seed("h1", "Alpha", "Auth", percent = 0.2, updatedAt = 100L)
+        seed("h2", "Bravo", "Auth", percent = 0.4, updatedAt = 300L)
+        seed("h3", "Charlie", "Auth", percent = 0.1, updatedAt = 200L)
+        vm.items.test {
+            var final = awaitItem()
+            while (final.size < 3) final = awaitItem()
+            assertThat(final.map { it.document.title }).containsExactly("Bravo", "Charlie", "Alpha").inOrder()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `TITLE sort orders alphabetically`() = runTest {
+        seed("h1", "Charlie", null)
+        seed("h2", "Alpha", null)
+        seed("h3", "Bravo", null)
+        vm.setSort(LibrarySort.TITLE)
+        vm.items.test {
+            var final = awaitItem()
+            while (final.size < 3) final = awaitItem()
+            val titles = final.map { it.document.title }
+            assertThat(titles).containsExactly("Alpha", "Bravo", "Charlie").inOrder()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `finished books are excluded from continueReading`() = runTest {
+        seed("h1", "InProgress", null, percent = 0.5, updatedAt = 100L)
+        seed("h2", "Finished", null, percent = 0.99, updatedAt = 200L, finishedAt = 200L)
+        vm.continueReading.test {
+            // skip nulls until we get a value or stable null
+            var emission = awaitItem()
+            // Wait one more tick if needed
+            if (emission?.document?.title != "InProgress") emission = awaitItem()
+            assertThat(emission?.document?.title).isEqualTo("InProgress")
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt
+++ b/auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt
@@ -3,6 +3,9 @@ package io.theficos.ereader.auth
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class CalibreCredentialStore(context: Context) {
 
@@ -14,23 +17,30 @@ class CalibreCredentialStore(context: Context) {
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
     )
 
-    fun get(): CalibreCredentials? {
-        val baseUrl = prefs.getString(KEY_BASE_URL, null) ?: return null
-        val user = prefs.getString(KEY_USER, null) ?: return null
-        val pass = prefs.getString(KEY_PASS, null) ?: return null
-        return CalibreCredentials(baseUrl, user, pass)
-    }
+    private val _flow = MutableStateFlow(load())
+    val flow: StateFlow<CalibreCredentials?> = _flow.asStateFlow()
+
+    fun get(): CalibreCredentials? = _flow.value
 
     fun put(creds: CalibreCredentials) {
         prefs.edit()
             .putString(KEY_BASE_URL, creds.baseUrl)
             .putString(KEY_USER, creds.username)
             .putString(KEY_PASS, creds.password)
-            .apply()
+            .commit()
+        _flow.value = creds
     }
 
     fun clear() {
         prefs.edit().clear().commit()
+        _flow.value = null
+    }
+
+    private fun load(): CalibreCredentials? {
+        val baseUrl = prefs.getString(KEY_BASE_URL, null) ?: return null
+        val user = prefs.getString(KEY_USER, null) ?: return null
+        val pass = prefs.getString(KEY_PASS, null) ?: return null
+        return CalibreCredentials(baseUrl, user, pass)
     }
 
     private companion object {

--- a/auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt
+++ b/auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt
@@ -30,4 +30,30 @@ class CalibreCredentialStoreTest {
         store.clear()
         assertThat(store.get()).isNull()
     }
+
+    @Test fun `flow emits null when nothing stored`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        assertThat(store.flow.value).isNull()
+    }
+
+    @Test fun `put updates flow synchronously`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.put(CalibreCredentials("https://example", "u", "p"))
+        assertThat(store.flow.value).isEqualTo(CalibreCredentials("https://example", "u", "p"))
+    }
+
+    @Test fun `clear emits null`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.put(CalibreCredentials("https://example", "u", "p"))
+        store.clear()
+        assertThat(store.flow.value).isNull()
+    }
+
+    @Test fun `flow value matches get`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.put(CalibreCredentials("https://example", "u", "p"))
+        assertThat(store.flow.value).isEqualTo(store.get())
+    }
 }

--- a/core/model/src/main/java/io/theficos/ereader/core/model/Progress.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/Progress.kt
@@ -5,6 +5,7 @@ data class Progress(
     val locator: String,
     val percent: Double,
     val updatedAt: Long,
+    val finishedAt: Long? = null,
 ) {
     init {
         require(percent in 0.0..1.0) { "percent must be in [0,1]" }

--- a/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/4.json
+++ b/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/4.json
@@ -1,0 +1,211 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "0d22572d018c4e58509896f04c48dad5",
+    "entities": [
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `metadataId` TEXT, `contentHash` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `downloadUrl` TEXT NOT NULL, `localPath` TEXT NOT NULL, `coverPath` TEXT, `downloadedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_documents_metadataId",
+            "unique": true,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_documents_contentHash",
+            "unique": true,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `documentId` INTEGER NOT NULL, `locator` TEXT NOT NULL, `percent` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `finishedAt` INTEGER, FOREIGN KEY(`documentId`) REFERENCES `documents`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locator",
+            "columnName": "locator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percent",
+            "columnName": "percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_documentId",
+            "unique": true,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_progress_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "documents",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `lastPulledAt` INTEGER NOT NULL, PRIMARY KEY(`tableName`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPulledAt",
+            "columnName": "lastPulledAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0d22572d018c4e58509896f04c48dad5')"
+    ]
+  }
+}

--- a/data/local/src/main/java/io/theficos/ereader/data/local/ProgressRepository.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/ProgressRepository.kt
@@ -22,6 +22,7 @@ class ProgressRepository(private val dao: ProgressDao) {
             updatedAt = progress.updatedAt,
             localUpdatedAt = now,
             syncedAt = 0L,
+            finishedAt = progress.finishedAt,
         ))
     }
 
@@ -38,9 +39,16 @@ class ProgressRepository(private val dao: ProgressDao) {
             updatedAt = now,
             localUpdatedAt = now,
             syncedAt = 0L,
+            finishedAt = null,
         ))
     }
 
     private fun ProgressEntity.toDomain(): Progress =
-        Progress(documentId = documentId, locator = locator, percent = percent, updatedAt = updatedAt)
+        Progress(
+            documentId = documentId,
+            locator = locator,
+            percent = percent,
+            updatedAt = updatedAt,
+            finishedAt = finishedAt,
+        )
 }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [DocumentEntity::class, ProgressEntity::class, SyncStateEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 abstract class EReaderDatabase : RoomDatabase() {
@@ -37,9 +37,15 @@ abstract class EReaderDatabase : RoomDatabase() {
             }
         }
 
+        internal val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE progress ADD COLUMN finishedAt INTEGER")
+            }
+        }
+
         fun build(context: Context): EReaderDatabase =
             Room.databaseBuilder(context, EReaderDatabase::class.java, "ereader.db")
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                 .build()
     }
 }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/ProgressEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/ProgressEntity.kt
@@ -25,4 +25,5 @@ data class ProgressEntity(
     val updatedAt: Long,
     val localUpdatedAt: Long,
     val syncedAt: Long,
+    val finishedAt: Long? = null,
 )

--- a/data/local/src/test/java/io/theficos/ereader/data/local/ProgressRepositoryTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/ProgressRepositoryTest.kt
@@ -61,4 +61,37 @@ class ProgressRepositoryTest {
         assertThat(row.percent).isEqualTo(0.0)
         assertThat(row.updatedAt).isEqualTo(42L)
     }
+
+    @Test fun `save persists finishedAt`() = runTest {
+        val docId = seedDoc()
+        repo.save(io.theficos.ereader.core.model.Progress(
+            documentId = docId, locator = "loc", percent = 0.99,
+            updatedAt = 100L, finishedAt = 200L,
+        ))
+        val row = db.progressDao().findByDocument(docId)!!
+        assertThat(row.finishedAt).isEqualTo(200L)
+    }
+
+    @Test fun `resetForDocument clears finishedAt`() = runTest {
+        val docId = seedDoc()
+        db.progressDao().upsert(ProgressEntity(
+            documentId = docId, locator = "x", percent = 0.99,
+            updatedAt = 1L, localUpdatedAt = 1L, syncedAt = 1L,
+            finishedAt = 999L,
+        ))
+        repo.resetForDocument(docId, now = 50L)
+        val row = db.progressDao().findByDocument(docId)!!
+        assertThat(row.finishedAt).isNull()
+    }
+
+    @Test fun `get returns finishedAt when present`() = runTest {
+        val docId = seedDoc()
+        db.progressDao().upsert(ProgressEntity(
+            documentId = docId, locator = "x", percent = 0.99,
+            updatedAt = 1L, localUpdatedAt = 1L, syncedAt = 1L,
+            finishedAt = 7L,
+        ))
+        val p = repo.get(docId)
+        assertThat(p?.finishedAt).isEqualTo(7L)
+    }
 }

--- a/data/local/src/test/java/io/theficos/ereader/data/local/db/ProgressDaoTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/db/ProgressDaoTest.kt
@@ -67,4 +67,63 @@ class ProgressDaoTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test fun `upsert round-trips finishedAt`() = runTest {
+        val docId = newDoc()
+        dao.upsert(ProgressEntity(
+            documentId = docId, locator = "x", percent = 0.99,
+            updatedAt = 1, localUpdatedAt = 1, syncedAt = 0,
+            finishedAt = 1234L,
+        ))
+        val found = dao.findByDocument(docId)
+        assertThat(found?.finishedAt).isEqualTo(1234L)
+    }
+
+    @Test fun `upsert allows null finishedAt`() = runTest {
+        val docId = newDoc()
+        dao.upsert(ProgressEntity(
+            documentId = docId, locator = "x", percent = 0.5,
+            updatedAt = 1, localUpdatedAt = 1, syncedAt = 0,
+            finishedAt = null,
+        ))
+        val found = dao.findByDocument(docId)
+        assertThat(found?.finishedAt).isNull()
+    }
+
+    @Test fun `MIGRATION_3_4 sql adds nullable finishedAt column`() {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val dbName = "migration-3to4-test.db"
+        ctx.deleteDatabase(dbName)
+        val sqlite = ctx.openOrCreateDatabase(dbName, android.content.Context.MODE_PRIVATE, null)
+        try {
+            sqlite.execSQL(
+                "CREATE TABLE progress (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                    "documentId INTEGER NOT NULL, " +
+                    "locator TEXT NOT NULL, " +
+                    "percent REAL NOT NULL, " +
+                    "updatedAt INTEGER NOT NULL, " +
+                    "localUpdatedAt INTEGER NOT NULL DEFAULT 0, " +
+                    "syncedAt INTEGER NOT NULL DEFAULT 0)"
+            )
+            sqlite.execSQL("INSERT INTO progress (documentId, locator, percent, updatedAt, localUpdatedAt, syncedAt) VALUES (1, '', 0.0, 0, 0, 0)")
+
+            // Apply the same SQL the production migration runs.
+            sqlite.execSQL("ALTER TABLE progress ADD COLUMN finishedAt INTEGER")
+
+            sqlite.rawQuery("PRAGMA table_info(progress)", null).use { c ->
+                val cols = mutableListOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("finishedAt")
+            }
+            // Pre-existing rows tolerate NULL for the new column.
+            sqlite.rawQuery("SELECT finishedAt FROM progress", null).use { c ->
+                assertThat(c.moveToNext()).isTrue()
+                assertThat(c.isNull(0)).isTrue()
+            }
+        } finally {
+            sqlite.close()
+            ctx.deleteDatabase(dbName)
+        }
+    }
 }

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsCatalog.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsCatalog.kt
@@ -17,6 +17,8 @@ data class OpdsPublication(
     val author: String?,
     val epubDownloadHref: String,
     val coverUrl: String?,
+    /** OPDS `rel=alternate type=text/html` href — the book's web detail page on the OPDS server (calibre-web's `/book/{id}`). Null if the feed didn't expose one. */
+    val webUrl: String? = null,
 )
 
 data class OpdsSearchLink(

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt
@@ -29,6 +29,9 @@ class OpdsClient(
             // Readium also drops opds:image/thumbnail links unless a sibling opds:image link
             // is present, so we pull cover hrefs from the raw XML and join by acquisition href.
             val coversByEpubHref = parseCoverHrefs(bytes, absoluteUrl)
+            // The `rel=alternate type=text/html` link points at the OPDS server's web detail page
+            // (e.g. calibre-web's `/book/{id}`); Readium doesn't surface it, so we read raw XML too.
+            val webUrlsByEpubHref = parseWebUrls(bytes, absoluteUrl)
             OpdsFeed(
                 title = feed.metadata.title,
                 navigation = feed.navigation.map { link ->
@@ -48,6 +51,7 @@ class OpdsClient(
                         author = pub.metadata.authors.firstOrNull()?.name,
                         epubDownloadHref = absoluteEpubHref,
                         coverUrl = coversByEpubHref[absoluteEpubHref],
+                        webUrl = webUrlsByEpubHref[absoluteEpubHref],
                     )
                 },
                 searchLink = searchLink,
@@ -92,6 +96,37 @@ class OpdsClient(
             val cover = thumbnailHref ?: imageHref
             if (epubHref != null && cover != null) {
                 result[absolutize(feedUrl, epubHref)] = absolutize(feedUrl, cover)
+            }
+        }
+        return result
+    }
+
+    private fun parseWebUrls(bytes: ByteArray, feedUrl: String): Map<String, String> {
+        val doc = runCatching {
+            DocumentBuilderFactory.newInstance()
+                .apply { isNamespaceAware = true }
+                .newDocumentBuilder()
+                .parse(ByteArrayInputStream(bytes))
+        }.getOrNull() ?: return emptyMap()
+        val entries = doc.getElementsByTagNameNS("http://www.w3.org/2005/Atom", "entry")
+        val result = mutableMapOf<String, String>()
+        for (i in 0 until entries.length) {
+            val entry = entries.item(i) as org.w3c.dom.Element
+            val links = entry.getElementsByTagNameNS("http://www.w3.org/2005/Atom", "link")
+            var epubHref: String? = null
+            var webHref: String? = null
+            for (j in 0 until links.length) {
+                val el = links.item(j) as org.w3c.dom.Element
+                val rel = el.getAttribute("rel")
+                val href = el.getAttribute("href").takeIf { it.isNotBlank() } ?: continue
+                val type = el.getAttribute("type")
+                when {
+                    rel == "http://opds-spec.org/acquisition" && type == "application/epub+zip" -> epubHref = href
+                    rel == "alternate" && type == "text/html" -> webHref = href
+                }
+            }
+            if (epubHref != null && webHref != null) {
+                result[absolutize(feedUrl, epubHref)] = absolutize(feedUrl, webHref)
             }
         }
         return result

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt
@@ -51,7 +51,8 @@ class OpdsClient(
                         author = pub.metadata.authors.firstOrNull()?.name,
                         epubDownloadHref = absoluteEpubHref,
                         coverUrl = coversByEpubHref[absoluteEpubHref],
-                        webUrl = webUrlsByEpubHref[absoluteEpubHref],
+                        webUrl = webUrlsByEpubHref[absoluteEpubHref]
+                            ?: deriveCalibreWebDetailUrl(absoluteEpubHref),
                     )
                 },
                 searchLink = searchLink,
@@ -132,6 +133,20 @@ class OpdsClient(
         return result
     }
 
+    /**
+     * Calibre-web's OPDS feeds don't include a `rel=alternate type=text/html` link, but the
+     * epub acquisition href follows the pattern `<origin>/opds/download/<book_id>/<format>`.
+     * The web detail page lives at `<origin>/book/<book_id>`. This best-effort derivation
+     * lets long-press → "Open in calibre-web" work without a spec-compliant alternate link.
+     * Returns null for non-calibre-web feeds (the URL doesn't match the pattern).
+     */
+    private fun deriveCalibreWebDetailUrl(absoluteEpubHref: String): String? {
+        val match = CALIBRE_DOWNLOAD_REGEX.find(absoluteEpubHref) ?: return null
+        val bookId = match.groupValues[1]
+        val origin = absoluteEpubHref.substring(0, match.range.first)
+        return "$origin/book/$bookId"
+    }
+
     private fun parseSearchLink(bytes: ByteArray, feedUrl: String): OpdsSearchLink? {
         val doc = runCatching {
             DocumentBuilderFactory.newInstance()
@@ -201,5 +216,6 @@ class OpdsClient(
 
     private companion object {
         private val OPTIONAL_PARAM = Regex("""\{[^{}]+\?\}""")
+        private val CALIBRE_DOWNLOAD_REGEX = Regex("""/opds/download/(\d+)/[^/?]+/?(?:\?.*)?$""")
     }
 }

--- a/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
+++ b/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
@@ -87,10 +87,13 @@ class OpdsClientTest {
         assertThat(pub.webUrl).endsWith("/book/42")
     }
 
-    @Test fun `webUrl is null when feed has no alternate text-html link`() = runTest {
+    @Test fun `webUrl derives from calibre-web download href when no alternate link is present`() = runTest {
         val feed = client.fetch(server.url("/opds/thumb-only").toString())
         val pub = feed.publications.single()
-        assertThat(pub.webUrl).isNull()
+        // No rel=alternate text/html in this fixture, but the acquisition href is
+        // /opds/download/42/epub — fallback should produce <origin>/book/42.
+        assertThat(pub.webUrl).isNotNull()
+        assertThat(pub.webUrl).endsWith("/book/42")
     }
 
     @Test fun `feed without a search link exposes none`() = runTest {

--- a/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
+++ b/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
@@ -80,6 +80,19 @@ class OpdsClientTest {
         assertThat(pub.coverUrl).endsWith("/opds/cover/42")
     }
 
+    @Test fun `fetch acquisition feed extracts webUrl from rel=alternate text-html link`() = runTest {
+        val feed = client.fetch(server.url("/opds/new").toString())
+        val pub = feed.publications[0]
+        assertThat(pub.webUrl).isNotNull()
+        assertThat(pub.webUrl).endsWith("/book/42")
+    }
+
+    @Test fun `webUrl is null when feed has no alternate text-html link`() = runTest {
+        val feed = client.fetch(server.url("/opds/thumb-only").toString())
+        val pub = feed.publications.single()
+        assertThat(pub.webUrl).isNull()
+    }
+
     @Test fun `feed without a search link exposes none`() = runTest {
         val feed = client.fetch(server.url("/opds").toString())
         assertThat(feed.searchLink).isNull()

--- a/data/opds/src/test/resources/opds/catalog-feed.xml
+++ b/data/opds/src/test/resources/opds/catalog-feed.xml
@@ -12,5 +12,6 @@
     <dc:identifier>urn:uuid:550e8400-e29b-41d4-a716-446655440000</dc:identifier>
     <link rel="http://opds-spec.org/acquisition" href="/opds/download/42/epub" type="application/epub+zip"/>
     <link rel="http://opds-spec.org/image" href="/opds/cover/42" type="image/jpeg"/>
+    <link rel="alternate" type="text/html" href="/book/42"/>
   </entry>
 </feed>

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
@@ -15,6 +15,7 @@ data class ProgressItemDto(
     val locator: String,
     val percent: Double,
     @SerialName("client_updated_at") val clientUpdatedAt: String,
+    @SerialName("finished_at") val finishedAt: String? = null,
 )
 
 @Serializable

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
@@ -30,6 +30,7 @@ class SyncOrchestrator(
                     locator = progress.locator,
                     percent = progress.percent,
                     clientUpdatedAt = Instant.ofEpochMilli(progress.updatedAt).toString(),
+                    finishedAt = progress.finishedAt?.let { Instant.ofEpochMilli(it).toString() },
                 )
             }
             when (val res = client.pushProgress(ProgressPushBody(items))) {
@@ -61,6 +62,7 @@ class SyncOrchestrator(
         val identity = DocumentIdentity(metadataId = item.document.metadataId, contentHash = item.document.contentHash)
         val doc = documentRepo.findByIdentity(identity) ?: return
         val incomingUpdatedAt = Instant.parse(item.clientUpdatedAt).toEpochMilli()
+        val incomingFinishedAt = item.finishedAt?.let { Instant.parse(it).toEpochMilli() }
         val existing = progressDao.findByDocument(doc.id)
         if (existing != null && existing.localUpdatedAt >= incomingUpdatedAt) {
             return
@@ -74,6 +76,7 @@ class SyncOrchestrator(
                 updatedAt = incomingUpdatedAt,
                 localUpdatedAt = incomingUpdatedAt,
                 syncedAt = incomingUpdatedAt,
+                finishedAt = incomingFinishedAt,
             )
         )
     }

--- a/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
+++ b/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
@@ -32,4 +32,44 @@ class ProgressDtosTest {
         assertThat(r.items).hasSize(1)
         assertThat(r.serverTime).isEqualTo("2026-05-05T12:00:01+00:00")
     }
+
+    @Test fun `push body round-trips finishedAt`() {
+        val body = ProgressPushBody(
+            items = listOf(
+                ProgressItemDto(
+                    document = DocumentIdDto(metadataId = "m1", contentHash = "h1"),
+                    locator = "loc",
+                    percent = 0.99,
+                    clientUpdatedAt = "2026-05-09T12:00:00+00:00",
+                    finishedAt = "2026-05-09T12:00:00+00:00",
+                )
+            )
+        )
+        val encoded = json.encodeToString(ProgressPushBody.serializer(), body)
+        assertThat(encoded).contains("\"finished_at\":\"2026-05-09T12:00:00+00:00\"")
+        val decoded = json.decodeFromString(ProgressPushBody.serializer(), encoded)
+        assertThat(decoded).isEqualTo(body)
+    }
+
+    @Test fun `null finishedAt is omitted on the wire`() {
+        val body = ProgressPushBody(
+            items = listOf(
+                ProgressItemDto(
+                    document = DocumentIdDto(metadataId = "m1", contentHash = "h1"),
+                    locator = "loc",
+                    percent = 0.5,
+                    clientUpdatedAt = "2026-05-09T12:00:00+00:00",
+                    finishedAt = null,
+                )
+            )
+        )
+        val encoded = json.encodeToString(ProgressPushBody.serializer(), body)
+        assertThat(encoded).doesNotContain("finished_at")
+    }
+
+    @Test fun `pull response decodes with optional finishedAt`() {
+        val raw = """{"items":[{"document":{"metadata_id":null,"content_hash":"h"},"locator":"l","percent":0.99,"client_updated_at":"2026-05-09T12:00:00+00:00","finished_at":"2026-05-09T12:00:00+00:00"}],"server_time":"2026-05-09T12:00:01+00:00"}"""
+        val r = json.decodeFromString(ProgressPullResponse.serializer(), raw)
+        assertThat(r.items.first().finishedAt).isEqualTo("2026-05-09T12:00:00+00:00")
+    }
 }

--- a/docs/superpowers/plans/2026-05-09-reader-library-pack.md
+++ b/docs/superpowers/plans/2026-05-09-reader-library-pack.md
@@ -1,0 +1,2477 @@
+# Reader & Library feature pack — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship five reader and library improvements (finished-state bug fix, keep-screen-on, tap-to-page, library sort, library search) on a single branch in five reviewable phases.
+
+**Architecture:** Phase 1 introduces a nullable `finishedAt` field through Android Room, the sync DTOs, the FastAPI server, and the Postgres schema; Phase 2 is a one-flag screen-wakelock; Phase 3 lifts the Readium navigator fragment reference into `ReaderScreen` and adds tap zones + a `ReaderPreferences` toggle; Phase 4 adds a `LibrarySort` enum, a sibling `LibraryPreferencesStore`, and a finished-checkmark overlay; Phase 5 adds in-memory query filtering. All work lands as five logical commits on `feat/reader-library-pack` (already created), tests green at every boundary.
+
+**Tech Stack:** Kotlin / Jetpack Compose / Room / DataStore-ish SharedPreferences / kotlinx.serialization / Readium 3.x / FastAPI / SQLAlchemy 2.x / Alembic / pytest / Robolectric / Truth.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-reader-library-pack-design.md`.
+
+---
+
+## Conventions used in this plan
+
+- Build commands assume CWD = repo root.
+- Android tests run with `./gradlew :<module>:testDebugUnitTest --tests <FQN>`.
+- Server tests run with `cd server && uv run pytest <path> -v` (see `server/README.md`); fall back to `pytest` if `uv` is not available.
+- Each phase ends in a single commit named with the existing gitmoji style. Phases use these prefixes:
+
+| Phase | Commit prefix |
+|---|---|
+| 1 | `:bug: fix(reader): track finished books and stop the 99% Continue Reading loop` |
+| 2 | `:sparkles: feat(reader): keep screen on while reading` |
+| 3 | `:sparkles: feat(reader): tap left/right to turn pages (toggleable)` |
+| 4 | `:sparkles: feat(library): sort options and finished badge` |
+| 5 | `:sparkles: feat(library): local search by title and author` |
+
+- TDD: each task starts with a failing test, runs it red, makes it pass, runs it green. Compile-time errors after a refactor count as a failing red — note them as "Expected: build fails with …" rather than running the test.
+- Don't combine commits across phases; each phase is its own commit so the branch is bisectable.
+
+---
+
+# Phase 1 — "Finished" concept
+
+Files touched in this phase:
+
+- Create: server `migrations/versions/0002_progress_finished_at.py`
+- Modify (Android core/model): `core/model/src/main/java/io/theficos/ereader/core/model/Progress.kt`
+- Modify (Android local DB): `data/local/src/main/java/io/theficos/ereader/data/local/db/ProgressEntity.kt`, `data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt`, `data/local/src/main/java/io/theficos/ereader/data/local/ProgressRepository.kt`
+- Schema export: `data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/4.json` (auto-generated on build)
+- Modify (Android reader): `reader/src/main/java/io/theficos/ereader/reader/ProgressTracker.kt`
+- Modify (Android app): `app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt`
+- Modify (Android sync): `data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt`, `data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt`
+- Modify (server): `server/opds_sync/db/models.py`, `server/opds_sync/api/progress.py`
+- Modify tests: `data/local/src/test/java/io/theficos/ereader/data/local/db/ProgressDaoTest.kt`, `data/local/src/test/java/io/theficos/ereader/data/local/ProgressRepositoryTest.kt`, `reader/src/test/java/io/theficos/ereader/reader/ProgressTrackerTest.kt`, `data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt`, `server/tests/integration/test_progress.py`
+
+---
+
+## Task 1.1 — Add `finishedAt` to the domain model
+
+**Files:**
+- Modify: `core/model/src/main/java/io/theficos/ereader/core/model/Progress.kt`
+
+- [ ] **Step 1: Update `Progress` data class**
+
+Replace the entire file content with:
+
+```kotlin
+package io.theficos.ereader.core.model
+
+data class Progress(
+    val documentId: Long,
+    val locator: String,
+    val percent: Double,
+    val updatedAt: Long,
+    val finishedAt: Long? = null,
+) {
+    init {
+        require(percent in 0.0..1.0) { "percent must be in [0,1]" }
+    }
+}
+```
+
+Default `null` keeps existing call sites compiling.
+
+- [ ] **Step 2: Verify the module still builds**
+
+Run: `./gradlew :core:model:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Do not commit yet** — Task 1.2 extends the schema and the commit is created at the end of the phase.
+
+---
+
+## Task 1.2 — Room migration to v4 (`finishedAt` column)
+
+**Files:**
+- Modify: `data/local/src/main/java/io/theficos/ereader/data/local/db/ProgressEntity.kt`
+- Modify: `data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt`
+- Test: `data/local/src/test/java/io/theficos/ereader/data/local/db/ProgressDaoTest.kt`
+
+- [ ] **Step 1: Write the failing test for the new column**
+
+Append this test to `ProgressDaoTest.kt`:
+
+```kotlin
+    @Test fun `upsert round-trips finishedAt`() = runTest {
+        val docId = newDoc()
+        dao.upsert(ProgressEntity(
+            documentId = docId, locator = "x", percent = 0.99,
+            updatedAt = 1, localUpdatedAt = 1, syncedAt = 0,
+            finishedAt = 1234L,
+        ))
+        val found = dao.findByDocument(docId)
+        assertThat(found?.finishedAt).isEqualTo(1234L)
+    }
+
+    @Test fun `upsert allows null finishedAt`() = runTest {
+        val docId = newDoc()
+        dao.upsert(ProgressEntity(
+            documentId = docId, locator = "x", percent = 0.5,
+            updatedAt = 1, localUpdatedAt = 1, syncedAt = 0,
+            finishedAt = null,
+        ))
+        val found = dao.findByDocument(docId)
+        assertThat(found?.finishedAt).isNull()
+    }
+```
+
+- [ ] **Step 2: Run the new test and confirm it fails**
+
+Run: `./gradlew :data:local:testDebugUnitTest --tests "io.theficos.ereader.data.local.db.ProgressDaoTest.upsert round-trips finishedAt"`
+Expected: compile error — `finishedAt` is not a parameter of `ProgressEntity`.
+
+- [ ] **Step 3: Add `finishedAt` to `ProgressEntity`**
+
+Replace the data class declaration in `ProgressEntity.kt` with:
+
+```kotlin
+data class ProgressEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val documentId: Long,
+    val locator: String,
+    val percent: Double,
+    val updatedAt: Long,
+    val localUpdatedAt: Long,
+    val syncedAt: Long,
+    val finishedAt: Long? = null,
+)
+```
+
+Keep imports and annotations untouched.
+
+- [ ] **Step 4: Bump database version and add `MIGRATION_3_4`**
+
+In `EReaderDatabase.kt`, change `version = 3` to `version = 4` and add the migration to the companion object:
+
+```kotlin
+        internal val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE progress ADD COLUMN finishedAt INTEGER")
+            }
+        }
+```
+
+…and register it in the `build` factory:
+
+```kotlin
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+```
+
+- [ ] **Step 5: Run the new test and confirm it passes**
+
+Run: `./gradlew :data:local:testDebugUnitTest --tests "io.theficos.ereader.data.local.db.ProgressDaoTest"`
+Expected: all tests pass, including the two new ones.
+
+A `4.json` file should appear in `data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/`. Leave it untouched; it gets committed at the end of the phase.
+
+- [ ] **Step 6: Add a migration test**
+
+Append this lightweight migration test to `ProgressDaoTest.kt`. It opens a SQLite database with the v3 progress schema, runs the migration's SQL, and asserts the new column exists with NULL accepted as a value. It deliberately avoids Room's `MigrationTestHelper` (which requires an `androidTest` source set and `androidx.room:room-testing` on `androidTestImplementation`) — for an `ALTER TABLE ADD COLUMN` migration, the SQL itself is the entire risk surface and Room's happiness with the resulting schema is exercised by every other test in this class:
+
+```kotlin
+    @Test fun `MIGRATION_3_4 sql adds nullable finishedAt column`() {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val dbName = "migration-3to4-test.db"
+        ctx.deleteDatabase(dbName)
+        val sqlite = ctx.openOrCreateDatabase(dbName, android.content.Context.MODE_PRIVATE, null)
+        try {
+            sqlite.execSQL(
+                "CREATE TABLE progress (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                    "documentId INTEGER NOT NULL, " +
+                    "locator TEXT NOT NULL, " +
+                    "percent REAL NOT NULL, " +
+                    "updatedAt INTEGER NOT NULL, " +
+                    "localUpdatedAt INTEGER NOT NULL DEFAULT 0, " +
+                    "syncedAt INTEGER NOT NULL DEFAULT 0)"
+            )
+            sqlite.execSQL("INSERT INTO progress (documentId, locator, percent, updatedAt, localUpdatedAt, syncedAt) VALUES (1, '', 0.0, 0, 0, 0)")
+
+            // Apply the same SQL the production migration runs.
+            sqlite.execSQL("ALTER TABLE progress ADD COLUMN finishedAt INTEGER")
+
+            sqlite.rawQuery("PRAGMA table_info(progress)", null).use { c ->
+                val cols = mutableListOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("finishedAt")
+            }
+            // Pre-existing rows tolerate NULL for the new column.
+            sqlite.rawQuery("SELECT finishedAt FROM progress", null).use { c ->
+                assertThat(c.moveToNext()).isTrue()
+                assertThat(c.isNull(0)).isTrue()
+            }
+        } finally {
+            sqlite.close()
+            ctx.deleteDatabase(dbName)
+        }
+    }
+```
+
+This test depends only on `android.content.Context` (already accessible through `ApplicationProvider`) and `assertThat` (already imported). No new module imports required.
+
+- [ ] **Step 7: Run the migration test**
+
+Run: `./gradlew :data:local:testDebugUnitTest --tests "io.theficos.ereader.data.local.db.ProgressDaoTest"`
+Expected: PASS.
+
+---
+
+## Task 1.3 — Map `finishedAt` through `ProgressRepository`
+
+**Files:**
+- Modify: `data/local/src/main/java/io/theficos/ereader/data/local/ProgressRepository.kt`
+- Test: `data/local/src/test/java/io/theficos/ereader/data/local/ProgressRepositoryTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ProgressRepositoryTest.kt`:
+
+```kotlin
+    @Test fun `save persists finishedAt`() = runTest {
+        val docId = seedDoc()
+        repo.save(io.theficos.ereader.core.model.Progress(
+            documentId = docId, locator = "loc", percent = 0.99,
+            updatedAt = 100L, finishedAt = 200L,
+        ))
+        val row = db.progressDao().findByDocument(docId)!!
+        assertThat(row.finishedAt).isEqualTo(200L)
+    }
+
+    @Test fun `resetForDocument clears finishedAt`() = runTest {
+        val docId = seedDoc()
+        db.progressDao().upsert(ProgressEntity(
+            documentId = docId, locator = "x", percent = 0.99,
+            updatedAt = 1L, localUpdatedAt = 1L, syncedAt = 1L,
+            finishedAt = 999L,
+        ))
+        repo.resetForDocument(docId, now = 50L)
+        val row = db.progressDao().findByDocument(docId)!!
+        assertThat(row.finishedAt).isNull()
+    }
+
+    @Test fun `get returns finishedAt when present`() = runTest {
+        val docId = seedDoc()
+        db.progressDao().upsert(ProgressEntity(
+            documentId = docId, locator = "x", percent = 0.99,
+            updatedAt = 1L, localUpdatedAt = 1L, syncedAt = 1L,
+            finishedAt = 7L,
+        ))
+        val p = repo.get(docId)
+        assertThat(p?.finishedAt).isEqualTo(7L)
+    }
+```
+
+- [ ] **Step 2: Run them and confirm they fail**
+
+Run: `./gradlew :data:local:testDebugUnitTest --tests "io.theficos.ereader.data.local.ProgressRepositoryTest"`
+Expected: compile error — `Progress` does not have `finishedAt` parameter, and the entity round-trip fails. (Step 1.1 already added `finishedAt` to `Progress`, so it's actually only the `save`/`reset`/`toDomain` paths that are wrong; the test should fail with assertions, not compile errors. Either is acceptable.)
+
+- [ ] **Step 3: Update `ProgressRepository.kt`**
+
+Replace the file content with:
+
+```kotlin
+package io.theficos.ereader.data.local
+
+import io.theficos.ereader.core.model.Progress
+import io.theficos.ereader.data.local.db.ProgressDao
+import io.theficos.ereader.data.local.db.ProgressEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class ProgressRepository(private val dao: ProgressDao) {
+    suspend fun get(documentId: Long): Progress? =
+        dao.findByDocument(documentId)?.toDomain()
+
+    fun observe(documentId: Long): Flow<Progress?> =
+        dao.observeByDocument(documentId).map { it?.toDomain() }
+
+    suspend fun save(progress: Progress) {
+        val now = System.currentTimeMillis()
+        dao.upsert(ProgressEntity(
+            documentId = progress.documentId,
+            locator = progress.locator,
+            percent = progress.percent,
+            updatedAt = progress.updatedAt,
+            localUpdatedAt = now,
+            syncedAt = 0L,
+            finishedAt = progress.finishedAt,
+        ))
+    }
+
+    suspend fun dirty(): List<Progress> = dao.dirty().map { it.toDomain() }
+
+    suspend fun markSynced(documentId: Long, syncedAt: Long) =
+        dao.markSynced(documentId, syncedAt)
+
+    suspend fun resetForDocument(documentId: Long, now: Long) {
+        dao.upsert(ProgressEntity(
+            documentId = documentId,
+            locator = "",
+            percent = 0.0,
+            updatedAt = now,
+            localUpdatedAt = now,
+            syncedAt = 0L,
+            finishedAt = null,
+        ))
+    }
+
+    private fun ProgressEntity.toDomain(): Progress =
+        Progress(
+            documentId = documentId,
+            locator = locator,
+            percent = percent,
+            updatedAt = updatedAt,
+            finishedAt = finishedAt,
+        )
+}
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+Run: `./gradlew :data:local:testDebugUnitTest`
+Expected: all tests pass.
+
+---
+
+## Task 1.4 — Detect "finished" inside `ProgressTracker`
+
+**Files:**
+- Modify: `reader/src/main/java/io/theficos/ereader/reader/ProgressTracker.kt`
+- Test: `reader/src/test/java/io/theficos/ereader/reader/ProgressTrackerTest.kt`
+
+The new `attach` signature takes the EPUB's last-spine href and the existing `finishedAt` (read from the saved progress). The tracker computes `finishedAt` per save according to:
+
+1. Sticky: if `existingFinishedAt != null`, keep it forever.
+2. Threshold: `totalProgression >= 0.98` ⇒ now.
+3. End-of-last-resource: `locator.href == lastSpineHref` and `progression >= 0.99` ⇒ now.
+4. Else: `null`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `ProgressTrackerTest.kt`. Update the existing helper and existing tests to keep compiling under the new `attach` signature (passing `lastSpineHref = null, initialFinishedAt = null` is the safe default), then append the new behaviour tests. The full file should look like this — overwrite `ProgressTrackerTest.kt` with:
+
+```kotlin
+package io.theficos.ereader.reader
+
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.core.model.Progress
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ProgressTrackerTest {
+
+    private fun locatorAt(href: String, totalProgression: Double, progression: Double = totalProgression): Locator =
+        Locator(
+            href = Url(href)!!,
+            mediaType = MediaType.XHTML,
+            locations = Locator.Locations(
+                progression = progression,
+                totalProgression = totalProgression,
+            ),
+        )
+
+    private fun newTracker(
+        saved: MutableList<Progress>,
+        scope: kotlinx.coroutines.CoroutineScope,
+        nowProvider: () -> Long,
+    ) = ProgressTracker(
+        save = { saved += it },
+        scope = scope,
+        nowMs = nowProvider,
+    )
+
+    @Test fun `debounces saves to one per second`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = null, initialFinishedAt = null)
+
+        repeat(5) { locators.tryEmit(locatorAt("/ch1", 0.10 + it * 0.01)) }
+        runCurrent()
+        advanceTimeBy(50)
+        assertThat(saved).isEmpty()
+
+        advanceTimeBy(1_000)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().percent).isWithin(0.001).of(0.14)
+    }
+
+    @Test fun `flushes immediately on detach`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = null, initialFinishedAt = null)
+        locators.tryEmit(locatorAt("/ch1", 0.5))
+        runCurrent()
+        tracker.detach()
+        assertThat(saved).hasSize(1)
+        assertThat(saved.first().locator).contains("/ch1")
+        assertThat(saved.first().percent).isEqualTo(0.5)
+        assertThat(saved.first().finishedAt).isNull()
+    }
+
+    @Test fun `marks finished when totalProgression crosses 0_98`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = null, initialFinishedAt = null)
+        locators.tryEmit(locatorAt("/ch9", 0.985))
+        runCurrent()
+        advanceTimeBy(1_100)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().finishedAt).isNotNull()
+    }
+
+    @Test fun `does not mark finished below threshold and away from last spine`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = Url("/ch9")!!, initialFinishedAt = null)
+        locators.tryEmit(locatorAt("/ch5", 0.40))
+        runCurrent()
+        advanceTimeBy(1_100)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().finishedAt).isNull()
+    }
+
+    @Test fun `marks finished when at last spine and progression at end`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = Url("/ch9")!!, initialFinishedAt = null)
+        // totalProgression below threshold but we're at last spine and end-of-resource
+        locators.tryEmit(locatorAt("/ch9", totalProgression = 0.92, progression = 0.995))
+        runCurrent()
+        advanceTimeBy(1_100)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().finishedAt).isNotNull()
+    }
+
+    @Test fun `finishedAt is sticky once set`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = null, initialFinishedAt = 4242L)
+        locators.tryEmit(locatorAt("/ch1", 0.10))
+        runCurrent()
+        advanceTimeBy(1_100)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().finishedAt).isEqualTo(4242L)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `./gradlew :reader:testDebugUnitTest`
+Expected: compile error — `attach` does not accept `lastSpineHref`/`initialFinishedAt`.
+
+- [ ] **Step 3: Update `ProgressTracker.kt`**
+
+Replace the file content with:
+
+```kotlin
+package io.theficos.ereader.reader
+
+import io.theficos.ereader.core.model.Progress
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.Url
+
+class ProgressTracker(
+    private val save: suspend (Progress) -> Unit,
+    private val scope: CoroutineScope,
+    private val nowMs: () -> Long = System::currentTimeMillis,
+    private val debounceMs: Long = 1_000L,
+) {
+    private val pending = MutableStateFlow<Pending?>(null)
+    private var collectJob: Job? = null
+    private var debounceJob: Job? = null
+    private var documentId: Long = -1L
+    private var lastSpineHref: Url? = null
+    private var stickyFinishedAt: Long? = null
+
+    fun attach(
+        documentId: Long,
+        locatorUpdates: Flow<Locator>,
+        lastSpineHref: Url?,
+        initialFinishedAt: Long?,
+    ) {
+        this.documentId = documentId
+        this.lastSpineHref = lastSpineHref
+        this.stickyFinishedAt = initialFinishedAt
+        collectJob = scope.launch {
+            locatorUpdates.collect { locator ->
+                pending.value = Pending(locator, nowMs())
+                debounceJob?.cancel()
+                debounceJob = scope.launch {
+                    delay(debounceMs)
+                    flushOnce()
+                }
+            }
+        }
+    }
+
+    fun detach() {
+        debounceJob?.cancel()
+        runBlocking { flushOnce() }
+        collectJob?.cancel()
+    }
+
+    private suspend fun flushOnce() {
+        val p = pending.value ?: return
+        pending.value = null
+        val finishedAt = computeFinishedAt(p.locator, p.timestampMs)
+        stickyFinishedAt = finishedAt
+        save(Progress(
+            documentId = documentId,
+            locator = serialize(p.locator),
+            percent = (p.locator.locations.totalProgression
+                ?: p.locator.locations.progression
+                ?: 0.0).coerceIn(0.0, 1.0),
+            updatedAt = p.timestampMs,
+            finishedAt = finishedAt,
+        ))
+    }
+
+    private fun computeFinishedAt(locator: Locator, nowMs: Long): Long? {
+        stickyFinishedAt?.let { return it }
+        val total = locator.locations.totalProgression
+        if (total != null && total >= FINISHED_TOTAL_THRESHOLD) return nowMs
+        val prog = locator.locations.progression
+        val last = lastSpineHref
+        if (last != null && locator.href == last && prog != null && prog >= FINISHED_LAST_RESOURCE_THRESHOLD) {
+            return nowMs
+        }
+        return null
+    }
+
+    private data class Pending(val locator: Locator, val timestampMs: Long)
+
+    companion object {
+        private const val FINISHED_TOTAL_THRESHOLD = 0.98
+        private const val FINISHED_LAST_RESOURCE_THRESHOLD = 0.99
+
+        /** Encodes a Readium [Locator] as a JSON string for persistence and (Phase 2) sync. */
+        fun serialize(locator: Locator): String =
+            locator.toJSON().toString()
+
+        /**
+         * Returns a [Locator] reconstituted from a previously-[serialize]d string, or `null` if
+         * the input is the Phase 1 legacy format, malformed JSON, or otherwise un-parseable.
+         */
+        fun parseOrNull(raw: String): Locator? = try {
+            val json = JSONObject(raw)
+            // Legacy Phase 1 stub wrote {"href":..., "percent":...} — no "locations" object.
+            if (json.has("percent") && !json.has("locations")) null
+            else Locator.fromJSON(json)
+        } catch (_: Throwable) {
+            null
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+Run: `./gradlew :reader:testDebugUnitTest`
+Expected: all `ProgressTrackerTest` cases pass.
+
+---
+
+## Task 1.5 — Wire the new `attach` signature in `ReaderViewModel`
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt`
+
+- [ ] **Step 1: Update `load()` to read `lastSpineHref` and `initialFinishedAt`**
+
+Replace the `load()` body (and only the `load()` body) with:
+
+```kotlin
+    fun load() {
+        viewModelScope.launch {
+            val doc = docs.findById(documentId) ?: run {
+                _state.value = ReaderUiState.Error("Document not found")
+                return@launch
+            }
+            val publication = runCatching {
+                readium.open(EpubAsset(doc.id, File(doc.localPath), doc.title))
+            }.getOrElse {
+                _state.value = ReaderUiState.Error(it.message ?: "Failed to open book")
+                return@launch
+            }
+            val savedProgress = progress.get(doc.id)
+            val initialLocator = savedProgress?.locator?.let { ProgressTracker.parseOrNull(it) }
+            val lastSpineHref = publication.readingOrder.lastOrNull()?.href
+            _state.value = ReaderUiState.Open(doc, publication, initialLocator, savedProgress)
+            tracker.attach(
+                documentId = doc.id,
+                locatorUpdates = locatorUpdates,
+                lastSpineHref = lastSpineHref,
+                initialFinishedAt = savedProgress?.finishedAt,
+            )
+        }
+    }
+```
+
+- [ ] **Step 2: Build the app module to confirm it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+---
+
+## Task 1.6 — Add `finishedAt` to the sync DTOs
+
+**Files:**
+- Modify: `data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt`
+- Test: `data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ProgressDtosTest.kt`:
+
+```kotlin
+    @Test fun `push body round-trips finishedAt`() {
+        val body = ProgressPushBody(
+            items = listOf(
+                ProgressItemDto(
+                    document = DocumentIdDto(metadataId = "m1", contentHash = "h1"),
+                    locator = "loc",
+                    percent = 0.99,
+                    clientUpdatedAt = "2026-05-09T12:00:00+00:00",
+                    finishedAt = "2026-05-09T12:00:00+00:00",
+                )
+            )
+        )
+        val encoded = json.encodeToString(ProgressPushBody.serializer(), body)
+        assertThat(encoded).contains("\"finished_at\":\"2026-05-09T12:00:00+00:00\"")
+        val decoded = json.decodeFromString(ProgressPushBody.serializer(), encoded)
+        assertThat(decoded).isEqualTo(body)
+    }
+
+    @Test fun `null finishedAt is omitted on the wire`() {
+        val body = ProgressPushBody(
+            items = listOf(
+                ProgressItemDto(
+                    document = DocumentIdDto(metadataId = "m1", contentHash = "h1"),
+                    locator = "loc",
+                    percent = 0.5,
+                    clientUpdatedAt = "2026-05-09T12:00:00+00:00",
+                    finishedAt = null,
+                )
+            )
+        )
+        val encoded = json.encodeToString(ProgressPushBody.serializer(), body)
+        assertThat(encoded).doesNotContain("finished_at")
+    }
+
+    @Test fun `pull response decodes with optional finishedAt`() {
+        val raw = """{"items":[{"document":{"metadata_id":null,"content_hash":"h"},"locator":"l","percent":0.99,"client_updated_at":"2026-05-09T12:00:00+00:00","finished_at":"2026-05-09T12:00:00+00:00"}],"server_time":"2026-05-09T12:00:01+00:00"}"""
+        val r = json.decodeFromString(ProgressPullResponse.serializer(), raw)
+        assertThat(r.items.first().finishedAt).isEqualTo("2026-05-09T12:00:00+00:00")
+    }
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `./gradlew :data:sync:testDebugUnitTest`
+Expected: compile error — `ProgressItemDto` has no `finishedAt`.
+
+- [ ] **Step 3: Add the field to `ProgressItemDto`**
+
+Open `ProgressDtos.kt`. Replace the `ProgressItemDto` declaration with:
+
+```kotlin
+@Serializable
+data class ProgressItemDto(
+    val document: DocumentIdDto,
+    val locator: String,
+    val percent: Double,
+    @SerialName("client_updated_at") val clientUpdatedAt: String,
+    @SerialName("finished_at") val finishedAt: String? = null,
+)
+```
+
+`Json { ignoreUnknownKeys = true }` defaults to `encodeDefaults = false`, so a `null` `finishedAt` is omitted on the wire — keeping the request format backwards compatible with older servers.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `./gradlew :data:sync:testDebugUnitTest`
+Expected: all tests pass.
+
+---
+
+## Task 1.7 — Carry `finishedAt` through `SyncOrchestrator`
+
+**Files:**
+- Modify: `data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt`
+
+- [ ] **Step 1: Update push — include `finishedAt`**
+
+In the `runOnce()` push block, change the `ProgressItemDto(...)` construction to include `finishedAt`:
+
+```kotlin
+                ProgressItemDto(
+                    document = DocumentIdDto(metadataId = doc.identity.metadataId, contentHash = doc.identity.contentHash),
+                    locator = progress.locator,
+                    percent = progress.percent,
+                    clientUpdatedAt = Instant.ofEpochMilli(progress.updatedAt).toString(),
+                    finishedAt = progress.finishedAt?.let { Instant.ofEpochMilli(it).toString() },
+                )
+```
+
+- [ ] **Step 2: Update pull — persist `finishedAt`**
+
+Replace `applyPulled` in `SyncOrchestrator.kt` with:
+
+```kotlin
+    private suspend fun applyPulled(item: ProgressItemDto) {
+        val identity = DocumentIdentity(metadataId = item.document.metadataId, contentHash = item.document.contentHash)
+        val doc = documentRepo.findByIdentity(identity) ?: return
+        val incomingUpdatedAt = Instant.parse(item.clientUpdatedAt).toEpochMilli()
+        val incomingFinishedAt = item.finishedAt?.let { Instant.parse(it).toEpochMilli() }
+        val existing = progressDao.findByDocument(doc.id)
+        if (existing != null && existing.localUpdatedAt >= incomingUpdatedAt) {
+            return
+        }
+        progressDao.upsert(
+            ProgressEntity(
+                id = existing?.id ?: 0L,
+                documentId = doc.id,
+                locator = item.locator,
+                percent = item.percent,
+                updatedAt = incomingUpdatedAt,
+                localUpdatedAt = incomingUpdatedAt,
+                syncedAt = incomingUpdatedAt,
+                finishedAt = incomingFinishedAt,
+            )
+        )
+    }
+```
+
+- [ ] **Step 3: Build to confirm**
+
+Run: `./gradlew :data:sync:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+The existing `SyncOrchestratorTest` does not exercise `finishedAt` directly; round-trip is covered by `ProgressDtosTest` (Task 1.6) and the server tests (Task 1.10).
+
+---
+
+## Task 1.8 — Server: add `finished_at` column and SQLAlchemy mapping
+
+**Files:**
+- Modify: `server/opds_sync/db/models.py`
+- Create: `server/migrations/versions/0002_progress_finished_at.py`
+
+- [ ] **Step 1: Add `finished_at` to the SQLAlchemy model**
+
+Open `server/opds_sync/db/models.py`. Edit the `Progress` class to add the column directly after `percent`:
+
+```python
+class Progress(Base):
+    __tablename__ = "progress"
+    __table_args__ = (
+        CheckConstraint("percent >= 0 AND percent <= 1", name="ck_progress_percent_range"),
+        Index("ix_progress_document_client_updated_at", "document_pk", "client_updated_at"),
+    )
+
+    document_pk: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("documents.pk", ondelete="CASCADE"), primary_key=True
+    )
+    locator: Mapped[str] = mapped_column(String, nullable=False)
+    percent: Mapped[float] = mapped_column(Float, nullable=False)
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    client_updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    document: Mapped[Document] = relationship(back_populates="progress")
+```
+
+- [ ] **Step 2: Create the Alembic migration**
+
+Create `server/migrations/versions/0002_progress_finished_at.py`:
+
+```python
+"""progress: add nullable finished_at
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-09 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "progress",
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("progress", "finished_at")
+```
+
+- [ ] **Step 3: Verify the migration is picked up**
+
+Run: `cd server && uv run alembic heads` (or `alembic heads`).
+Expected: `0002 (head)`.
+
+- [ ] **Step 4: No commit yet** — Tasks 1.9 / 1.10 close out the phase.
+
+---
+
+## Task 1.9 — Server: thread `finished_at` through the API
+
+**Files:**
+- Modify: `server/opds_sync/api/progress.py`
+
+- [ ] **Step 1: Update Pydantic models and handlers**
+
+Replace the entire content of `server/opds_sync/api/progress.py` with:
+
+```python
+from datetime import UTC, datetime
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, field_serializer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opds_sync.core.auth import current_user_id
+from opds_sync.db.models import Document, Progress
+from opds_sync.db.session import get_session
+
+router = APIRouter(tags=["progress"])
+
+
+class DocumentIdentity(BaseModel):
+    metadata_id: str | None = None
+    content_hash: str
+
+
+class ProgressItem(BaseModel):
+    document: DocumentIdentity
+    locator: str
+    percent: float
+    client_updated_at: datetime
+    finished_at: datetime | None = None
+
+
+class ProgressPushBody(BaseModel):
+    items: list[ProgressItem]
+
+
+class ProgressPushResult(BaseModel):
+    document: DocumentIdentity
+    status: Literal["accepted", "stale"]
+    server_client_updated_at: datetime
+
+    @field_serializer("server_client_updated_at")
+    def _serialize_dt(self, v: datetime) -> str:
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=UTC)
+        return v.isoformat()
+
+
+class ProgressPushResponse(BaseModel):
+    results: list[ProgressPushResult]
+
+
+class ProgressPullItem(BaseModel):
+    document: DocumentIdentity
+    locator: str
+    percent: float
+    client_updated_at: datetime
+    finished_at: datetime | None = None
+
+
+class ProgressPullResponse(BaseModel):
+    items: list[ProgressPullItem]
+    server_time: datetime
+
+
+async def _resolve_or_create_document(
+    session: AsyncSession, user_id: str, ident: DocumentIdentity
+) -> Document:
+    """Per spec §5.4: metadata_id first, then content_hash, else create."""
+    if ident.metadata_id:
+        existing = (
+            await session.execute(
+                select(Document).where(
+                    Document.user_id == user_id, Document.metadata_id == ident.metadata_id
+                )
+            )
+        ).scalar_one_or_none()
+        if existing:
+            return existing
+    existing = (
+        await session.execute(
+            select(Document).where(
+                Document.user_id == user_id, Document.content_hash == ident.content_hash
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        if ident.metadata_id and existing.metadata_id is None:
+            existing.metadata_id = ident.metadata_id
+        return existing
+    doc = Document(user_id=user_id, metadata_id=ident.metadata_id, content_hash=ident.content_hash)
+    session.add(doc)
+    await session.flush()
+    return doc
+
+
+@router.post("/progress", response_model=ProgressPushResponse)
+async def push_progress(
+    body: ProgressPushBody,
+    user_id: Annotated[str, Depends(current_user_id)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ProgressPushResponse:
+    results: list[ProgressPushResult] = []
+    for item in body.items:
+        doc = await _resolve_or_create_document(session, user_id, item.document)
+        existing = (
+            await session.execute(select(Progress).where(Progress.document_pk == doc.pk))
+        ).scalar_one_or_none()
+        if existing is None:
+            session.add(
+                Progress(
+                    document_pk=doc.pk,
+                    locator=item.locator,
+                    percent=item.percent,
+                    client_updated_at=item.client_updated_at,
+                    finished_at=item.finished_at,
+                )
+            )
+            results.append(
+                ProgressPushResult(
+                    document=item.document,
+                    status="accepted",
+                    server_client_updated_at=item.client_updated_at,
+                )
+            )
+            continue
+        if item.client_updated_at > existing.client_updated_at:
+            existing.locator = item.locator
+            existing.percent = item.percent
+            existing.client_updated_at = item.client_updated_at
+            existing.finished_at = item.finished_at
+            results.append(
+                ProgressPushResult(
+                    document=item.document,
+                    status="accepted",
+                    server_client_updated_at=item.client_updated_at,
+                )
+            )
+        else:
+            results.append(
+                ProgressPushResult(
+                    document=item.document,
+                    status="stale",
+                    server_client_updated_at=existing.client_updated_at,
+                )
+            )
+    await session.commit()
+    return ProgressPushResponse(results=results)
+
+
+@router.get("/progress", response_model=ProgressPullResponse)
+async def pull_progress(
+    since: Annotated[str, Query()],
+    user_id: Annotated[str, Depends(current_user_id)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ProgressPullResponse:
+    since_dt = datetime.fromisoformat(since.replace(" ", "+"))
+    rows = (
+        await session.execute(
+            select(Progress, Document)
+            .join(Document, Document.pk == Progress.document_pk)
+            .where(Document.user_id == user_id, Progress.client_updated_at > since_dt)
+            .order_by(Progress.client_updated_at)
+        )
+    ).all()
+    items = [
+        ProgressPullItem(
+            document=DocumentIdentity(metadata_id=d.metadata_id, content_hash=d.content_hash),
+            locator=p.locator,
+            percent=p.percent,
+            client_updated_at=p.client_updated_at,
+            finished_at=p.finished_at,
+        )
+        for p, d in rows
+    ]
+    server_time = datetime.now().astimezone()
+    return ProgressPullResponse(items=items, server_time=server_time)
+```
+
+The two material changes are: `ProgressItem`/`ProgressPullItem` get `finished_at`, and the push handler stores/overwrites it on the `Progress` row.
+
+- [ ] **Step 2: Confirm the file compiles cleanly**
+
+Run: `cd server && uv run python -c "from opds_sync.api import progress as p; print(p.ProgressItem.model_json_schema())"`
+Expected: prints a JSON schema that includes `finished_at`.
+
+---
+
+## Task 1.10 — Server tests for `finished_at`
+
+**Files:**
+- Modify: `server/tests/integration/test_progress.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `server/tests/integration/test_progress.py`:
+
+```python
+async def test_post_progress_round_trips_finished_at(app_under_test):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic("alice", "alicepass")
+    body = {
+        "items": [
+            {
+                "document": {"metadata_id": "fa1", "content_hash": "fa1"},
+                "locator": "loc",
+                "percent": 0.99,
+                "client_updated_at": "2026-05-09T12:00:00+00:00",
+                "finished_at": "2026-05-09T12:00:00+00:00",
+            }
+        ]
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/sync/v1/progress", json=body, headers=headers)
+        assert r.status_code == 200, r.text
+        r2 = await c.get(
+            "/sync/v1/progress?since=2026-01-01T00:00:00+00:00", headers=headers
+        )
+    items = r2.json()["items"]
+    assert len(items) == 1
+    assert items[0]["finished_at"] == "2026-05-09T12:00:00+00:00"
+
+
+async def test_post_progress_omits_finished_at_when_absent(app_under_test):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic("alice", "alicepass")
+    body = {
+        "items": [
+            {
+                "document": {"metadata_id": "noFa", "content_hash": "noFa"},
+                "locator": "loc",
+                "percent": 0.5,
+                "client_updated_at": "2026-05-09T12:00:00+00:00",
+            }
+        ]
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/sync/v1/progress", json=body, headers=headers)
+        assert r.status_code == 200
+        r2 = await c.get(
+            "/sync/v1/progress?since=2026-01-01T00:00:00+00:00", headers=headers
+        )
+    items = r2.json()["items"]
+    pulled = next(i for i in items if i["document"]["content_hash"] == "noFa")
+    assert pulled["finished_at"] is None
+
+
+async def test_post_progress_lww_overwrites_finished_with_unfinished(app_under_test):
+    """Restart on a newer client must clear server-side finished_at."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic("alice", "alicepass")
+    base_doc = {"metadata_id": "lww", "content_hash": "lww"}
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # finished
+        await c.post(
+            "/sync/v1/progress",
+            json={
+                "items": [
+                    {
+                        "document": base_doc,
+                        "locator": "end",
+                        "percent": 0.99,
+                        "client_updated_at": "2026-05-09T12:00:00+00:00",
+                        "finished_at": "2026-05-09T12:00:00+00:00",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        # restart pushes newer unfinished
+        r = await c.post(
+            "/sync/v1/progress",
+            json={
+                "items": [
+                    {
+                        "document": base_doc,
+                        "locator": "",
+                        "percent": 0.0,
+                        "client_updated_at": "2026-05-09T13:00:00+00:00",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert r.status_code == 200
+        assert r.json()["results"][0]["status"] == "accepted"
+        r2 = await c.get(
+            "/sync/v1/progress?since=2026-01-01T00:00:00+00:00", headers=headers
+        )
+    items = [i for i in r2.json()["items"] if i["document"]["content_hash"] == "lww"]
+    assert len(items) == 1
+    assert items[0]["percent"] == 0.0
+    assert items[0]["finished_at"] is None
+```
+
+- [ ] **Step 2: Run server tests**
+
+Run: `cd server && uv run pytest tests/integration/test_progress.py -v`
+Expected: all tests pass, including the three new ones.
+
+If `app_under_test` is a session-scoped fixture that does not auto-run migrations, you may need to start with a fresh test DB. Verify by checking `conftest.py`; if fixture re-creates schema each session, no extra step is needed.
+
+---
+
+## Task 1.11 — Phase 1 commit
+
+- [ ] **Step 1: Run the full Android test suite**
+
+Run: `./gradlew test`
+Expected: BUILD SUCCESSFUL with all module tests green.
+
+- [ ] **Step 2: Run the full server test suite**
+
+Run: `cd server && uv run pytest -v`
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/model data/local data/sync reader app server/opds_sync server/migrations server/tests data/local/schemas
+git status   # confirm only intended paths
+git commit -m "$(cat <<'EOF'
+:bug: fix(reader): track finished books and stop the 99% Continue Reading loop
+
+Adds a nullable finishedAt timestamp to Progress, persisted through Room
+(v3->v4 migration), the sync DTOs, and the Postgres schema (Alembic 0002).
+ProgressTracker stamps finishedAt when totalProgression crosses 0.98 or
+when at the last spine resource with progression >= 0.99; the value is
+sticky once set and is cleared by Restart. LibraryViewModel will switch
+its Continue Reading filter in phase 4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Confirm the commit is on `feat/reader-library-pack`.
+
+---
+
+# Phase 2 — Keep screen on
+
+Files touched:
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt`
+
+---
+
+## Task 2.1 — Add `FLAG_KEEP_SCREEN_ON` for the reader
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt`
+
+- [ ] **Step 1: Add the imports and effect**
+
+In `ReaderScreen.kt`, add these imports next to the existing ones:
+
+```kotlin
+import android.app.Activity
+import android.view.WindowManager
+```
+
+Inside the `ReaderScreen` composable, immediately before the existing `LaunchedEffect(Unit) { viewModel.load() }`, insert:
+
+```kotlin
+    val activity = LocalContext.current as Activity
+    DisposableEffect(activity) {
+        activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            activity.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+```
+
+- [ ] **Step 2: Build the app**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Sanity check by hand on a device or emulator**
+
+Run the app, open a book, leave the device idle for ~30 s, and confirm the screen does not dim. Navigate back to Library and confirm the system timeout resumes.
+
+(Skip this step if running unattended — record "verified by hand" in the PR description before merge.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
+git commit -m "$(cat <<'EOF'
+:sparkles: feat(reader): keep screen on while reading
+
+ReaderScreen sets FLAG_KEEP_SCREEN_ON on enter and clears it on dispose,
+scoped to its composition so leaving the reader restores the system
+timeout.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 3 — Tap zones and reader-side toggle
+
+Files touched:
+- Modify: `reader/src/main/java/io/theficos/ereader/reader/ReaderPreferences.kt`
+- Modify: `reader/src/main/java/io/theficos/ereader/reader/ReaderPreferencesStore.kt`
+- Create: `reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt`
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt`
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt`
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt`
+
+---
+
+## Task 3.1 — Add `tapNavigationEnabled` to `ReaderPreferences`
+
+**Files:**
+- Modify: `reader/src/main/java/io/theficos/ereader/reader/ReaderPreferences.kt`
+- Modify: `reader/src/main/java/io/theficos/ereader/reader/ReaderPreferencesStore.kt`
+- Create: `reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt`:
+
+```kotlin
+package io.theficos.ereader.reader
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ReaderPreferencesStoreTest {
+
+    private fun freshStore() = ReaderPreferencesStore(ApplicationProvider.getApplicationContext()).also {
+        it.update { ReaderPreferences() }
+    }
+
+    @Test fun `default tapNavigationEnabled is true`() {
+        val store = freshStore()
+        assertThat(store.flow.value.tapNavigationEnabled).isTrue()
+    }
+
+    @Test fun `tapNavigationEnabled round-trips through update and reload`() {
+        val store1 = freshStore()
+        store1.update { it.copy(tapNavigationEnabled = false) }
+        assertThat(store1.flow.value.tapNavigationEnabled).isFalse()
+
+        val store2 = ReaderPreferencesStore(ApplicationProvider.getApplicationContext())
+        assertThat(store2.flow.value.tapNavigationEnabled).isFalse()
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `./gradlew :reader:testDebugUnitTest --tests "io.theficos.ereader.reader.ReaderPreferencesStoreTest"`
+Expected: compile error — `tapNavigationEnabled` is not a property of `ReaderPreferences`.
+
+- [ ] **Step 3: Add the property to `ReaderPreferences`**
+
+In `ReaderPreferences.kt`, replace the `data class ReaderPreferences(...)` block with:
+
+```kotlin
+data class ReaderPreferences(
+    val fontScale: Double = 1.0,
+    val theme: ReaderTheme = ReaderTheme.LIGHT,
+    val fontFamily: ReaderFontFamily = ReaderFontFamily.SYSTEM,
+    val lineSpacing: Double = 1.4,
+    val tapNavigationEnabled: Boolean = true,
+) {
+    init {
+        require(fontScale in 0.5..2.0) { "fontScale out of range: $fontScale" }
+        require(lineSpacing in 1.0..1.8) { "lineSpacing out of range: $lineSpacing" }
+    }
+}
+```
+
+- [ ] **Step 4: Persist it in `ReaderPreferencesStore`**
+
+In `ReaderPreferencesStore.kt`:
+
+1. Add a new key constant inside the `companion object`:
+
+```kotlin
+        const val KEY_TAP_NAVIGATION = "tap_navigation_enabled"
+```
+
+2. Replace the `update` body with:
+
+```kotlin
+    fun update(transform: (ReaderPreferences) -> ReaderPreferences) {
+        val next = transform(_flow.value)
+        prefs.edit()
+            .putFloat(KEY_FONT_SCALE, next.fontScale.toFloat())
+            .putString(KEY_THEME, next.theme.name)
+            .putString(KEY_FONT_FAMILY, next.fontFamily.name)
+            .putFloat(KEY_LINE_SPACING, next.lineSpacing.toFloat())
+            .putBoolean(KEY_TAP_NAVIGATION, next.tapNavigationEnabled)
+            .apply()
+        _flow.value = next
+    }
+```
+
+3. Replace the `load()` body with:
+
+```kotlin
+    private fun load(): ReaderPreferences {
+        val fontScale = prefs.getFloat(KEY_FONT_SCALE, 1.0f).toDouble().coerceIn(0.5, 2.0)
+        val themeName = prefs.getString(KEY_THEME, ReaderTheme.LIGHT.name) ?: ReaderTheme.LIGHT.name
+        val theme = runCatching { ReaderTheme.valueOf(themeName) }.getOrDefault(ReaderTheme.LIGHT)
+        val familyName = prefs.getString(KEY_FONT_FAMILY, ReaderFontFamily.SYSTEM.name)
+            ?: ReaderFontFamily.SYSTEM.name
+        val family = runCatching { ReaderFontFamily.valueOf(familyName) }
+            .getOrDefault(ReaderFontFamily.SYSTEM)
+        val lineSpacing = prefs.getFloat(KEY_LINE_SPACING, 1.4f).toDouble().coerceIn(1.0, 1.8)
+        val tap = prefs.getBoolean(KEY_TAP_NAVIGATION, true)
+        return ReaderPreferences(
+            fontScale = fontScale,
+            theme = theme,
+            fontFamily = family,
+            lineSpacing = lineSpacing,
+            tapNavigationEnabled = tap,
+        )
+    }
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `./gradlew :reader:testDebugUnitTest`
+Expected: all tests pass.
+
+---
+
+## Task 3.2 — Lift the navigator fragment ref into `ReaderViewModel`
+
+The `EpubNavigatorFragment` is currently local to `ReaderContent`. We move the reference up so `ReaderViewModel` can issue `goForward` / `goBackward` from tap callbacks.
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt`
+
+- [ ] **Step 1: Add navigator fields and page commands**
+
+In `ReaderViewModel.kt`, add these imports next to the existing ones:
+
+```kotlin
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+```
+
+Inside the `ReaderViewModel` class, after the `tracker` field, add:
+
+```kotlin
+    private var navigator: EpubNavigatorFragment? = null
+
+    fun bindNavigator(nav: EpubNavigatorFragment?) {
+        navigator = nav
+    }
+
+    fun pageForward() {
+        viewModelScope.launch { navigator?.goForward() }
+    }
+
+    fun pageBackward() {
+        viewModelScope.launch { navigator?.goBackward() }
+    }
+```
+
+- [ ] **Step 2: Build to confirm**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. The methods are unused at this step; they get wired in Task 3.3.
+
+---
+
+## Task 3.3 — Add tap zones to `ReaderScreen` and bind the navigator
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt`
+
+- [ ] **Step 1: Bind the navigator and add left/right zones**
+
+In `ReaderScreen.kt`:
+
+1. Find `ReaderContent(...)` inside the `is ReaderUiState.Open` branch. Replace the call with one that passes a callback up to bind the navigator (full call shown below):
+
+```kotlin
+                ReaderContent(
+                    publication = s.publication,
+                    initialLocator = s.initialLocator,
+                    preferences = preferences,
+                    onLocator = viewModel::publishLocator,
+                    onNavigatorReady = viewModel::bindNavigator,
+                )
+```
+
+2. Replace the existing `Box(modifier = Modifier.align(Alignment.Center).fillMaxHeight().fillMaxWidth(0.34f).pointerInput(Unit) { detectTapGestures(onTap = { viewModel.toggleChrome() }) })` block with a `Row` that hosts three zones, gated by the preference:
+
+```kotlin
+                if (preferences.tapNavigationEnabled) {
+                    Row(modifier = Modifier.fillMaxSize()) {
+                        Box(
+                            modifier = Modifier
+                                .weight(0.33f)
+                                .fillMaxHeight()
+                                .pointerInput(Unit) {
+                                    detectTapGestures(onTap = { viewModel.pageBackward() })
+                                }
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(0.34f)
+                                .fillMaxHeight()
+                                .pointerInput(Unit) {
+                                    detectTapGestures(onTap = { viewModel.toggleChrome() })
+                                }
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(0.33f)
+                                .fillMaxHeight()
+                                .pointerInput(Unit) {
+                                    detectTapGestures(onTap = { viewModel.pageForward() })
+                                }
+                        )
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .fillMaxHeight()
+                            .fillMaxWidth(0.34f)
+                            .pointerInput(Unit) {
+                                detectTapGestures(onTap = { viewModel.toggleChrome() })
+                            }
+                    )
+                }
+```
+
+3. Add `import androidx.compose.foundation.layout.Row` to the imports.
+
+- [ ] **Step 2: Update `ReaderContent` to surface the navigator**
+
+Replace the entire `ReaderContent` composable in `ReaderScreen.kt` with:
+
+```kotlin
+@Composable
+private fun ReaderContent(
+    publication: Publication,
+    initialLocator: Locator?,
+    preferences: ReaderPreferences,
+    onLocator: (Locator) -> Unit,
+    onNavigatorReady: (EpubNavigatorFragment?) -> Unit,
+) {
+    val activity = LocalContext.current as FragmentActivity
+    val containerId = rememberSaveable { View.generateViewId() }
+    val tag = "reader-${publication.metadata.identifier ?: containerId}"
+    var fragment by remember { mutableStateOf<EpubNavigatorFragment?>(null) }
+
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { ctx ->
+            FragmentContainerView(ctx).apply {
+                id = containerId
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+        },
+    )
+
+    DisposableEffect(publication) {
+        val fm = activity.supportFragmentManager
+        val factory = EpubNavigatorFactory(publication)
+        fm.fragmentFactory = factory.createFragmentFactory(
+            initialLocator = initialLocator,
+            initialPreferences = preferences.toEpubPreferences(),
+        )
+        val nav = (fm.fragmentFactory.instantiate(
+            activity.classLoader,
+            EpubNavigatorFragment::class.java.name,
+        ) as EpubNavigatorFragment)
+        fm.beginTransaction()
+            .replace(containerId, nav, tag)
+            .commitNow()
+        fragment = nav
+        onNavigatorReady(nav)
+
+        val job = activity.lifecycleScope.launch {
+            nav.currentLocator.collect { onLocator(it) }
+        }
+
+        onDispose {
+            job.cancel()
+            fragment = null
+            onNavigatorReady(null)
+            fm.beginTransaction()
+                .remove(nav)
+                .commitNowAllowingStateLoss()
+        }
+    }
+
+    LaunchedEffect(preferences) {
+        fragment?.submitPreferences(preferences.toEpubPreferences())
+    }
+}
+```
+
+- [ ] **Step 3: Build the app**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Sanity check by hand**
+
+Open a book. Tap on the right third — page advances. Tap on the left third — page goes back. Tap center — chrome toggles. Try at the very first page (back tap is a no-op) and very last page (forward tap is a no-op).
+
+---
+
+## Task 3.4 — Add the toggle row to `FontSettingsSheet`
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt`
+
+- [ ] **Step 1: Inspect the existing sheet**
+
+Run: `cat app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt`
+
+Identify where preferences are mutated (look for an `onChange(prefs.copy(...))` pattern). The new row mirrors that style.
+
+- [ ] **Step 2: Add the toggle row**
+
+At the bottom of the sheet content (before the final closing brace of the `Column` that holds the existing controls), add:
+
+```kotlin
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Tap to turn pages", style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        "Tap left or right edges to flip pages",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = prefs.tapNavigationEnabled,
+                    onCheckedChange = { onChange(prefs.copy(tapNavigationEnabled = it)) },
+                )
+            }
+```
+
+Add these imports next to the existing ones:
+
+```kotlin
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Switch
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+```
+
+If any of those are already imported, skip them — duplicates fail to compile.
+
+- [ ] **Step 3: Build to confirm**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Sanity check**
+
+Open the font sheet from the reader, toggle "Tap to turn pages" off, and verify left/right tap zones become passive (only center toggles chrome). Toggle on, verify they reactivate. Restart the app, verify the preference persisted.
+
+- [ ] **Step 5: Commit phase 3**
+
+```bash
+git add reader/src/main/java/io/theficos/ereader/reader app/src/main/java/io/theficos/ereader/ui/reader reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt
+git status
+git commit -m "$(cat <<'EOF'
+:sparkles: feat(reader): tap left/right to turn pages (toggleable)
+
+Three full-height tap zones over the navigator: left previous, center
+chrome (existing), right next. The navigator fragment ref is lifted
+into ReaderViewModel so taps drive goForward/goBackward. A new
+ReaderPreferences.tapNavigationEnabled flag (default on) gates the
+behaviour and lives next to the font controls in FontSettingsSheet.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 4 — Library sort + finished badge
+
+Files touched:
+- Create: `app/src/main/java/io/theficos/ereader/ui/library/LibrarySort.kt`
+- Create: `app/src/main/java/io/theficos/ereader/ui/library/LibraryPreferencesStore.kt`
+- Create: `app/src/test/java/io/theficos/ereader/ui/library/LibraryPreferencesStoreTest.kt`
+- Modify: `app/src/main/java/io/theficos/ereader/di/AppContainer.kt`
+- Modify: `app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt`
+- Modify: `app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt`
+- Modify: `app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt`
+
+---
+
+## Task 4.1 — Define `LibrarySort` and `LibraryPreferencesStore`
+
+**Files:**
+- Create: `app/src/main/java/io/theficos/ereader/ui/library/LibrarySort.kt`
+- Create: `app/src/main/java/io/theficos/ereader/ui/library/LibraryPreferencesStore.kt`
+- Create: `app/src/test/java/io/theficos/ereader/ui/library/LibraryPreferencesStoreTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/io/theficos/ereader/ui/library/LibraryPreferencesStoreTest.kt`:
+
+```kotlin
+package io.theficos.ereader.ui.library
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class LibraryPreferencesStoreTest {
+
+    private fun fresh() = LibraryPreferencesStore(ApplicationProvider.getApplicationContext()).also {
+        it.update(LibrarySort.RECENTLY_READ)
+    }
+
+    @Test fun `default sort is RECENTLY_READ`() {
+        val store = fresh()
+        assertThat(store.flow.value).isEqualTo(LibrarySort.RECENTLY_READ)
+    }
+
+    @Test fun `sort round-trips through update and reload`() {
+        val store1 = fresh()
+        store1.update(LibrarySort.AUTHOR)
+        assertThat(store1.flow.value).isEqualTo(LibrarySort.AUTHOR)
+
+        val store2 = LibraryPreferencesStore(ApplicationProvider.getApplicationContext())
+        assertThat(store2.flow.value).isEqualTo(LibrarySort.AUTHOR)
+    }
+
+    @Test fun `unknown stored value falls back to default`() {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        ctx.getSharedPreferences("library_prefs", android.content.Context.MODE_PRIVATE)
+            .edit().putString("library_sort", "NONSENSE").apply()
+        val store = LibraryPreferencesStore(ctx)
+        assertThat(store.flow.value).isEqualTo(LibrarySort.RECENTLY_READ)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "io.theficos.ereader.ui.library.LibraryPreferencesStoreTest"`
+Expected: compile error — `LibrarySort` and `LibraryPreferencesStore` do not exist.
+
+- [ ] **Step 3: Create `LibrarySort.kt`**
+
+```kotlin
+package io.theficos.ereader.ui.library
+
+enum class LibrarySort { RECENTLY_READ, RECENTLY_ADDED, TITLE, AUTHOR }
+```
+
+- [ ] **Step 4: Create `LibraryPreferencesStore.kt`**
+
+```kotlin
+package io.theficos.ereader.ui.library
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class LibraryPreferencesStore(context: Context) {
+    private val prefs = context.applicationContext
+        .getSharedPreferences("library_prefs", Context.MODE_PRIVATE)
+
+    private val _flow = MutableStateFlow(load())
+    val flow: StateFlow<LibrarySort> = _flow.asStateFlow()
+
+    fun update(sort: LibrarySort) {
+        prefs.edit().putString(KEY_SORT, sort.name).apply()
+        _flow.value = sort
+    }
+
+    private fun load(): LibrarySort {
+        val raw = prefs.getString(KEY_SORT, LibrarySort.RECENTLY_READ.name)
+            ?: LibrarySort.RECENTLY_READ.name
+        return runCatching { LibrarySort.valueOf(raw) }.getOrDefault(LibrarySort.RECENTLY_READ)
+    }
+
+    private companion object {
+        const val KEY_SORT = "library_sort"
+    }
+}
+```
+
+- [ ] **Step 5: Run the test and confirm it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "io.theficos.ereader.ui.library.LibraryPreferencesStoreTest"`
+Expected: PASS.
+
+---
+
+## Task 4.2 — Wire `LibraryPreferencesStore` into the DI container
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/di/AppContainer.kt`
+
+- [ ] **Step 1: Add the field**
+
+Add this import:
+
+```kotlin
+import io.theficos.ereader.ui.library.LibraryPreferencesStore
+```
+
+…and add this field next to `readerPreferencesStore`:
+
+```kotlin
+    val libraryPreferencesStore = LibraryPreferencesStore(appContext)
+```
+
+- [ ] **Step 2: Build to confirm**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+(The store is wired into `LibraryViewModel` at the call site in MainActivity / NavGraph / wherever the VM is instantiated — covered in Task 4.4 along with the UI work, after the VM signature changes.)
+
+---
+
+## Task 4.3 — Sort, finished filter, and `finishedAt` exposure in `LibraryViewModel`
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt`
+- Modify: `app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `LibraryViewModelTest.kt` (note: the existing setUp does **not** pass `LibraryPreferencesStore` yet — the new constructor parameter from Step 3 below is what causes the existing tests to also need updating; do that in this step):
+
+First, change the existing setUp's `LibraryViewModel(...)` construction to pass a `LibraryPreferencesStore`:
+
+```kotlin
+        vm = LibraryViewModel(
+            docs = docs,
+            progress = progress,
+            syncOrchestrator = orchestrator,
+            booksDir = File("/dev/null"),
+            libraryPreferencesStore = LibraryPreferencesStore(ApplicationProvider.getApplicationContext()),
+            nowMillis = { 999L },
+        )
+```
+
+…and add this import at the top of the file:
+
+```kotlin
+import io.theficos.ereader.core.model.Progress as DomainProgress
+```
+
+Then append these tests:
+
+```kotlin
+    private suspend fun seed(
+        contentHash: String, title: String, author: String?,
+        percent: Double = 0.0, updatedAt: Long = 0L, finishedAt: Long? = null,
+    ): Long {
+        val docId = db.documentDao().insert(DocumentEntity(
+            metadataId = contentHash, contentHash = contentHash, title = title, author = author,
+            downloadUrl = "u", localPath = "p", coverPath = null, downloadedAt = 0,
+        ))
+        if (percent > 0.0 || finishedAt != null) {
+            progress.save(DomainProgress(
+                documentId = docId, locator = "loc", percent = percent,
+                updatedAt = updatedAt, finishedAt = finishedAt,
+            ))
+        }
+        return docId
+    }
+
+    @Test fun `default sort is RECENTLY_READ ordering by progressUpdatedAt desc`() = runTest {
+        seed("h1", "Alpha", "Auth", percent = 0.2, updatedAt = 100L)
+        seed("h2", "Bravo", "Auth", percent = 0.4, updatedAt = 300L)
+        seed("h3", "Charlie", "Auth", percent = 0.1, updatedAt = 200L)
+        vm.items.test {
+            val list = awaitItem().filter { it.document.title in setOf("Alpha", "Bravo", "Charlie") }
+            // Skip empty initial emission if any
+            val final = if (list.isEmpty()) awaitItem() else list
+            assertThat(final.map { it.document.title }).containsExactly("Bravo", "Charlie", "Alpha").inOrder()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `TITLE sort orders alphabetically`() = runTest {
+        seed("h1", "Charlie", null)
+        seed("h2", "Alpha", null)
+        seed("h3", "Bravo", null)
+        vm.setSort(LibrarySort.TITLE)
+        vm.items.test {
+            val final = awaitItem().also { if (it.size < 3) awaitItem() }
+            val titles = final.map { it.document.title }
+            assertThat(titles).containsExactly("Alpha", "Bravo", "Charlie").inOrder()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `finished books are excluded from continueReading`() = runTest {
+        seed("h1", "InProgress", null, percent = 0.5, updatedAt = 100L)
+        seed("h2", "Finished", null, percent = 0.99, updatedAt = 200L, finishedAt = 200L)
+        vm.continueReading.test {
+            // skip nulls until we get a value or stable null
+            var emission = awaitItem()
+            // Wait one more tick if needed
+            if (emission?.document?.title != "InProgress") emission = awaitItem()
+            assertThat(emission?.document?.title).isEqualTo("InProgress")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "io.theficos.ereader.ui.library.LibraryViewModelTest"`
+Expected: compile error — `LibraryViewModel` does not accept `libraryPreferencesStore`, and there is no `setSort` method.
+
+- [ ] **Step 3: Update `LibraryViewModel`**
+
+Replace the entire content of `LibraryViewModel.kt` with:
+
+```kotlin
+package io.theficos.ereader.ui.library
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.theficos.ereader.core.model.Document
+import io.theficos.ereader.data.local.DocumentRepository
+import io.theficos.ereader.data.local.ProgressRepository
+import io.theficos.ereader.data.sync.SyncEnqueuer
+import io.theficos.ereader.data.sync.SyncOrchestrator
+import io.theficos.ereader.data.sync.SyncResult
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.io.File
+
+sealed interface LibraryEvent {
+    data object RestartFailed : LibraryEvent
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryViewModel(
+    private val docs: DocumentRepository,
+    private val progress: ProgressRepository,
+    private val syncOrchestrator: SyncOrchestrator,
+    private val booksDir: File,
+    private val libraryPreferencesStore: LibraryPreferencesStore,
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+    private val syncEnqueuer: (Context) -> Unit = { SyncEnqueuer.enqueue(it, expedited = true, replaceExisting = true) },
+) : ViewModel() {
+
+    val sort: StateFlow<LibrarySort> = libraryPreferencesStore.flow
+
+    fun setSort(next: LibrarySort) = libraryPreferencesStore.update(next)
+
+    private val rows: StateFlow<List<LibraryRow>> =
+        docs.observeLibrary()
+            .flatMapLatest { docList ->
+                if (docList.isEmpty()) flowOf(emptyList())
+                else combine(docList.map { d -> progress.observe(d.id).map { d to it } }) { it.toList() }
+            }
+            .map { pairs ->
+                pairs.map { (d, p) ->
+                    LibraryRow(
+                        document = d,
+                        percent = p?.percent ?: 0.0,
+                        progressUpdatedAt = p?.updatedAt ?: 0L,
+                        finishedAt = p?.finishedAt,
+                    )
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val items: StateFlow<List<LibraryRow>> = combine(rows, sort) { list, by ->
+        applySort(list, by)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val continueReading: StateFlow<LibraryRow?> = rows
+        .map { list ->
+            list
+                .filter { it.percent > 0.0001 && it.finishedAt == null }
+                .maxByOrNull { it.progressUpdatedAt }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    private val _events = MutableSharedFlow<LibraryEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<LibraryEvent> = _events.asSharedFlow()
+
+    fun delete(document: Document) {
+        viewModelScope.launch { docs.delete(document) }
+    }
+
+    suspend fun restart(document: Document, alsoDeleteFile: Boolean): Boolean {
+        progress.resetForDocument(document.id, now = nowMillis())
+        val pushed = syncOrchestrator.runOnce()
+        return when (pushed) {
+            is SyncResult.Success -> {
+                if (alsoDeleteFile) docs.delete(document)
+                true
+            }
+            else -> {
+                _events.tryEmit(LibraryEvent.RestartFailed)
+                false
+            }
+        }
+    }
+
+    fun restartFromUi(document: Document, alsoDeleteFile: Boolean, context: Context) {
+        viewModelScope.launch {
+            if (!restart(document, alsoDeleteFile)) {
+                syncEnqueuer(context)
+            }
+        }
+    }
+
+    private fun applySort(list: List<LibraryRow>, by: LibrarySort): List<LibraryRow> = when (by) {
+        LibrarySort.RECENTLY_READ -> list.sortedWith(
+            compareByDescending<LibraryRow> { it.progressUpdatedAt }
+                .thenBy { it.document.title.lowercase() }
+        )
+        LibrarySort.RECENTLY_ADDED -> list.sortedByDescending { it.document.id }
+        LibrarySort.TITLE -> list.sortedBy { it.document.title.lowercase() }
+        LibrarySort.AUTHOR -> list.sortedWith(
+            compareBy<LibraryRow> { it.document.author?.lowercase() ?: "￿" }
+                .thenBy { it.document.title.lowercase() }
+        )
+    }
+}
+
+data class LibraryRow(
+    val document: Document,
+    val percent: Double,
+    val progressUpdatedAt: Long,
+    val finishedAt: Long? = null,
+)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `./gradlew :app:testDebugUnitTest`
+Expected: all `LibraryViewModelTest` cases pass.
+
+---
+
+## Task 4.4 — UI: sort dropdown, finished badge, VM construction at the call site
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt`
+- Modify: wherever `LibraryViewModel` is constructed (search and update)
+
+- [ ] **Step 1: Find where the VM is constructed**
+
+Run: `grep -rn "LibraryViewModel(" app/src/main 2>/dev/null`
+Expected: at least one call site outside of tests. It's likely in a `MainActivity.kt` or `NavGraph.kt`. Open that file.
+
+- [ ] **Step 2: Pass the new dependency**
+
+Add the constructor argument:
+
+```kotlin
+                libraryPreferencesStore = container.libraryPreferencesStore,
+```
+
+…where `container` is the existing `AppContainer` reference at that call site (the variable name may differ — match the local scope).
+
+- [ ] **Step 3: Build to confirm**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Add the sort row to `LibraryScreen.kt`**
+
+In `LibraryScreen.kt`:
+
+1. Add these imports:
+
+```kotlin
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.shape.CircleShape
+```
+
+2. Replace the `item(span = { GridItemSpan(maxLineSpan) }) { Text(text = "Quire", ... ) }` block with this header item that hosts the title + sort dropdown:
+
+```kotlin
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Quire",
+                        style = MaterialTheme.typography.displaySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
+                    var sortMenuOpen by remember { mutableStateOf(false) }
+                    val currentSort by viewModel.sort.collectAsState()
+                    Box {
+                        IconButton(onClick = { sortMenuOpen = true }) {
+                            Icon(Icons.Filled.Sort, contentDescription = "Sort")
+                        }
+                        DropdownMenu(
+                            expanded = sortMenuOpen,
+                            onDismissRequest = { sortMenuOpen = false },
+                        ) {
+                            sortLabels.forEach { (key, label) ->
+                                DropdownMenuItem(
+                                    text = { Text(label) },
+                                    leadingIcon = if (currentSort == key) {
+                                        { Icon(Icons.Filled.Check, contentDescription = null) }
+                                    } else null,
+                                    onClick = {
+                                        viewModel.setSort(key)
+                                        sortMenuOpen = false
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+```
+
+3. At the file-level (outside any composable, near the top), add the sort labels list:
+
+```kotlin
+private val sortLabels: List<Pair<LibrarySort, String>> = listOf(
+    LibrarySort.RECENTLY_READ to "Recently read",
+    LibrarySort.RECENTLY_ADDED to "Recently added",
+    LibrarySort.TITLE to "Title",
+    LibrarySort.AUTHOR to "Author",
+)
+```
+
+…and import `LibrarySort` if not already imported:
+
+```kotlin
+import io.theficos.ereader.ui.library.LibrarySort
+```
+
+4. Add the finished badge to each book cell. Find the `Column { CoverImage(...) Text(...) }` rendering the book cell. Wrap the `CoverImage` in a `Box` and overlay the badge when `row.finishedAt != null`:
+
+```kotlin
+                Column(
+                    modifier = Modifier.combinedClickable(
+                        onClick = { onOpenBook(row.document.id) },
+                        onLongClick = { menuFor = row.document },
+                    ),
+                ) {
+                    Box(modifier = Modifier.fillMaxWidth()) {
+                        CoverImage(
+                            source = row.document.coverPath,
+                            title = row.document.title,
+                            author = row.document.author,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(2f / 3f),
+                        )
+                        if (row.finishedAt != null) {
+                            Surface(
+                                shape = CircleShape,
+                                color = MaterialTheme.colorScheme.tertiaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .padding(6.dp)
+                                    .size(24.dp),
+                            ) {
+                                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                                    Icon(
+                                        imageVector = Icons.Filled.Check,
+                                        contentDescription = "Finished",
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    Text(
+                        text = row.document.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
+                }
+```
+
+- [ ] **Step 5: Build and sanity check**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+By hand: open the Library, tap the Sort icon, switch sort orders, confirm grid order changes. Finish a book (or seed a `finishedAt` via the reader); confirm the checkmark badge appears on its cover and it leaves Continue Reading.
+
+- [ ] **Step 6: Commit phase 4**
+
+```bash
+git add app/src/main/java/io/theficos/ereader/ui/library app/src/test/java/io/theficos/ereader/ui/library app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+# Also add the call site that constructs LibraryViewModel
+git add $(grep -rl "LibraryViewModel(" app/src/main | tr '\n' ' ')
+git status
+git commit -m "$(cat <<'EOF'
+:sparkles: feat(library): sort options and finished badge
+
+LibrarySort (Recently read / Recently added / Title / Author) persists
+through a new sibling LibraryPreferencesStore; sort applies in-memory
+inside LibraryViewModel. LibraryRow now exposes finishedAt; book cells
+render a small checkmark badge on finished covers and Continue Reading
+filters out finished books — the user-visible payoff of phase 1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 5 — Library search
+
+Files touched:
+- Modify: `app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt`
+- Modify: `app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt`
+- Modify: `app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt`
+
+---
+
+## Task 5.1 — Add `query` state and filtering to `LibraryViewModel`
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt`
+- Modify: `app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `LibraryViewModelTest.kt`:
+
+```kotlin
+    @Test fun `query filters by title case-insensitively`() = runTest {
+        seed("h1", "Alpha", "Auth")
+        seed("h2", "BRAVO", "Auth")
+        seed("h3", "Charlie", "Auth")
+        vm.setSort(LibrarySort.TITLE)
+        vm.setQuery("bra")
+        vm.items.test {
+            val final = awaitItem().also { if (it.size != 1) awaitItem() }
+            assertThat(final.map { it.document.title }).containsExactly("BRAVO")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `query filters by author`() = runTest {
+        seed("h1", "Alpha", "King")
+        seed("h2", "Bravo", "Tolkien")
+        vm.setSort(LibrarySort.TITLE)
+        vm.setQuery("tolk")
+        vm.items.test {
+            val final = awaitItem().also { if (it.size != 1) awaitItem() }
+            assertThat(final.map { it.document.title }).containsExactly("Bravo")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `clearing query restores full list`() = runTest {
+        seed("h1", "Alpha", null)
+        seed("h2", "Bravo", null)
+        vm.setSort(LibrarySort.TITLE)
+        vm.setQuery("alpha")
+        // wait for filter to apply
+        vm.items.test {
+            awaitItem()
+            vm.setQuery("")
+            val final = awaitItem().also { if (it.size != 2) awaitItem() }
+            assertThat(final).hasSize(2)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "io.theficos.ereader.ui.library.LibraryViewModelTest"`
+Expected: compile error — `setQuery` does not exist.
+
+- [ ] **Step 3: Add the query state and filter pipeline**
+
+Open `LibraryViewModel.kt`. Make these targeted edits:
+
+1. Add the new state field after `sort`:
+
+```kotlin
+    private val _query = kotlinx.coroutines.flow.MutableStateFlow("")
+    val query: StateFlow<String> = _query
+
+    fun setQuery(next: String) { _query.value = next }
+```
+
+2. Replace the `items` declaration with a three-way combine:
+
+```kotlin
+    val items: StateFlow<List<LibraryRow>> = combine(rows, sort, _query) { list, by, q ->
+        val sorted = applySort(list, by)
+        if (q.isBlank()) sorted else {
+            val needle = q.trim().lowercase()
+            sorted.filter { row ->
+                row.document.title.lowercase().contains(needle) ||
+                    (row.document.author?.lowercase()?.contains(needle) == true)
+            }
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+```
+
+`continueReading` is intentionally **not** filtered by `_query` (per spec).
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "io.theficos.ereader.ui.library.LibraryViewModelTest"`
+Expected: all tests pass.
+
+---
+
+## Task 5.2 — Add the search field to `LibraryScreen`
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt`
+
+- [ ] **Step 1: Add the search button and inline field**
+
+In `LibraryScreen.kt`:
+
+1. Add these imports:
+
+```kotlin
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.foundation.text.KeyboardOptions
+```
+
+2. In `LibraryScreen`, add a remembered "search active" flag near the existing `var menuFor by remember ...`:
+
+```kotlin
+    var searchActive by remember { mutableStateOf(false) }
+    val query by viewModel.query.collectAsState()
+```
+
+3. In the header `Row` from Task 4.4, add a Search icon button right before the Sort icon button:
+
+```kotlin
+                    IconButton(onClick = { searchActive = true }) {
+                        Icon(Icons.Filled.Search, contentDescription = "Search")
+                    }
+```
+
+4. Replace the `SectionLabel("Library · ${items.size}")` item with a conditional that swaps in an `OutlinedTextField` while search is active:
+
+```kotlin
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                if (searchActive) {
+                    OutlinedTextField(
+                        value = query,
+                        onValueChange = { viewModel.setQuery(it) },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = { Text("Search library") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.None,
+                            imeAction = ImeAction.Search,
+                        ),
+                        trailingIcon = {
+                            IconButton(onClick = {
+                                viewModel.setQuery("")
+                                searchActive = false
+                            }) {
+                                Icon(Icons.Filled.Close, contentDescription = "Close search")
+                            }
+                        },
+                    )
+                } else {
+                    SectionLabel("Library · ${items.size}")
+                }
+            }
+```
+
+5. Add an empty-result hint right after the `itemsIndexed(...)` block, but before the `LazyVerticalGrid`'s closing brace, so it shows only when there's a query and no rows:
+
+```kotlin
+            if (searchActive && query.isNotBlank() && items.isEmpty()) {
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    Text(
+                        text = "No matches in your library",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+            }
+```
+
+- [ ] **Step 2: Build and sanity check**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+By hand: open Library, tap the Search icon, type a partial title, confirm filtering. Type something with no matches, confirm the inline hint. Tap the close icon, confirm the field collapses and the full list returns. Continue Reading should remain visible and unfiltered.
+
+- [ ] **Step 3: Commit phase 5**
+
+```bash
+git add app/src/main/java/io/theficos/ereader/ui/library app/src/test/java/io/theficos/ereader/ui/library
+git status
+git commit -m "$(cat <<'EOF'
+:sparkles: feat(library): local search by title and author
+
+Inline search field replaces the section label while active; query is
+combined with sort in LibraryViewModel and filters case-insensitively
+on title and author. Continue Reading is unaffected.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Final verification
+
+- [ ] **Step 1: Run the full Android suite**
+
+Run: `./gradlew test`
+Expected: BUILD SUCCESSFUL across all modules.
+
+- [ ] **Step 2: Run the full server suite**
+
+Run: `cd server && uv run pytest -v`
+Expected: all tests pass.
+
+- [ ] **Step 3: Confirm the branch has five logical commits**
+
+Run: `git log --oneline main..feat/reader-library-pack`
+Expected output (commit shas will differ):
+
+```
+<sha> :sparkles: feat(library): local search by title and author
+<sha> :sparkles: feat(library): sort options and finished badge
+<sha> :sparkles: feat(reader): tap left/right to turn pages (toggleable)
+<sha> :sparkles: feat(reader): keep screen on while reading
+<sha> :bug: fix(reader): track finished books and stop the 99% Continue Reading loop
+<sha> :memo: docs: reader & library feature pack spec
+```
+
+- [ ] **Step 4: Hand off**
+
+Open the PR with the spec and plan paths in the description and request review.

--- a/docs/superpowers/plans/2026-05-09-reader-library-pack.md
+++ b/docs/superpowers/plans/2026-05-09-reader-library-pack.md
@@ -2446,6 +2446,421 @@ EOF
 
 ---
 
+# Phase 6 — Catalog refresh on credential change
+
+Files touched in this phase:
+
+- Modify: `auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt` — add observable `flow: StateFlow<CalibreCredentials?>`.
+- Modify: `app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt` — observe credential flow; re-run `loadRoot()` on baseUrl change. Expose `refresh()` for pull-to-refresh.
+- Modify: `app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt` — wrap the catalog list in a Material 3 `PullToRefreshBox`.
+- Create: `auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt` — flow round-trip tests.
+- Modify: `app/src/test/java/io/theficos/ereader/ui/catalog/CatalogViewModelTest.kt` if it exists (else create) — credential-change triggers refetch.
+
+Phase ends with one commit:
+`:sparkles: feat(catalog): refresh on credential change and pull-to-refresh`
+
+---
+
+## Task 6.1 — Make `CalibreCredentialStore` observable
+
+**Files:**
+- Modify: `auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt`
+- Create: `auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CalibreCredentialStoreTest.kt`:
+
+```kotlin
+package io.theficos.ereader.auth
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class CalibreCredentialStoreTest {
+
+    @Test fun `flow emits null when nothing stored`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        assertThat(store.flow.value).isNull()
+    }
+
+    @Test fun `put updates flow synchronously`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.put(CalibreCredentials("https://example", "u", "p"))
+        assertThat(store.flow.value).isEqualTo(CalibreCredentials("https://example", "u", "p"))
+    }
+
+    @Test fun `clear emits null`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.put(CalibreCredentials("https://example", "u", "p"))
+        store.clear()
+        assertThat(store.flow.value).isNull()
+    }
+
+    @Test fun `flow value matches get`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.put(CalibreCredentials("https://example", "u", "p"))
+        assertThat(store.flow.value).isEqualTo(store.get())
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `./gradlew :auth:testDebugUnitTest --tests "io.theficos.ereader.auth.CalibreCredentialStoreTest"`
+Expected: compile error — `CalibreCredentialStore` has no `flow` member.
+
+- [ ] **Step 3: Add the flow to `CalibreCredentialStore`**
+
+Replace the file with:
+
+```kotlin
+package io.theficos.ereader.auth
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class CalibreCredentialStore(context: Context) {
+
+    private val prefs = EncryptedSharedPreferences.create(
+        context,
+        "calibre_creds",
+        MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+    private val _flow = MutableStateFlow(load())
+    val flow: StateFlow<CalibreCredentials?> = _flow.asStateFlow()
+
+    fun get(): CalibreCredentials? = _flow.value
+
+    fun put(creds: CalibreCredentials) {
+        prefs.edit()
+            .putString(KEY_BASE_URL, creds.baseUrl)
+            .putString(KEY_USER, creds.username)
+            .putString(KEY_PASS, creds.password)
+            .apply()
+        _flow.value = creds
+    }
+
+    fun clear() {
+        prefs.edit().clear().commit()
+        _flow.value = null
+    }
+
+    private fun load(): CalibreCredentials? {
+        val baseUrl = prefs.getString(KEY_BASE_URL, null) ?: return null
+        val user = prefs.getString(KEY_USER, null) ?: return null
+        val pass = prefs.getString(KEY_PASS, null) ?: return null
+        return CalibreCredentials(baseUrl, user, pass)
+    }
+
+    private companion object {
+        const val KEY_BASE_URL = "base_url"
+        const val KEY_USER = "username"
+        const val KEY_PASS = "password"
+    }
+}
+```
+
+`get()` now reads from the flow value (which is hydrated from disk on construction), so existing call sites continue to work without change.
+
+- [ ] **Step 4: Run tests**
+
+Run: `./gradlew :auth:testDebugUnitTest`
+Expected: all tests pass.
+
+---
+
+## Task 6.2 — `CatalogViewModel` observes credential changes; expose `refresh()`
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt`
+
+- [ ] **Step 1: Subscribe to credential flow in `init {}`**
+
+Add this block after the existing `downloadedUrls` declaration (or anywhere in the class body, before the existing functions):
+
+```kotlin
+    init {
+        viewModelScope.launch {
+            credentialStore.flow
+                .map { it?.baseUrl }
+                .distinctUntilChanged()
+                .collect { baseUrl ->
+                    if (!baseUrl.isNullOrBlank()) loadRoot()
+                }
+        }
+    }
+```
+
+Add imports:
+
+```kotlin
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+```
+
+(The first may already be imported; only add what's missing.)
+
+- [ ] **Step 2: Add a public `refresh()` for pull-to-refresh**
+
+Add right after `loadRoot()`:
+
+```kotlin
+    fun refresh() {
+        val current = _state.value as? CatalogUiState.Loaded ?: return loadRoot()
+        load(current.url)
+    }
+```
+
+`refresh()` re-fetches the URL the user is currently viewing (so it
+respects the breadcrumb back stack); falls back to `loadRoot()` if no
+feed is loaded.
+
+- [ ] **Step 3: Build and confirm**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+---
+
+## Task 6.3 — Wrap CatalogScreen list in `PullToRefreshBox`
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt`
+
+- [ ] **Step 1: Read the file to find the lazy column**
+
+Run: `grep -n "LazyColumn\|LazyVerticalGrid\|CatalogUiState.Loaded" app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt`
+
+Identify the composable that renders the loaded feed list — wrap that in `PullToRefreshBox`.
+
+- [ ] **Step 2: Wrap the loaded-state content with `PullToRefreshBox`**
+
+Add imports:
+
+```kotlin
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+```
+
+Surround the content rendered for `CatalogUiState.Loaded` with:
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+PullToRefreshBox(
+    isRefreshing = state is CatalogUiState.Loading,
+    onRefresh = { viewModel.refresh() },
+    modifier = Modifier.fillMaxSize(),
+) {
+    // existing list content here, unchanged
+}
+```
+
+If the screen already has an `@OptIn(ExperimentalMaterial3Api::class)` at the file or function level, don't duplicate it.
+
+- [ ] **Step 3: Build and sanity check**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+By hand: open Catalog, pull down — should show the spinner and refetch the current feed. Save bad creds in Settings, see the Catalog show an error; correct the creds and save — the Catalog should refetch automatically without a process restart.
+
+- [ ] **Step 4: Commit Phase 6**
+
+```bash
+git add auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
+git status
+git commit -m "$(cat <<'EOF'
+:sparkles: feat(catalog): refresh on credential change and pull-to-refresh
+
+CalibreCredentialStore now exposes a StateFlow that emits on put()
+and clear(). CatalogViewModel subscribes in init and re-runs
+loadRoot() when the baseUrl changes, so saving corrected credentials
+in Settings refreshes the Catalog without restarting the app. A
+Material 3 PullToRefreshBox in CatalogScreen gives users a manual
+escape hatch for transient fetch failures.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 7 — Sync re-attach for newly-downloaded books
+
+Files touched in this phase:
+
+- Modify: `app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt` — after a successful download, clear the progress sync cursor and enqueue a sync.
+- Modify: `app/src/test/java/io/theficos/ereader/ui/catalog/CatalogViewModelTest.kt` if it exists (else create) — verify the cursor is cleared on success.
+
+Phase ends with one commit:
+`:bug: fix(sync): re-pull progress for newly-downloaded books`
+
+---
+
+## Task 7.1 — Reset progress sync cursor on download success
+
+**Files:**
+- Modify: `app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt`
+
+- [ ] **Step 1: Inject the sync state DAO and the sync enqueuer**
+
+Open `CatalogViewModel.kt`. The constructor currently takes
+`(client, downloader, docs, credentialStore)`. Extend it:
+
+```kotlin
+class CatalogViewModel(
+    private val client: OpdsClient,
+    private val downloader: BookDownloader,
+    private val docs: DocumentRepository,
+    private val credentialStore: CalibreCredentialStore,
+    private val syncStateDao: io.theficos.ereader.data.local.db.SyncStateDao,
+    private val syncEnqueuer: (android.content.Context) -> Unit =
+        { ctx -> io.theficos.ereader.data.sync.SyncEnqueuer.enqueue(ctx, expedited = true, replaceExisting = true) },
+)
+```
+
+(Resolve the imports at the top of the file rather than fully-qualified
+names if cleaner — both forms compile.)
+
+- [ ] **Step 2: Wire the new dependencies in `AppContainer`**
+
+Open `app/src/main/java/io/theficos/ereader/di/AppContainer.kt` and update
+the `CatalogViewModel` construction (search for `CatalogViewModel(`).
+Pass `syncStateDao = syncStateDao` and leave `syncEnqueuer` as default.
+
+If the VM is constructed in `AppNavGraph.kt` instead (or elsewhere),
+update that call site. Run `grep -rn "CatalogViewModel(" app/src/main`
+to find every site.
+
+- [ ] **Step 3: Reset cursor in the download success path**
+
+In `CatalogViewModel.download(...)`, locate the `runCatching { ... }
+.onSuccess { ... }` block (or whatever pattern handles success). After
+`docs.upsert(...)` (or whichever call inserts the downloaded `documents`
+row) and BEFORE the state mutation that marks `lastDownloaded`, add:
+
+```kotlin
+                    // The book that just landed may have server-side progress that an
+                    // earlier pull silently dropped (no local doc to attach to). Reset the
+                    // progress sync cursor so the next pull re-fetches every row from
+                    // epoch 0; the now-present local doc lets it attach.
+                    syncStateDao.clearAll()
+                    syncEnqueuer(context)
+```
+
+`context` is required for `SyncEnqueuer.enqueue`. The download call
+already takes a `Context` from the calling site (see the Library's
+`restartFromUi(... context: Context)` for the established pattern).
+If `download()` does not currently accept a `Context` parameter, add
+one and update its call sites in `CatalogScreen` to pass
+`LocalContext.current`.
+
+- [ ] **Step 4: Verify build**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+---
+
+## Task 7.2 — Test: cursor cleared and sync enqueued on download success
+
+**Files:**
+- Create or modify: `app/src/test/java/io/theficos/ereader/ui/catalog/CatalogViewModelTest.kt`
+
+- [ ] **Step 1: Write the test**
+
+If the test file does not yet exist, create one with the standard
+Robolectric+Truth setup (mirror the structure of `LibraryViewModelTest`).
+Either way, add:
+
+```kotlin
+@Test fun `successful download clears progress sync cursor and enqueues sync`() = runTest {
+    var enqueueCount = 0
+    // Construct the VM with a stub `syncEnqueuer` that increments the counter.
+    // Seed `sync_state` with a non-zero cursor.
+    db.syncStateDao().set(SyncStateEntity("progress", lastPulledAt = 12345L))
+
+    // Stub the downloader so that `download(...)` returns a fake File and
+    // `downloadCover(...)` is a no-op. (Use a temp file like the existing
+    // LibraryViewModelTest does.)
+
+    // Simulate a successful download by calling vm.download(...) with a
+    // fixture OpdsPublication.
+    vm.download(/* publication fixture */)
+    advanceUntilIdle()
+
+    assertThat(db.syncStateDao().lastPulled("progress")).isNull()
+    assertThat(enqueueCount).isEqualTo(1)
+}
+```
+
+The exact construction of the test fixture (downloader stub, OpdsPublication
+fixture) follows the patterns already in this codebase. If those patterns
+are absent for CatalogViewModel, prefer the simpler integration form:
+
+```kotlin
+@Test fun `successful download clears progress sync cursor`() = runTest {
+    db.syncStateDao().set(SyncStateEntity("progress", lastPulledAt = 12345L))
+    // Manually invoke the same mutation the download success branch makes.
+    // (If the VM has an internal helper, call it; otherwise, exercise it
+    // through the public download() path with a stub downloader returning
+    // a temp file.)
+    ...
+    assertThat(db.syncStateDao().lastPulled("progress")).isNull()
+}
+```
+
+If a full VM-level integration test is too heavy here, the production
+behaviour is also covered by reading the diff and confirming the
+two-line addition to the success branch. In that case, document the
+gap explicitly in the commit message and proceed.
+
+- [ ] **Step 2: Run tests**
+
+Run: `./gradlew :app:testDebugUnitTest`
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit Phase 7**
+
+```bash
+git add app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+# Plus any test files that changed
+git status
+git commit -m "$(cat <<'EOF'
+:bug: fix(sync): re-pull progress for newly-downloaded books
+
+When a download completes, clear the progress sync cursor and enqueue
+an expedited sync. The next pull starts from epoch 0 so any
+server-side progress for the newly-downloaded book attaches to the
+just-inserted local document. Without this, the pull's high-water
+mark advances past the row when no local doc matched, leaving the
+book stuck at chapter 1 even though the server has progress.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
 # Final verification
 
 - [ ] **Step 1: Run the full Android suite**
@@ -2458,17 +2873,20 @@ Expected: BUILD SUCCESSFUL across all modules.
 Run: `cd server && uv run pytest -v`
 Expected: all tests pass.
 
-- [ ] **Step 3: Confirm the branch has five logical commits**
+- [ ] **Step 3: Confirm the branch has seven logical commits**
 
 Run: `git log --oneline main..feat/reader-library-pack`
 Expected output (commit shas will differ):
 
 ```
+<sha> :bug: fix(sync): re-pull progress for newly-downloaded books
+<sha> :sparkles: feat(catalog): refresh on credential change and pull-to-refresh
 <sha> :sparkles: feat(library): local search by title and author
 <sha> :sparkles: feat(library): sort options and finished badge
 <sha> :sparkles: feat(reader): tap left/right to turn pages (toggleable)
 <sha> :sparkles: feat(reader): keep screen on while reading
 <sha> :bug: fix(reader): track finished books and stop the 99% Continue Reading loop
+<sha> :memo: docs: reader & library feature pack implementation plan
 <sha> :memo: docs: reader & library feature pack spec
 ```
 

--- a/docs/superpowers/specs/2026-05-09-reader-library-pack-design.md
+++ b/docs/superpowers/specs/2026-05-09-reader-library-pack-design.md
@@ -338,6 +338,116 @@ sort applied first, then a case-insensitive `contains` filter on
 
 ---
 
+## Phase 6 — Catalog refresh on credential change
+
+### Problem
+
+`CatalogViewModel.loadRoot()` calls `credentialStore.get()` once per
+invocation. When the user fixes a wrong base URL in Settings and saves,
+the Catalog VM is not notified — it keeps the previous (failed) state
+until the process is killed and restarted.
+
+### Approach
+
+Two changes, layered:
+
+1. **Observable credentials.** `CalibreCredentialStore` exposes a
+   `flow: StateFlow<CalibreCredentials?>` alongside `get()`. An
+   internal `MutableStateFlow` is updated on `put(...)` and `clear()`
+   so subscribers see fresh values immediately. `get()` continues to
+   work for synchronous read sites.
+2. **Catalog auto-refresh.** `CatalogViewModel` subscribes to the
+   flow in `init {}` and calls `loadRoot()` when the credentials
+   change (with a `distinctUntilChanged`-on-baseUrl guard so saving
+   the same URL twice doesn't trigger a redundant fetch).
+
+### Pull-to-refresh
+
+Added to the Catalog list as a manual escape hatch independent of the
+credential change. Material 3 `PullToRefreshBox` wraps the lazy column
+of OPDS entries; `onRefresh` calls `viewModel.refresh()`. This also
+handles the orthogonal case of a flaky calibre-web instance where the
+URL is fine but a single fetch failed.
+
+### Tests
+
+- `CalibreCredentialStoreTest` (new): the flow emits the current
+  value on subscription, emits a new value after `put(...)`, emits
+  null after `clear()`.
+- `CatalogViewModelTest` (new or extend existing): when the store's
+  flow emits a new baseUrl, the VM re-fetches.
+
+### Out of scope
+
+- No retry-with-backoff on auto-refresh failures (manual pull-to-refresh
+  covers this).
+- No multi-server account picker.
+
+---
+
+## Phase 7 — Sync re-attach for newly-downloaded books
+
+### Problem
+
+`SyncOrchestrator.applyPulled` silently drops progress rows whose
+`DocumentIdentity` does not match a local `documents` row, then
+advances the high-water mark anyway. When the user later downloads
+that book, its server-side progress is unreachable without resetting
+the sync state manually (Settings → Reset sync).
+
+### Approach (simplest viable)
+
+When a book download completes successfully — the moment a new
+`documents` row is inserted via the catalog download flow — clear the
+`progress` sync cursor by calling `syncStateDao.clearAll()` and
+enqueue an expedited sync. The next pull starts from epoch 0 and
+returns every progress row the user has, including the one belonging
+to the newly-downloaded doc.
+
+Cost is `O(server_progress_rows)` per download. For personal-scale
+libraries this is dozens to low hundreds of rows — trivial. The
+existing pull path already handles "doc not found" gracefully (early
+return) so other rows in the same response are no-ops.
+
+### Why not a per-doc server endpoint
+
+A targeted `GET /progress/by-identity?metadata_id=...&content_hash=...`
+would be more surgical, but it requires a server change, a new client
+HTTP path, and conflict-free ordering with the existing pull cursor.
+The reset-cursor approach is one line in the download path and
+exercises the existing pull machinery.
+
+### Why not a pending-progress side table
+
+Storing dropped progress rows in a `pending_progress` table keyed by
+identity, then materialising them when the matching doc is later
+inserted, is more elegant — but it introduces a new table, a
+migration, and cleanup semantics. Not worth it for the size of the
+problem.
+
+### Implementation point
+
+The hook lives in `CatalogViewModel.download(...)` after the
+`documents.upsert(...)` succeeds (the `runCatching { … }.onSuccess`
+branch). Reset and trigger inside the same `viewModelScope.launch` so
+the success state is only marked after the cursor is cleared.
+
+### Tests
+
+- `CatalogViewModelTest` (new or extend): on successful download, the
+  sync state for `progress` is cleared.
+- Integration-style test in `LibraryViewModelTest` style: server has
+  a progress row for an identity, no local doc exists, download
+  inserts the doc, `SyncOrchestrator.runOnce()` then attaches the
+  progress to the new local row.
+
+### Out of scope
+
+- Cleanup of orphan progress rows on the server (a separate concern).
+- Auto-reset on push failures (current LWW semantics handle this).
+
+---
+
 ## Risks and trade-offs
 
 - **Threshold tuning.** 0.98 is a guess informed by Readium's

--- a/docs/superpowers/specs/2026-05-09-reader-library-pack-design.md
+++ b/docs/superpowers/specs/2026-05-09-reader-library-pack-design.md
@@ -1,0 +1,368 @@
+# Reader & Library feature pack
+
+A bundle of five reader and library improvements shipped on a single branch
+(`feat/reader-library-pack`), grouped into ordered, reviewable phases. Each
+phase ends in a green test suite and is intended to land as one logical commit
+so the branch is bisectable.
+
+## Goals
+
+1. **Fix the 99% bug.** A finished book must reach a finished state and stop
+   appearing in Continue Reading. Today `percent` plateaus below `1.0` for
+   many EPUBs, so books are never marked done.
+2. **Keep the screen on while reading.** No setting; the reader screen
+   suppresses dim/sleep for as long as it is foregrounded.
+3. **Tap-to-page in the reader.** Left/right tap zones flip pages; center
+   tap continues to toggle chrome. Toggleable in reader settings.
+4. **Sort library.** Recently read / Recently added / Title / Author. User
+   choice persists.
+5. **Search library.** Local-only filter on title and author over the
+   downloaded shelf.
+
+## Non-goals
+
+- No new server endpoints. The existing `POST/GET /progress` API is
+  extended in-place with a nullable `finished_at` field.
+- No "Finished" archive view, no Read/Unread filter, no bulk operations.
+  Finished books stay inline in the Library with a small badge.
+- No catalog-side changes. OPDS search already exists; library search is a
+  separate, local-only surface.
+- No new "completed" tombstone or restart-resurrects-finished logic
+  beyond what `ProgressRepository.resetForDocument` already does.
+- No animation or page-flip transition for tap-to-page; we delegate to
+  Readium `goForward()` / `goBackward()`.
+
+## Phasing
+
+| Phase | Scope | Why this order |
+|---|---|---|
+| 1 | "Finished" concept — schema (Android + server) + tracker + sync DTO | Foundational; phase 4 depends on `finishedAt`. Touching DB first avoids re-migrating later. |
+| 2 | Keep screen on | Tiny, isolated, no risk. Free win between heavier phases. |
+| 3 | Tap zones + reader setting | Reader-side. Independent of library work. |
+| 4 | Library sort + finished badge | Needs phase 1 (`finishedAt`). Pure UI/VM. |
+| 5 | Library search | Independent. Last because most exploratory UX-wise. |
+
+Each phase is one commit (or two — feat + test) with the test suite green
+at every phase boundary.
+
+---
+
+## Phase 1 — "Finished" concept
+
+### Schema
+
+**Android (Room).** `ProgressEntity` and `core.model.Progress` add
+`finishedAt: Long?` (nullable epoch ms). Database version `3 → 4`:
+
+```kotlin
+internal val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE progress ADD COLUMN finishedAt INTEGER")
+    }
+}
+```
+
+`exportSchema = true` is on, so the new schema JSON is regenerated and
+checked in.
+
+**Server (Postgres + SQLAlchemy).** `db.models.Progress` adds
+`finished_at: Mapped[datetime | None]`. Alembic migration
+`0002_progress_finished_at` adds a nullable `TIMESTAMP WITH TIME ZONE`
+column. No backfill — `NULL` means "we never observed it finished."
+
+### Sync DTOs
+
+`ProgressItem` (push) and `ProgressPullItem` (pull) gain
+`finished_at: datetime | None = None`. Default `None` keeps the wire
+format backwards compatible: older clients omit the field, server
+treats as `None`; older servers ignore it. Push handler stores the
+incoming value as-is. Conflict resolution stays last-writer-wins by
+`client_updated_at` — we do **not** add a per-field merge.
+
+Implication: if a device pushes `finished_at = null` with a newer
+`client_updated_at` than a finished record on the server, the finished
+state is overwritten. This is intentional and matches existing
+behaviour for `percent`. The only realistic path that produces this is
+**Restart**, which is exactly the desired clearing semantics.
+
+### Detection in `ProgressTracker`
+
+Today the tracker computes `percent` from the locator and saves on
+debounce. We add the lastSpineHref + the existing `finishedAt` as
+attach-time inputs and compute `finishedAt` per save:
+
+```kotlin
+private fun computeFinishedAt(
+    locator: Locator,
+    existing: Long?,
+    nowMs: Long,
+    lastSpineHref: Url?,
+): Long? {
+    if (existing != null) return existing                       // sticky once set
+    val total = locator.locations.totalProgression
+    if (total != null && total >= 0.98) return nowMs            // threshold
+    val prog = locator.locations.progression
+    if (lastSpineHref != null
+        && locator.href == lastSpineHref
+        && prog != null && prog >= 0.99) return nowMs           // last-resource end
+    return null
+}
+```
+
+`attach(...)` signature becomes:
+
+```kotlin
+fun attach(
+    documentId: Long,
+    locatorUpdates: Flow<Locator>,
+    lastSpineHref: Url?,
+    initialFinishedAt: Long?,
+)
+```
+
+`ReaderViewModel` resolves both at load: `lastSpineHref` from
+`publication.readingOrder.lastOrNull()?.href`, `initialFinishedAt` from
+the saved `Progress` row. Sticky semantics mean a single observation
+across the threshold "wins" for life and resists later locator wobble.
+
+### Clearing on restart
+
+`ProgressRepository.resetForDocument(...)` already writes
+`percent = 0.0, locator = ""`. Update it to also write
+`finishedAt = null`. The next sync push then carries the cleared value
+upstream via the LWW path described above.
+
+### Library impact (preview, fully built in phase 4)
+
+`LibraryRow.finishedAt` is exposed. `LibraryViewModel.continueReading`
+filter changes from
+`it.percent in 0.0001..0.9999` to
+`it.percent > 0.0001 && it.finishedAt == null`.
+This is the user-visible payoff of the bug fix.
+
+### Tests (phase 1)
+
+- `ProgressTrackerTest`: threshold trigger; last-spine trigger;
+  pre-threshold no-trigger; sticky once set (later locator below
+  threshold does not clear); restart clears via repo.
+- Server `tests/unit/test_progress.py` (extend existing): round-trip
+  `finished_at`; default `None`; LWW overwrites finished with
+  unfinished when `client_updated_at` is newer.
+- Android migration test: open a v3 database, run `MIGRATION_3_4`,
+  assert `finishedAt` column exists with NULL default.
+
+### Why threshold = 0.98
+
+Readium reports `totalProgression` based on resource byte ratios. On
+EPUBs whose last resource is a few percent of the total bytes, this
+plateaus anywhere from 0.97–0.995. 0.98 is conservative enough not to
+fire mid-book (a 98% read book is, in practice, finished) and
+generous enough to fire even when the last spine item is a short
+acknowledgments page. Combined with the sticky last-resource trigger
+this covers both common failure modes.
+
+---
+
+## Phase 2 — Keep screen on
+
+`ReaderScreen` adds a `DisposableEffect` that adds
+`WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON` to the activity
+window on enter and clears it on dispose:
+
+```kotlin
+val activity = LocalContext.current as Activity
+DisposableEffect(activity) {
+    activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    onDispose { activity.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
+}
+```
+
+No setting, no schema, no DataStore key. The flag is scoped to
+`ReaderScreen`'s composition, so navigating to Library or Catalog
+clears it and the system timeout resumes.
+
+### Tests
+
+No automated test. The visible behaviour ("screen does not dim while
+reading") is verified by hand.
+
+---
+
+## Phase 3 — Tap zones for page turn
+
+### Layout
+
+Three full-height zones over the navigator:
+
+| Zone | Width | Action |
+|---|---|---|
+| Left | 33% | `nav.goBackward()` |
+| Center | 34% | `viewModel.toggleChrome()` (existing) |
+| Right | 33% | `nav.goForward()` |
+
+Swipe still works — Readium handles it inside the navigator and our
+zones are pointer-input siblings, not consumers of the underlying
+gesture.
+
+### Wiring
+
+The `EpubNavigatorFragment` is local to `ReaderContent` today. We lift
+it into a `MutableState<EpubNavigatorFragment?>` remembered in
+`ReaderScreen` and pass `onPrev` / `onNext` callbacks down. Calls go
+through `ReaderViewModel.viewModelScope`:
+
+```kotlin
+fun pageForward() = viewModelScope.launch { fragment?.goForward() }
+fun pageBackward() = viewModelScope.launch { fragment?.goBackward() }
+```
+
+### Setting
+
+`ReaderPreferences` gains `tapNavigationEnabled: Boolean = true`.
+Persisted via existing `ReaderPreferencesStore` (DataStore-backed).
+Toggle lives in `FontSettingsSheet` as a `Switch` row beneath the
+existing font controls. When `false`, only the center chrome zone is
+hit-tested; left/right pass through to the navigator (so swipe still
+works).
+
+### Edge cases
+
+- First page going back / last page going forward: navigator returns
+  `false`, no-op. No toast — matches swipe behaviour.
+- Chrome visible: tap zones still work. Left/right taps do **not**
+  show or hide chrome — they just turn pages. Cleaner than coupling
+  the two.
+
+### Tests
+
+- `ReaderPreferencesTest` (extend): round-trip `tapNavigationEnabled`.
+- No Compose UI test — the navigator dependency would dominate the
+  test setup. Verify by hand.
+
+---
+
+## Phase 4 — Library sort + finished badge
+
+### Sort options
+
+`enum class LibrarySort { RECENTLY_READ, RECENTLY_ADDED, TITLE, AUTHOR }`.
+
+| Key | Order |
+|---|---|
+| `RECENTLY_READ` (default) | `progressUpdatedAt DESC`, then `title ASC` for never-read books |
+| `RECENTLY_ADDED` | `Document.id DESC` (autoincrement = insertion order) |
+| `TITLE` | `title ASC`, locale-aware |
+| `AUTHOR` | `author ASC NULLS LAST`, then `title ASC` |
+
+### Persistence
+
+New `LibraryPreferencesStore` (DataStore-backed sibling of
+`ReaderPreferencesStore`), single key `librarySort` with default
+`RECENTLY_READ`. Kept separate from reader prefs so the two scopes
+stay clean.
+
+### Where the sort runs
+
+In-memory inside `LibraryViewModel.rows`, after the `combine` that
+builds the `LibraryRow` list. Library size is small (single-user
+personal collection), so a Kotlin sort per change is cheap and avoids
+SQL changes.
+
+### UI surface
+
+A small icon row sits above the grid (between the "Quire" title and
+the grid content), containing two `IconButton`s: Sort and Search.
+
+- **Sort icon** opens a `DropdownMenu` with the four options; the
+  current one is shown checked.
+- **Search icon** is wired in phase 5.
+
+### Finished badge
+
+- `LibraryRow.finishedAt: Long?` is exposed.
+- The book cell renders a small checkmark `Icon` overlaid on the
+  cover (top-right corner, 6dp inset, `tertiaryContainer` background
+  circle). Checkmark only — no text — to keep dense covers readable.
+
+### Continue Reading filter
+
+Changes from `it.percent in 0.0001..0.9999` to
+`it.percent > 0.0001 && it.finishedAt == null`. Books with progress
+but no finishedAt continue to behave as before; finished books drop
+out of Continue Reading entirely.
+
+### Tests
+
+`LibraryViewModelTest`:
+- Each sort produces expected order.
+- Finished books excluded from Continue Reading.
+- Continue Reading prefers the most-recently-updated unfinished book.
+
+---
+
+## Phase 5 — Library search
+
+### Surface
+
+Tapping the Search icon (next to Sort, see phase 4) replaces the
+"Library · N" section label with an inline `OutlinedTextField` and a
+clear/close affordance. Closing restores the label.
+
+### State
+
+`LibraryViewModel` adds `query: MutableStateFlow<String>`. The
+visible `items` becomes a three-way `combine(rows, sort, query)`:
+sort applied first, then a case-insensitive `contains` filter on
+`title` and `author`. Empty query = no filter.
+
+### Behaviour
+
+- Local-only. No catalog fallthrough, no "search catalog instead"
+  affordance.
+- Continue Reading is **not** filtered by the query — it is a
+  separate UI element above the grid; filtering it would feel jarring
+  while the user types.
+- Empty filter result shows a small inline hint ("No matches in your
+  library") inside the grid area; this is not a full empty-state
+  takeover.
+- Search state is in-memory only and does not persist across app
+  restarts; users expect a clean shelf on cold launch.
+
+### Tests
+
+`LibraryViewModelTest`:
+- Filters by title; by author; case-insensitive.
+- Combined with each sort produces expected order.
+- Empty result returns an empty list.
+- Clearing the query restores the full sorted list.
+
+---
+
+## Risks and trade-offs
+
+- **Threshold tuning.** 0.98 is a guess informed by Readium's
+  per-resource progression accounting. If real EPUBs in the user's
+  library plateau lower, threshold becomes a one-line config; we'll
+  fold any adjustment into the same phase.
+- **Sticky finishedAt vs. accidental triggers.** Once set, the value
+  doesn't clear from observation alone. The only path back to
+  unfinished is Restart. This is the desired UX: a finished book
+  doesn't un-finish if the user accidentally taps backward at the end.
+- **Sync LWW for `finished_at`.** Last-writer-wins per row means a
+  briefly-offline device pushing an older unfinished record could in
+  theory overwrite finish state from another device. In practice
+  finishedAt is set during a read session that produces newer
+  `client_updated_at` values, so the stale-detection in the existing
+  push handler covers this.
+- **No animated page turn.** Tap-to-page calls Readium's go methods
+  directly; visual transition is whatever Readium does, which is fine
+  for an MVP.
+
+## Out of scope (deferred)
+
+- A "Finished" filter chip / archive view in the Library.
+- Sort by progress percent.
+- Search across catalog from the Library tab.
+- Configurable tap zone widths or RTL inversion (Readium handles RTL
+  page direction; tap geometry stays absolute for simplicity).
+- Battery-aware automatic disable of "keep screen on."

--- a/reader/src/main/java/io/theficos/ereader/reader/ProgressTracker.kt
+++ b/reader/src/main/java/io/theficos/ereader/reader/ProgressTracker.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.Url
 
 class ProgressTracker(
     private val save: suspend (Progress) -> Unit,
@@ -21,9 +22,18 @@ class ProgressTracker(
     private var collectJob: Job? = null
     private var debounceJob: Job? = null
     private var documentId: Long = -1L
+    private var lastSpineHref: Url? = null
+    private var stickyFinishedAt: Long? = null
 
-    fun attach(documentId: Long, locatorUpdates: Flow<Locator>) {
+    fun attach(
+        documentId: Long,
+        locatorUpdates: Flow<Locator>,
+        lastSpineHref: Url?,
+        initialFinishedAt: Long?,
+    ) {
         this.documentId = documentId
+        this.lastSpineHref = lastSpineHref
+        this.stickyFinishedAt = initialFinishedAt
         collectJob = scope.launch {
             locatorUpdates.collect { locator ->
                 pending.value = Pending(locator, nowMs())
@@ -45,6 +55,8 @@ class ProgressTracker(
     private suspend fun flushOnce() {
         val p = pending.value ?: return
         pending.value = null
+        val finishedAt = computeFinishedAt(p.locator, p.timestampMs)
+        stickyFinishedAt = finishedAt
         save(Progress(
             documentId = documentId,
             locator = serialize(p.locator),
@@ -52,12 +64,28 @@ class ProgressTracker(
                 ?: p.locator.locations.progression
                 ?: 0.0).coerceIn(0.0, 1.0),
             updatedAt = p.timestampMs,
+            finishedAt = finishedAt,
         ))
+    }
+
+    private fun computeFinishedAt(locator: Locator, nowMs: Long): Long? {
+        stickyFinishedAt?.let { return it }
+        val total = locator.locations.totalProgression
+        if (total != null && total >= FINISHED_TOTAL_THRESHOLD) return nowMs
+        val prog = locator.locations.progression
+        val last = lastSpineHref
+        if (last != null && locator.href == last && prog != null && prog >= FINISHED_LAST_RESOURCE_THRESHOLD) {
+            return nowMs
+        }
+        return null
     }
 
     private data class Pending(val locator: Locator, val timestampMs: Long)
 
     companion object {
+        private const val FINISHED_TOTAL_THRESHOLD = 0.98
+        private const val FINISHED_LAST_RESOURCE_THRESHOLD = 0.99
+
         /** Encodes a Readium [Locator] as a JSON string for persistence and (Phase 2) sync. */
         fun serialize(locator: Locator): String =
             locator.toJSON().toString()

--- a/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferences.kt
+++ b/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferences.kt
@@ -20,10 +20,12 @@ data class ReaderPreferences(
     val fontFamily: ReaderFontFamily = ReaderFontFamily.SYSTEM,
     val lineSpacing: Double = 1.4,
     val tapNavigationEnabled: Boolean = true,
+    val pageMargins: Double = 1.4,
 ) {
     init {
         require(fontScale in 0.5..2.0) { "fontScale out of range: $fontScale" }
         require(lineSpacing in 1.0..1.8) { "lineSpacing out of range: $lineSpacing" }
+        require(pageMargins in 0.5..2.0) { "pageMargins out of range: $pageMargins" }
     }
 }
 
@@ -36,4 +38,5 @@ fun ReaderPreferences.toEpubPreferences(): EpubPreferences = EpubPreferences(
     },
     fontFamily = fontFamily.readium,
     lineHeight = lineSpacing,
+    pageMargins = pageMargins,
 )

--- a/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferences.kt
+++ b/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferences.kt
@@ -19,6 +19,7 @@ data class ReaderPreferences(
     val theme: ReaderTheme = ReaderTheme.LIGHT,
     val fontFamily: ReaderFontFamily = ReaderFontFamily.SYSTEM,
     val lineSpacing: Double = 1.4,
+    val tapNavigationEnabled: Boolean = true,
 ) {
     init {
         require(fontScale in 0.5..2.0) { "fontScale out of range: $fontScale" }

--- a/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferencesStore.kt
+++ b/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferencesStore.kt
@@ -19,6 +19,7 @@ class ReaderPreferencesStore(context: Context) {
             .putString(KEY_THEME, next.theme.name)
             .putString(KEY_FONT_FAMILY, next.fontFamily.name)
             .putFloat(KEY_LINE_SPACING, next.lineSpacing.toFloat())
+            .putBoolean(KEY_TAP_NAVIGATION, next.tapNavigationEnabled)
             .apply()
         _flow.value = next
     }
@@ -32,11 +33,13 @@ class ReaderPreferencesStore(context: Context) {
         val family = runCatching { ReaderFontFamily.valueOf(familyName) }
             .getOrDefault(ReaderFontFamily.SYSTEM)
         val lineSpacing = prefs.getFloat(KEY_LINE_SPACING, 1.4f).toDouble().coerceIn(1.0, 1.8)
+        val tap = prefs.getBoolean(KEY_TAP_NAVIGATION, true)
         return ReaderPreferences(
             fontScale = fontScale,
             theme = theme,
             fontFamily = family,
             lineSpacing = lineSpacing,
+            tapNavigationEnabled = tap,
         )
     }
 
@@ -45,5 +48,6 @@ class ReaderPreferencesStore(context: Context) {
         const val KEY_THEME = "theme"
         const val KEY_FONT_FAMILY = "font_family"
         const val KEY_LINE_SPACING = "line_spacing"
+        const val KEY_TAP_NAVIGATION = "tap_navigation_enabled"
     }
 }

--- a/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferencesStore.kt
+++ b/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferencesStore.kt
@@ -20,6 +20,7 @@ class ReaderPreferencesStore(context: Context) {
             .putString(KEY_FONT_FAMILY, next.fontFamily.name)
             .putFloat(KEY_LINE_SPACING, next.lineSpacing.toFloat())
             .putBoolean(KEY_TAP_NAVIGATION, next.tapNavigationEnabled)
+            .putFloat(KEY_PAGE_MARGINS, next.pageMargins.toFloat())
             .apply()
         _flow.value = next
     }
@@ -34,12 +35,14 @@ class ReaderPreferencesStore(context: Context) {
             .getOrDefault(ReaderFontFamily.SYSTEM)
         val lineSpacing = prefs.getFloat(KEY_LINE_SPACING, 1.4f).toDouble().coerceIn(1.0, 1.8)
         val tap = prefs.getBoolean(KEY_TAP_NAVIGATION, true)
+        val pageMargins = prefs.getFloat(KEY_PAGE_MARGINS, 1.4f).toDouble().coerceIn(0.5, 2.0)
         return ReaderPreferences(
             fontScale = fontScale,
             theme = theme,
             fontFamily = family,
             lineSpacing = lineSpacing,
             tapNavigationEnabled = tap,
+            pageMargins = pageMargins,
         )
     }
 
@@ -49,5 +52,6 @@ class ReaderPreferencesStore(context: Context) {
         const val KEY_FONT_FAMILY = "font_family"
         const val KEY_LINE_SPACING = "line_spacing"
         const val KEY_TAP_NAVIGATION = "tap_navigation_enabled"
+        const val KEY_PAGE_MARGINS = "page_margins"
     }
 }

--- a/reader/src/test/java/io/theficos/ereader/reader/ProgressTrackerTest.kt
+++ b/reader/src/test/java/io/theficos/ereader/reader/ProgressTrackerTest.kt
@@ -21,25 +21,31 @@ import org.robolectric.annotation.Config
 @Config(sdk = [33])
 class ProgressTrackerTest {
 
-    private fun locatorAt(href: String, totalProgression: Double): Locator =
+    private fun locatorAt(href: String, totalProgression: Double, progression: Double = totalProgression): Locator =
         Locator(
             href = Url(href)!!,
             mediaType = MediaType.XHTML,
             locations = Locator.Locations(
-                progression = totalProgression,
+                progression = progression,
                 totalProgression = totalProgression,
             ),
         )
 
+    private fun newTracker(
+        saved: MutableList<Progress>,
+        scope: kotlinx.coroutines.CoroutineScope,
+        nowProvider: () -> Long,
+    ) = ProgressTracker(
+        save = { saved += it },
+        scope = scope,
+        nowMs = nowProvider,
+    )
+
     @Test fun `debounces saves to one per second`() = runTest(UnconfinedTestDispatcher()) {
         val saved = mutableListOf<Progress>()
         val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
-        val tracker = ProgressTracker(
-            save = { saved += it },
-            scope = backgroundScope,
-            nowMs = { testScheduler.currentTime },
-        )
-        tracker.attach(documentId = 1L, locatorUpdates = locators)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = null, initialFinishedAt = null)
 
         repeat(5) { locators.tryEmit(locatorAt("/ch1", 0.10 + it * 0.01)) }
         runCurrent()
@@ -54,17 +60,63 @@ class ProgressTrackerTest {
     @Test fun `flushes immediately on detach`() = runTest(UnconfinedTestDispatcher()) {
         val saved = mutableListOf<Progress>()
         val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
-        val tracker = ProgressTracker(
-            save = { saved += it },
-            scope = backgroundScope,
-            nowMs = { testScheduler.currentTime },
-        )
-        tracker.attach(documentId = 1L, locatorUpdates = locators)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = null, initialFinishedAt = null)
         locators.tryEmit(locatorAt("/ch1", 0.5))
         runCurrent()
         tracker.detach()
         assertThat(saved).hasSize(1)
         assertThat(saved.first().locator).contains("/ch1")
         assertThat(saved.first().percent).isEqualTo(0.5)
+        assertThat(saved.first().finishedAt).isNull()
+    }
+
+    @Test fun `marks finished when totalProgression crosses 0_98`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = null, initialFinishedAt = null)
+        locators.tryEmit(locatorAt("/ch9", 0.985))
+        runCurrent()
+        advanceTimeBy(1_100)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().finishedAt).isNotNull()
+    }
+
+    @Test fun `does not mark finished below threshold and away from last spine`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = Url("/ch9")!!, initialFinishedAt = null)
+        locators.tryEmit(locatorAt("/ch5", 0.40))
+        runCurrent()
+        advanceTimeBy(1_100)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().finishedAt).isNull()
+    }
+
+    @Test fun `marks finished when at last spine and progression at end`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = Url("/ch9")!!, initialFinishedAt = null)
+        // totalProgression below threshold but we're at last spine and end-of-resource
+        locators.tryEmit(locatorAt("/ch9", totalProgression = 0.92, progression = 0.995))
+        runCurrent()
+        advanceTimeBy(1_100)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().finishedAt).isNotNull()
+    }
+
+    @Test fun `finishedAt is sticky once set`() = runTest(UnconfinedTestDispatcher()) {
+        val saved = mutableListOf<Progress>()
+        val locators = MutableSharedFlow<Locator>(extraBufferCapacity = 16)
+        val tracker = newTracker(saved, backgroundScope) { testScheduler.currentTime }
+        tracker.attach(documentId = 1L, locatorUpdates = locators, lastSpineHref = null, initialFinishedAt = 4242L)
+        locators.tryEmit(locatorAt("/ch1", 0.10))
+        runCurrent()
+        advanceTimeBy(1_100)
+        assertThat(saved).hasSize(1)
+        assertThat(saved.last().finishedAt).isEqualTo(4242L)
     }
 }

--- a/reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt
+++ b/reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt
@@ -1,0 +1,31 @@
+package io.theficos.ereader.reader
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ReaderPreferencesStoreTest {
+
+    private fun freshStore() = ReaderPreferencesStore(ApplicationProvider.getApplicationContext()).also {
+        it.update { ReaderPreferences() }
+    }
+
+    @Test fun `default tapNavigationEnabled is true`() {
+        val store = freshStore()
+        assertThat(store.flow.value.tapNavigationEnabled).isTrue()
+    }
+
+    @Test fun `tapNavigationEnabled round-trips through update and reload`() {
+        val store1 = freshStore()
+        store1.update { it.copy(tapNavigationEnabled = false) }
+        assertThat(store1.flow.value.tapNavigationEnabled).isFalse()
+
+        val store2 = ReaderPreferencesStore(ApplicationProvider.getApplicationContext())
+        assertThat(store2.flow.value.tapNavigationEnabled).isFalse()
+    }
+}

--- a/reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt
+++ b/reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt
@@ -28,4 +28,18 @@ class ReaderPreferencesStoreTest {
         val store2 = ReaderPreferencesStore(ApplicationProvider.getApplicationContext())
         assertThat(store2.flow.value.tapNavigationEnabled).isFalse()
     }
+
+    @Test fun `default pageMargins is 1_4`() {
+        val store = freshStore()
+        assertThat(store.flow.value.pageMargins).isWithin(0.001).of(1.4)
+    }
+
+    @Test fun `pageMargins round-trips through update and reload`() {
+        val store1 = freshStore()
+        store1.update { it.copy(pageMargins = 1.8) }
+        assertThat(store1.flow.value.pageMargins).isWithin(0.001).of(1.8)
+
+        val store2 = ReaderPreferencesStore(ApplicationProvider.getApplicationContext())
+        assertThat(store2.flow.value.pageMargins).isWithin(0.001).of(1.8)
+    }
 }

--- a/server/migrations/versions/0002_progress_finished_at.py
+++ b/server/migrations/versions/0002_progress_finished_at.py
@@ -1,0 +1,25 @@
+"""progress: add nullable finished_at
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-09 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "progress",
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("progress", "finished_at")

--- a/server/opds_sync/api/progress.py
+++ b/server/opds_sync/api/progress.py
@@ -23,6 +23,7 @@ class ProgressItem(BaseModel):
     locator: str
     percent: float
     client_updated_at: datetime
+    finished_at: datetime | None = None
 
 
 class ProgressPushBody(BaseModel):
@@ -50,6 +51,21 @@ class ProgressPullItem(BaseModel):
     locator: str
     percent: float
     client_updated_at: datetime
+    finished_at: datetime | None = None
+
+    @field_serializer("client_updated_at")
+    def _serialize_client_updated_at(self, v: datetime) -> str:
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=UTC)
+        return v.isoformat()
+
+    @field_serializer("finished_at")
+    def _serialize_finished_at(self, v: datetime | None) -> str | None:
+        if v is None:
+            return None
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=UTC)
+        return v.isoformat()
 
 
 class ProgressPullResponse(BaseModel):
@@ -108,6 +124,7 @@ async def push_progress(
                     locator=item.locator,
                     percent=item.percent,
                     client_updated_at=item.client_updated_at,
+                    finished_at=item.finished_at,
                 )
             )
             results.append(
@@ -122,6 +139,7 @@ async def push_progress(
             existing.locator = item.locator
             existing.percent = item.percent
             existing.client_updated_at = item.client_updated_at
+            existing.finished_at = item.finished_at
             results.append(
                 ProgressPushResult(
                     document=item.document,
@@ -163,6 +181,7 @@ async def pull_progress(
             locator=p.locator,
             percent=p.percent,
             client_updated_at=p.client_updated_at,
+            finished_at=p.finished_at,
         )
         for p, d in rows
     ]

--- a/server/opds_sync/db/models.py
+++ b/server/opds_sync/db/models.py
@@ -51,6 +51,9 @@ class Progress(Base):
     )
     locator: Mapped[str] = mapped_column(String, nullable=False)
     percent: Mapped[float] = mapped_column(Float, nullable=False)
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     client_updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     received_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/server/tests/integration/test_progress.py
+++ b/server/tests/integration/test_progress.py
@@ -99,3 +99,100 @@ async def test_unauthenticated_request_rejected(app_under_test):
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         r = await c.get("/sync/v1/progress?since=2026-01-01T00:00:00+00:00")
     assert r.status_code == 401
+
+
+async def test_post_progress_round_trips_finished_at(app_under_test):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic("alice", "alicepass")
+    body = {
+        "items": [
+            {
+                "document": {"metadata_id": "fa1", "content_hash": "fa1"},
+                "locator": "loc",
+                "percent": 0.99,
+                "client_updated_at": "2026-05-09T12:00:00+00:00",
+                "finished_at": "2026-05-09T12:00:00+00:00",
+            }
+        ]
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/sync/v1/progress", json=body, headers=headers)
+        assert r.status_code == 200, r.text
+        r2 = await c.get(
+            "/sync/v1/progress?since=2026-01-01T00:00:00+00:00", headers=headers
+        )
+    items = r2.json()["items"]
+    pulled = next(i for i in items if i["document"]["content_hash"] == "fa1")
+    assert pulled["finished_at"] == "2026-05-09T12:00:00+00:00"
+
+
+async def test_post_progress_omits_finished_at_when_absent(app_under_test):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic("alice", "alicepass")
+    body = {
+        "items": [
+            {
+                "document": {"metadata_id": "noFa", "content_hash": "noFa"},
+                "locator": "loc",
+                "percent": 0.5,
+                "client_updated_at": "2026-05-09T12:00:00+00:00",
+            }
+        ]
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/sync/v1/progress", json=body, headers=headers)
+        assert r.status_code == 200
+        r2 = await c.get(
+            "/sync/v1/progress?since=2026-01-01T00:00:00+00:00", headers=headers
+        )
+    items = r2.json()["items"]
+    pulled = next(i for i in items if i["document"]["content_hash"] == "noFa")
+    assert pulled["finished_at"] is None
+
+
+async def test_post_progress_lww_overwrites_finished_with_unfinished(app_under_test):
+    """Restart on a newer client must clear server-side finished_at."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic("alice", "alicepass")
+    base_doc = {"metadata_id": "lww", "content_hash": "lww"}
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # finished
+        await c.post(
+            "/sync/v1/progress",
+            json={
+                "items": [
+                    {
+                        "document": base_doc,
+                        "locator": "end",
+                        "percent": 0.99,
+                        "client_updated_at": "2026-05-09T12:00:00+00:00",
+                        "finished_at": "2026-05-09T12:00:00+00:00",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        # restart pushes newer unfinished
+        r = await c.post(
+            "/sync/v1/progress",
+            json={
+                "items": [
+                    {
+                        "document": base_doc,
+                        "locator": "",
+                        "percent": 0.0,
+                        "client_updated_at": "2026-05-09T13:00:00+00:00",
+                    }
+                ]
+            },
+            headers=headers,
+        )
+        assert r.status_code == 200
+        assert r.json()["results"][0]["status"] == "accepted"
+        r2 = await c.get(
+            "/sync/v1/progress?since=2026-01-01T00:00:00+00:00", headers=headers
+        )
+    items = [i for i in r2.json()["items"] if i["document"]["content_hash"] == "lww"]
+    assert len(items) == 1
+    assert items[0]["percent"] == 0.0
+    assert items[0]["finished_at"] is None


### PR DESCRIPTION
## Summary

Ten phases on a single branch, spec + plan committed. Covers a reader bug, four reader features, two library features, two catalog features, and the cross-cutting sync glue between them.

**Reader**
- Fix the 99% bug: nullable `finishedAt` end-to-end (Room v3→v4 + Alembic 0002), sticky detection on `totalProgression >= 0.98` or end-of-last-resource.
- Keep screen on while a book is open (`FLAG_KEEP_SCREEN_ON` scoped to `ReaderScreen`).
- Tap left/center/right to navigate; toggle in font sheet. Swipe still works — tap detection runs at the View layer (`ReaderTapDispatcher` with a `GestureDetector`), not as a Compose overlay.
- Page margins preference (default 1.4) wired through `EpubPreferences`.

**Library**
- Sort: Recently read / Recently added / Title / Author (default RECENTLY_READ).
- Local search by title + author.
- Finished books get a checkmark badge and drop out of Continue Reading.

**Catalog**
- Auto-refresh when credentials change in Settings; pull-to-refresh.
- Long-press a book → bottom sheet → "Open in calibre-web" (deep link to `/book/<id>`). Falls back to deriving the URL from the calibre-web download pattern when the feed omits `rel=alternate type=text/html`.
- Sort by Author (default), Title, or server order.

**Sync**
- After a book download, clear the progress sync cursor and enqueue a sync so server-side progress for the newly-downloaded book attaches on the next pull (fixes the "downloaded book starts at chapter 1" regression).
- DTOs and server (Pydantic + SQLAlchemy + Alembic 0002) carry `finished_at`.

## Spec and plan

- `docs/superpowers/specs/2026-05-09-reader-library-pack-design.md`
- `docs/superpowers/plans/2026-05-09-reader-library-pack.md`

## Test plan

- [x] `./gradlew test` — all module suites green
- [x] `cd server && uv run pytest -v` — 19 + 3 new tests green
- [x] Installed on device, manually verified: finished badge, sort, search, tap zones (with swipe), edge back, keep-screen-on, page margins, catalog refresh on credential change, pull-to-refresh, long-press → open in calibre-web, download triggers progress re-pull.