### PR TITLE
:sparkles: feat: book-insight schema v2 + tone-keyed cache

### DIFF
--- a/app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
+++ b/app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
@@ -37,11 +37,8 @@ class AiRepository(
         _prefs.value = out
     }
 
-    /** Update only the tone, keeping the rest of the style intact. */
     suspend fun setStyleTone(tone: String) {
-        val current = _prefs.value?.style ?: AiStyle()
-        val newStyle = current.copy(tone = tone)
-        val out = client.setPreferences(style = newStyle)
+        val out = client.setPreferences(style = AiStyle(tone = tone))
         _prefs.value = out
     }
 

--- a/app/src/main/java/io/theficos/ereader/ui/bookdetail/InsightCards.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/bookdetail/InsightCards.kt
@@ -31,12 +31,11 @@ fun InsightSection(state: InsightUiState, onRetry: () -> Unit) {
         InsightUiState.Loading -> LoadingCard()
         is InsightUiState.Error -> ErrorCard(state.message, onRetry)
         is InsightUiState.Loaded -> Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            state.payload.summary?.let { SummaryCard(it, suggestedFor = state.payload.suggestedFor) }
+            state.payload.intro?.takeIf { it.isNotBlank() }?.let { IntroCard(it) }
             state.payload.author?.let { AuthorCard(it) }
             state.payload.series?.let { SeriesCard(it) }
-            state.payload.themes?.takeIf { it.isNotEmpty() }?.let {
-                ThemesCard(themes = it, advisory = state.payload.contentAdvisory)
-            }
+            state.payload.analysis?.takeIf { it.isNotBlank() }?.let { AnalysisCard(it) }
+            state.payload.contentWarnings?.takeIf { it.isNotEmpty() }?.let { ContentWarningsCard(it) }
             if (state.sources.isNotEmpty()) SourcesFooter(state.sources)
         }
     }
@@ -65,16 +64,12 @@ private fun ErrorCard(message: String, onRetry: () -> Unit) {
 }
 
 @Composable
-private fun SummaryCard(summary: String, suggestedFor: String?) {
+private fun IntroCard(intro: String) {
     QuireCard(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
         Column {
             Text("About this book", style = MaterialTheme.typography.titleSmall)
             Spacer(Modifier.height(4.dp))
-            Text(summary, style = MaterialTheme.typography.bodyMedium)
-            if (!suggestedFor.isNullOrBlank()) {
-                Spacer(Modifier.height(6.dp))
-                Text("Suggested for: $suggestedFor", style = MaterialTheme.typography.bodySmall)
-            }
+            Text(intro, style = MaterialTheme.typography.bodyMedium)
         }
     }
 }
@@ -101,27 +96,37 @@ private fun SeriesCard(s: SeriesInsight) {
         Column {
             Text("Series", style = MaterialTheme.typography.titleSmall)
             Spacer(Modifier.height(4.dp))
-            val pos = s.position?.toString().orEmpty()
-            val total = s.totalKnown?.let { " of $it" } ?: ""
-            Text("${s.name}${if (pos.isNotEmpty()) " — book $pos$total" else ""}")
+            val header = buildString {
+                append(s.name)
+                s.position?.let { append(" — book $it") }
+            }
+            Text(header, style = MaterialTheme.typography.bodyMedium)
+            s.context?.takeIf { it.isNotBlank() }?.let {
+                Spacer(Modifier.height(4.dp))
+                Text(it, style = MaterialTheme.typography.bodySmall)
+            }
         }
     }
 }
 
 @Composable
-private fun ThemesCard(themes: List<String>, advisory: List<String>?) {
+private fun AnalysisCard(analysis: String) {
     QuireCard(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
         Column {
-            Text("Themes", style = MaterialTheme.typography.titleSmall)
+            Text("Themes & analysis", style = MaterialTheme.typography.titleSmall)
             Spacer(Modifier.height(4.dp))
-            Text(themes.joinToString(" · "), style = MaterialTheme.typography.bodyMedium)
-            advisory?.takeIf { it.isNotEmpty() }?.let {
-                Spacer(Modifier.height(6.dp))
-                Text(
-                    "Content advisory: ${it.joinToString(", ")}",
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
+            Text(analysis, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun ContentWarningsCard(warnings: List<String>) {
+    QuireCard(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        Column {
+            Text("Content warnings", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(4.dp))
+            Text(warnings.joinToString(" · "), style = MaterialTheme.typography.bodySmall)
         }
     }
 }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt
@@ -18,10 +18,6 @@ data class AiConfig(
 @Serializable
 data class AiStyle(
     val tone: String = "neutral",
-    val length: String = "standard",
-    @SerialName("author_focus") val authorFocus: String = "moderate",
-    @SerialName("include_spoilers") val includeSpoilers: Boolean = false,
-    val interests: List<String> = listOf("themes", "writing_style"),
 )
 
 @Serializable
@@ -48,29 +44,24 @@ data class Citation(
 data class AuthorInsight(
     val bio: String? = null,
     @SerialName("notable_works") val notableWorks: List<String>? = null,
-    val nationality: String? = null,
-    @SerialName("active_years") val activeYears: String? = null,
 )
 
 @Serializable
 data class SeriesInsight(
     val name: String,
     val position: Int? = null,
-    @SerialName("total_known") val totalKnown: Int? = null,
+    val context: String? = null,
 )
 
 @Serializable
 data class BookInsightPayload(
-    @SerialName("schema_version") val schemaVersion: Int = 1,
-    val summary: String? = null,
+    val intro: String? = null,
     val author: AuthorInsight? = null,
     val series: SeriesInsight? = null,
-    val themes: List<String>? = null,
-    val tone: String? = null,
-    @SerialName("content_advisory") val contentAdvisory: List<String>? = null,
-    @SerialName("suggested_for") val suggestedFor: String? = null,
+    val analysis: String? = null,
+    @SerialName("content_warnings") val contentWarnings: List<String>? = null,
     val confidence: String = "low",
-    val notes: String? = null,
+    @SerialName("schema_version") val schemaVersion: Int = 2,
 )
 
 @Serializable

--- a/data/ai/src/test/java/io/theficos/ereader/data/ai/AiClientTest.kt
+++ b/data/ai/src/test/java/io/theficos/ereader/data/ai/AiClientTest.kt
@@ -53,20 +53,19 @@ class AiClientTest {
     fun `getPreferences parses style`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
-                """{"ai_enabled":true,"style":{"tone":"scholarly","length":"standard","author_focus":"moderate","include_spoilers":false,"interests":["themes"]}}"""
+                """{"ai_enabled":true,"style":{"tone":"scholarly"}}"""
             )
         )
         val prefs = client.getPreferences()
         assertThat(prefs.aiEnabled).isTrue()
         assertThat(prefs.style.tone).isEqualTo("scholarly")
-        assertThat(prefs.style.interests).containsExactly("themes")
     }
 
     @Test
     fun `setPreferences sends PUT with body`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
-                """{"ai_enabled":true,"style":{"tone":"neutral","length":"standard","author_focus":"moderate","include_spoilers":false,"interests":["themes","writing_style"]}}"""
+                """{"ai_enabled":true,"style":{"tone":"neutral"}}"""
             )
         )
         val out = client.setPreferences(enabled = true)
@@ -81,7 +80,7 @@ class AiClientTest {
     fun `setPreferences with style only`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
-                """{"ai_enabled":true,"style":{"tone":"casual","length":"standard","author_focus":"moderate","include_spoilers":false,"interests":["themes","writing_style"]}}"""
+                """{"ai_enabled":true,"style":{"tone":"casual"}}"""
             )
         )
         client.setPreferences(style = AiStyle(tone = "casual"))
@@ -96,7 +95,7 @@ class AiClientTest {
     fun `lookupInsight serializes identity and bundle`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
-                """{"payload":{"schema_version":1,"summary":"hi","confidence":"high"},"sources":[],"model_id":"m","prompt_version":"1","generated_at":"2026-05-09T00:00:00+00:00"}"""
+                """{"payload":{"schema_version":2,"intro":"hi","confidence":"high"},"sources":[],"model_id":"m","prompt_version":"2","generated_at":"2026-05-09T00:00:00+00:00"}"""
             )
         )
         val bundle = MetadataBundle(title = "Foundation", author = "Isaac Asimov")
@@ -107,14 +106,14 @@ class AiClientTest {
         val req = server.takeRequest()
         assertThat(req.path).isEqualTo("/ai/v1/insights/lookup")
         assertThat(req.body.readUtf8()).contains("Foundation")
-        assertThat(out.payload.summary).isEqualTo("hi")
+        assertThat(out.payload.intro).isEqualTo("hi")
     }
 
     @Test
     fun `regenerateInsight sends reason`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
-                """{"payload":{"schema_version":1,"summary":"fixed","confidence":"high"},"sources":[],"model_id":"m","prompt_version":"1","generated_at":"2026-05-09T00:00:00+00:00"}"""
+                """{"payload":{"schema_version":2,"intro":"fixed","confidence":"high"},"sources":[],"model_id":"m","prompt_version":"2","generated_at":"2026-05-09T00:00:00+00:00"}"""
             )
         )
         val out = client.regenerateInsight(
@@ -125,7 +124,7 @@ class AiClientTest {
         val req = server.takeRequest()
         assertThat(req.path).isEqualTo("/ai/v1/insights/regenerate")
         assertThat(req.body.readUtf8()).contains("Author bio was wrong.")
-        assertThat(out.payload.summary).isEqualTo("fixed")
+        assertThat(out.payload.intro).isEqualTo("fixed")
     }
 
     @Test

--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -271,24 +271,25 @@ Returns the user-visible AI configuration. Public to authed users.
 
 ### `GET /ai/v1/preferences` / `PUT /ai/v1/preferences`
 
-Per-user opt-in flag plus style personalization knobs.
+Per-user opt-in flag plus a single personalization knob (`tone`). `tone`
+participates in the cache key for `book_insights` (via the `tone` column),
+so two users on the same instance with different tones get their own cached
+generations rather than one bleeding into the other.
 
 ```json
 {
   "ai_enabled": true,
   "style": {
-    "tone": "neutral",
-    "length": "standard",
-    "author_focus": "moderate",
-    "include_spoilers": false,
-    "interests": ["themes", "writing_style"]
+    "tone": "neutral"
   }
 }
 ```
 
+Allowed tones: `neutral`, `enthusiastic`, `scholarly`, `casual`.
+
 `PUT` accepts either field independently — send `{ "ai_enabled": true }` to flip
-the toggle without changing style, or `{ "style": { ... full AiStyle ... } }`
-to update preferences without touching opt-in. Response always returns the full
+the toggle without changing style, or `{ "style": { "tone": "scholarly" } }`
+to update tone without touching opt-in. Response always returns the full
 resolved state.
 
 ### `POST /ai/v1/insights/lookup`
@@ -307,6 +308,32 @@ header if the user's daily budget is exhausted. Body:
 Response: a `BookInsight` with `payload`, `sources`, `model_id`,
 `prompt_version`, `generated_at`. See `opds_sync/api/ai_schemas.py` for
 the full payload schema.
+
+`payload` is the structured `BookInsightPayload` (schema v2, the model
+generates keys in this order):
+
+```json
+{
+  "intro": "1-2 sentences saying what the book is and why it matters.",
+  "author": {
+    "bio": "Concise paragraph if confidence is high; otherwise null.",
+    "notable_works": ["…"]
+  },
+  "series": {
+    "name": "Foundation",
+    "position": 1,
+    "context": "Optional one-liner on how this volume fits."
+  },
+  "analysis": "One compact paragraph (~80–130 words) weaving synopsis, themes, tone, and reader fit.",
+  "content_warnings": ["graphic violence", "sexual content"],
+  "confidence": "high|medium|low",
+  "schema_version": 2
+}
+```
+
+`content_warnings` is scoped to concrete reader-safety concerns
+(violence, sexual content, abuse, self-harm, slurs, addiction, body horror) —
+**not** themes, genre, politics, or plot mechanics.
 
 ### `POST /ai/v1/insights/regenerate`
 

--- a/server/migrations/versions/0004_ai_insight_tone.py
+++ b/server/migrations/versions/0004_ai_insight_tone.py
@@ -1,0 +1,70 @@
+"""book_insights: add tone to cache key
+
+Tone is the only AiStyle field that affects model output (per Phase 1.5 design).
+Adding it to `book_insights` plus the partial unique indexes makes per-tone
+generations cacheable separately without one tone leaking into another.
+
+Existing rows are backfilled to 'neutral' (the default).
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-05-15 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "book_insights",
+        sa.Column(
+            "tone",
+            sa.String(),
+            nullable=False,
+            server_default=sa.text("'neutral'"),
+        ),
+    )
+
+    op.drop_index("uq_book_insights_content_hash_model_prompt", table_name="book_insights")
+    op.drop_index("uq_book_insights_metadata_id_model_prompt", table_name="book_insights")
+
+    op.create_index(
+        "uq_book_insights_content_hash_model_prompt_tone",
+        "book_insights",
+        ["content_hash", "model_id", "prompt_version", "tone"],
+        unique=True,
+        postgresql_where=sa.text("superseded_at IS NULL"),
+    )
+    op.create_index(
+        "uq_book_insights_metadata_id_model_prompt_tone",
+        "book_insights",
+        ["metadata_id", "model_id", "prompt_version", "tone"],
+        unique=True,
+        postgresql_where=sa.text("metadata_id IS NOT NULL AND superseded_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_book_insights_metadata_id_model_prompt_tone", table_name="book_insights")
+    op.drop_index("uq_book_insights_content_hash_model_prompt_tone", table_name="book_insights")
+    op.create_index(
+        "uq_book_insights_metadata_id_model_prompt",
+        "book_insights",
+        ["metadata_id", "model_id", "prompt_version"],
+        unique=True,
+        postgresql_where=sa.text("metadata_id IS NOT NULL AND superseded_at IS NULL"),
+    )
+    op.create_index(
+        "uq_book_insights_content_hash_model_prompt",
+        "book_insights",
+        ["content_hash", "model_id", "prompt_version"],
+        unique=True,
+        postgresql_where=sa.text("superseded_at IS NULL"),
+    )
+    op.drop_column("book_insights", "tone")

--- a/server/opds_sync/api/ai.py
+++ b/server/opds_sync/api/ai.py
@@ -59,13 +59,18 @@ async def _require_opt_in(session: AsyncSession, user_id: str) -> UserAIPreferen
 
 
 def _style_from_pref(pref: UserAIPreference) -> AiStyle:
-    """Build a validated AiStyle from the user's stored prefs, falling back to defaults."""
+    """Build a validated AiStyle from the user's stored prefs, falling back to defaults.
+
+    Tolerates prefs rows from older schema versions (which carried extra fields
+    like `length` / `author_focus`) by extracting only the keys AiStyle knows.
+    """
     if not pref.style:
         return AiStyle()
+    raw = pref.style if isinstance(pref.style, dict) else {}
+    filtered = {k: v for k, v in raw.items() if k in AiStyle.model_fields}
     try:
-        return AiStyle.model_validate(pref.style)
+        return AiStyle.model_validate(filtered)
     except Exception:
-        # Old / malformed prefs row → use defaults rather than 500-ing the read.
         return AiStyle()
 
 
@@ -200,7 +205,11 @@ async def get_insight(
     orch = _orchestrator(request)
     if orch is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="ai_disabled")
-    out = await orch.get(session, body.identity)
+    pref = (
+        await session.execute(select(UserAIPreference).where(UserAIPreference.user_id == user_id))
+    ).scalar_one_or_none()
+    style = _style_from_pref(pref) if pref is not None else AiStyle()
+    out = await orch.get(session, body.identity, style=style)
     if out is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="not_cached")
     return out

--- a/server/opds_sync/api/ai_schemas.py
+++ b/server/opds_sync/api/ai_schemas.py
@@ -38,33 +38,37 @@ class Citation(BaseModel):
 
 
 class AuthorInsight(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     bio: str | None = None
     notable_works: list[str] | None = None
-    nationality: str | None = None
-    active_years: str | None = None
 
 
 class SeriesInsight(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     position: int | None = None
-    total_known: int | None = None
+    context: str | None = None
 
 
 class BookInsightPayload(BaseModel):
-    """The structured body of a book insight. Stored verbatim in book_insights.payload."""
+    """The structured body of a book insight. Stored verbatim in book_insights.payload.
 
-    model_config = ConfigDict(extra="forbid")  # tighten the model contract
+    Field order is the reading order for BookDetailScreen — the model is
+    instructed to generate keys in declared order, which keeps the streaming
+    narrative coherent (intro before analysis, etc.).
+    """
 
-    schema_version: int = 1
-    summary: str | None = None
+    model_config = ConfigDict(extra="forbid")
+
+    intro: str | None = None
     author: AuthorInsight | None = None
     series: SeriesInsight | None = None
-    themes: list[str] | None = None
-    tone: str | None = None
-    content_advisory: list[str] | None = None
-    suggested_for: str | None = None
+    analysis: str | None = None
+    content_warnings: list[str] | None = None
     confidence: Literal["high", "medium", "low"] = "low"
-    notes: str | None = None
+    schema_version: int = 2
 
 
 class BookInsightResponse(BaseModel):
@@ -103,19 +107,15 @@ class InsightRegenerateBody(BaseModel):
 
 
 class AiStyle(BaseModel):
-    """User-facing personalization knobs. Deliberately small; extend via JSON migration-free.
-
-    `interests` is a free-form list (e.g. ["themes", "writing_style", "historical_context",
-    "comparable_books"]). The prompt composer turns it into a short "focus on …" line.
+    """User-facing personalization. `tone` is the only knob that affects output:
+    it participates in the cache key (column `book_insights.tone`), so two users
+    on the same instance with different tones get separately-cached generations
+    rather than one bleeding into the other.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     tone: Literal["neutral", "enthusiastic", "scholarly", "casual"] = "neutral"
-    length: Literal["brief", "standard", "deep"] = "standard"
-    author_focus: Literal["none", "moderate", "detailed"] = "moderate"
-    include_spoilers: bool = False
-    interests: list[str] = Field(default_factory=lambda: ["themes", "writing_style"])
 
 
 class ConfigResponse(BaseModel):

--- a/server/opds_sync/core/ai/prompts.py
+++ b/server/opds_sync/core/ai/prompts.py
@@ -9,65 +9,50 @@ from __future__ import annotations
 
 from opds_sync.api.ai_schemas import AiStyle, Citation, MetadataBundle
 
-PROMPT_VERSION = "1"
+PROMPT_VERSION = "2"
 
-# `style` and `feedback` deliberately do NOT participate in the cache key
-# (PROMPT_VERSION is the only knob there). Personalization is a presentation
-# concern; if quality is poor the user regenerates, which writes a new row
-# under a new id but the same (content_hash, model_id, prompt_version) — the
-# old row is marked superseded by the orchestrator.
+# `tone` (from AiStyle) participates in the cache key via the `book_insights.tone`
+# column, so emitting tone-specific instructions in the prompt is safe across
+# users. `feedback` does NOT participate in the cache key — it's a one-shot input
+# on /insights/regenerate that produces a new row marked superseded against the
+# previous one.
 
-SYSTEM_PROMPT = """You write structured insights about books for a privacy-first reading app.
+SYSTEM_PROMPT = (
+    "You write cached, user-agnostic book insights for Quire, a privacy-first reading app.\n"
+    "\n"
+    "JSON key order matters. Generate keys in this order: intro, author, series, analysis,"
+    " content_warnings, confidence.\n"
+    "\n"
+    "Rules:\n"
+    "- Use the supplied EPUB metadata as the work's identity. If metadata names a series,"
+    " copy `name` and `position` exactly.\n"
+    "- If metadata has no series, fill `series` only when a cited source or clearly canonical"
+    " knowledge makes the series name and position unambiguous. Otherwise omit it (null).\n"
+    "- Be conservative with author identity. Fill `author` only when you have high confidence"
+    " the supplied author matches the cited sources or a well-known author. Otherwise leave"
+    " it null.\n"
+    "- `intro`: 1-2 sentences saying what the book is and why a reader might care. No spoilers"
+    " past the inciting incident.\n"
+    "- `analysis`: one compact paragraph, ~80-130 words, weaving together a short synopsis,"
+    ' the major themes, the tone or style, and a one-line "you\'ll like this if…" pointer.'
+    " Avoid bullet lists; keep it readable.\n"
+    "- `content_warnings`: only concrete reader-safety concerns — graphic violence, sexual"
+    " content, abuse, self-harm, racism or slurs, addiction, body horror. Do NOT list themes,"
+    " genre, politics, or plot mechanics here.\n"
+    '- `confidence`: "high" only when at least one external citation grounds the central'
+    ' book claims; "medium" when metadata plus reliable training knowledge is enough;'
+    ' "low" otherwise.\n'
+    "- Output strict JSON conforming exactly to the supplied JSON schema. No prose, no"
+    " markdown, no code fences."
+)
 
-Goals:
-- Help the reader understand what a book is, who wrote it, where it sits in
-  the author's body of work, and whether it's part of a series.
-- Provide useful but cautious analysis: themes, tone, content advisories,
-  and a one-line "you'll like this if..." pointer.
 
-Rules:
-- Only assert things you can support from the supplied metadata, the cited
-  external sources, or your own training knowledge. Where a field is unknown
-  or uncertain, return null instead of inventing it.
-- If a series is named in the metadata, treat that as authoritative — do not
-  override it.
-- Author biography in particular is high-risk: only fill it when you have
-  high confidence in the identity of the author. Otherwise leave the author
-  fields null.
-- Set `confidence` to "high" only if at least one external citation grounds
-  the central claims about the book; "medium" if you have only the metadata
-  to work from; "low" otherwise.
-- Output strict JSON conforming exactly to the supplied JSON schema. No
-  prose, no markdown, no code fences."""
-
-
-_DEFAULT_STYLE = AiStyle()
-
-
-def _style_block(style: AiStyle) -> list[str]:
-    """Emit a short style guide. Returns [] if style is the default — keep tokens lean."""
-    if style == _DEFAULT_STYLE:
-        return []
-    lines = ["", "## Style preferences (apply to summary, themes, suggested_for)"]
-    lines.append(f"- Tone: {style.tone}")
-    lines.append(
-        {
-            "brief": "- Length: keep it short — 2-3 sentence summary, terse themes.",
-            "standard": "- Length: standard — 4-6 sentence summary.",
-            "deep": "- Length: deep dive — 6-10 sentences, richer themes.",
-        }[style.length]
-    )
-    if style.author_focus == "none":
-        lines.append("- Author: leave author fields null.")
-    elif style.author_focus == "detailed":
-        lines.append("- Author: detailed — fill bio, nationality, active years, notable works.")
-    if style.include_spoilers:
-        lines.append("- Spoilers: permitted — discuss plot points freely.")
-    else:
-        lines.append("- Spoilers: avoid — no plot points past the inciting incident.")
-    if style.interests:
-        lines.append(f"- Focus on: {', '.join(style.interests)}.")
-    return lines
+_TONE_HINT = {
+    "neutral": "",
+    "enthusiastic": "Tone: warm, energetic, a recommender's voice — without overselling.",
+    "scholarly": "Tone: precise and analytical, comfortable with literary terms.",
+    "casual": "Tone: conversational and direct, like a friend with good taste.",
+}
 
 
 def compose_user_prompt(
@@ -84,6 +69,10 @@ def compose_user_prompt(
     lines.append(f"- Title: {bundle.title}")
     if bundle.author:
         lines.append(f"- Author: {bundle.author}")
+    if bundle.series_name:
+        position = bundle.series_position
+        pos_text = f", book {position}" if position is not None else ""
+        lines.append(f"- Series (authoritative — do not override): {bundle.series_name}{pos_text}")
     if bundle.language:
         lines.append(f"- Language: {bundle.language}")
     if bundle.publisher:
@@ -97,10 +86,6 @@ def compose_user_prompt(
     if bundle.description:
         lines.append("- Publisher description:")
         lines.append(f"  > {bundle.description.strip()}")
-    if bundle.series_name:
-        position = bundle.series_position
-        pos_text = f", book {position}" if position is not None else ""
-        lines.append(f"- Series (authoritative — do not override): {bundle.series_name}{pos_text}")
 
     if citations:
         lines.append("")
@@ -112,23 +97,25 @@ def compose_user_prompt(
                 "opf": "OPF metadata",
                 "model": "Model knowledge",
             }.get(c.kind, c.kind.capitalize())
-            url = f" <{c.url}>" if c.url else ""
-            lines.append(f"- {label}: {c.title}{url}")
+            lines.append(f"- {label}: {c.title}")
             if c.snippet:
                 lines.append(f"  > {c.snippet.strip()}")
 
     if style is not None:
-        lines.extend(_style_block(style))
+        hint = _TONE_HINT.get(style.tone, "")
+        if hint:
+            lines.append("")
+            lines.append(hint)
 
     if feedback:
         lines.append("")
         lines.append("## User feedback on the previous attempt")
         lines.append(f"> {feedback.strip()}")
-        lines.append("Address the feedback above when generating this new version.")
+        lines.append(
+            "Apply factual or coverage corrections. Ignore tone, length, or "
+            "personalization requests — those are handled separately."
+        )
 
     lines.append("")
-    lines.append(
-        "Return a single JSON object matching the BookInsightPayload schema. "
-        "If the series is given above, copy it verbatim into the `series` field."
-    )
+    lines.append("Return BookInsightPayload JSON only.")
     return "\n".join(lines)

--- a/server/opds_sync/core/ai/service.py
+++ b/server/opds_sync/core/ai/service.py
@@ -118,9 +118,14 @@ class InsightOrchestrator:
     # ------- public API -------
 
     async def get(
-        self, session: AsyncSession, ident: DocumentIdentity
+        self,
+        session: AsyncSession,
+        ident: DocumentIdentity,
+        *,
+        style: AiStyle | None = None,
     ) -> BookInsightResponse | None:
-        row = await self._cache_lookup(session, ident, allow_backfill=False)
+        tone = _tone_of(style)
+        row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=False)
         if row is None:
             return None
         return self._row_to_response(row)
@@ -134,13 +139,14 @@ class InsightOrchestrator:
         user_id: str,
         style: AiStyle | None = None,
     ) -> BookInsightResponse:
-        row = await self._cache_lookup(session, ident, allow_backfill=True)
+        tone = _tone_of(style)
+        row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=True)
         if row is not None:
             return self._row_to_response(row)
 
-        lock = await self._acquire_identity_lock(ident)
+        lock = await self._acquire_identity_lock(ident, tone=tone)
         async with lock:
-            row = await self._cache_lookup(session, ident, allow_backfill=True)
+            row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=True)
             if row is not None:
                 return self._row_to_response(row)
 
@@ -152,6 +158,7 @@ class InsightOrchestrator:
                 bundle,
                 user_id=user_id,
                 style=style,
+                tone=tone,
                 feedback=None,
                 previous_insight_ids=None,
             )
@@ -168,9 +175,10 @@ class InsightOrchestrator:
         style: AiStyle | None = None,
     ) -> BookInsightResponse:
         """Supersede the existing live row (if any) and generate a fresh one."""
-        lock = await self._acquire_identity_lock(ident)
+        tone = _tone_of(style)
+        lock = await self._acquire_identity_lock(ident, tone=tone)
         async with lock:
-            existing = await self._cache_lookup(session, ident, allow_backfill=False)
+            existing = await self._cache_lookup(session, ident, tone=tone, allow_backfill=False)
             previous_ids: list[int] = []
             if existing is not None:
                 previous_ids = list(existing.previous_insight_ids or [])
@@ -186,6 +194,7 @@ class InsightOrchestrator:
                 bundle,
                 user_id=user_id,
                 style=style,
+                tone=tone,
                 feedback=reason,
                 previous_insight_ids=previous_ids or None,
             )
@@ -217,6 +226,7 @@ class InsightOrchestrator:
         *,
         user_id: str,
         style: AiStyle | None,
+        tone: str,
         feedback: str | None,
         previous_insight_ids: list[int] | None,
     ) -> BookInsight:
@@ -253,6 +263,7 @@ class InsightOrchestrator:
             content_hash=ident.content_hash,
             model_id=self.model_id,
             prompt_version=self.prompt_version,
+            tone=tone,
             sources_used=list({c.kind for c in citations}),
             payload=payload.model_dump(),
             sources=[c.model_dump() for c in sources],
@@ -331,6 +342,7 @@ class InsightOrchestrator:
         session: AsyncSession,
         ident: DocumentIdentity,
         *,
+        tone: str,
         allow_backfill: bool,
     ) -> BookInsight | None:
         # Step 1: by metadata_id (live rows only)
@@ -341,6 +353,7 @@ class InsightOrchestrator:
                         BookInsight.metadata_id == ident.metadata_id,
                         BookInsight.model_id == self.model_id,
                         BookInsight.prompt_version == self.prompt_version,
+                        BookInsight.tone == tone,
                         BookInsight.superseded_at.is_(None),
                     )
                 )
@@ -354,6 +367,7 @@ class InsightOrchestrator:
                     BookInsight.content_hash == ident.content_hash,
                     BookInsight.model_id == self.model_id,
                     BookInsight.prompt_version == self.prompt_version,
+                    BookInsight.tone == tone,
                     BookInsight.superseded_at.is_(None),
                 )
             )
@@ -367,8 +381,10 @@ class InsightOrchestrator:
             await session.refresh(row)
         return row
 
-    async def _acquire_identity_lock(self, ident: DocumentIdentity) -> asyncio.Lock:
-        key = ident.metadata_id or ident.content_hash
+    async def _acquire_identity_lock(self, ident: DocumentIdentity, *, tone: str) -> asyncio.Lock:
+        # Per-(identity, tone): two users with different tones generating the
+        # same book in parallel should not serialize through one lock.
+        key = f"{ident.metadata_id or ident.content_hash}|{tone}"
         async with self._locks_master:
             lock = self._locks.get(key)
             if lock is None:
@@ -388,3 +404,7 @@ class InsightOrchestrator:
 
 def _next_utc_midnight(today: date) -> datetime:
     return datetime.combine(today + timedelta(days=1), datetime.min.time(), tzinfo=UTC)
+
+
+def _tone_of(style: AiStyle | None) -> str:
+    return style.tone if style is not None else "neutral"

--- a/server/opds_sync/db/models.py
+++ b/server/opds_sync/db/models.py
@@ -77,6 +77,11 @@ class BookInsight(Base):
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
     model_id: Mapped[str] = mapped_column(String, nullable=False)
     prompt_version: Mapped[str] = mapped_column(String, nullable=False)
+    # Part of the cache key so users with different AiStyle.tone get their own
+    # generations (`neutral` is the universal default).
+    tone: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("'neutral'"), default="neutral"
+    )
     sources_used: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False)
     payload: Mapped[dict] = mapped_column(JSON, nullable=False)
     sources: Mapped[list[dict]] = mapped_column(JSON, nullable=False)

--- a/server/tests/integration/test_ai_endpoints.py
+++ b/server/tests/integration/test_ai_endpoints.py
@@ -118,7 +118,7 @@ async def test_config_endpoint_when_enabled(client_factory):
 async def test_lookup_blocked_when_not_opted_in(client_factory, configure_ai, app):
     async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
         # Now that client_factory has populated app, install the fake AI.
-        configure_ai(app, {"schema_version": 1, "summary": "ok", "confidence": "low"})
+        configure_ai(app, {"schema_version": 2, "intro": "ok", "confidence": "low"})
         r = await client.post(
             "/ai/v1/insights/lookup",
             headers=_basic_header("alice"),
@@ -137,7 +137,7 @@ async def test_lookup_generates_then_get_serves_from_cache(
     async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
         configure_ai(
             app,
-            {"schema_version": 1, "summary": "Foundational sci-fi.", "confidence": "high"},
+            {"schema_version": 2, "intro": "Foundational sci-fi.", "confidence": "high"},
         )
 
         # Opt alice in.
@@ -156,7 +156,7 @@ async def test_lookup_generates_then_get_serves_from_cache(
         # Alice generates an insight.
         r1 = await client.post("/ai/v1/insights/lookup", headers=_basic_header("alice"), json=body)
         assert r1.status_code == 200
-        assert r1.json()["payload"]["summary"] == "Foundational sci-fi."
+        assert r1.json()["payload"]["intro"] == "Foundational sci-fi."
 
         # Bob is not opted in: lookup must 409.
         r2 = await client.post("/ai/v1/insights/lookup", headers=_basic_header("bob"), json=body)
@@ -170,12 +170,12 @@ async def test_lookup_generates_then_get_serves_from_cache(
             json={"identity": {"metadata_id": "9780553293357", "content_hash": "ch1"}},
         )
         assert r3.status_code == 200
-        assert r3.json()["payload"]["summary"] == "Foundational sci-fi."
+        assert r3.json()["payload"]["intro"] == "Foundational sci-fi."
 
 
 async def test_invalidate_drops_cache(client_factory, configure_ai, app, session):
     async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
-        configure_ai(app, {"schema_version": 1, "summary": "v1", "confidence": "low"})
+        configure_ai(app, {"schema_version": 2, "intro": "first version", "confidence": "low"})
 
         await client.put(
             "/ai/v1/preferences",

--- a/server/tests/unit/test_ai_client.py
+++ b/server/tests/unit/test_ai_client.py
@@ -24,8 +24,8 @@ def _make_chat_response(content: str) -> dict:
 @pytest.mark.asyncio
 async def test_chat_structured_returns_validated_payload():
     payload = {
-        "schema_version": 1,
-        "summary": "A foundational sci-fi novel.",
+        "schema_version": 2,
+        "intro": "A foundational sci-fi novel.",
         "confidence": "high",
     }
     handler = httpx.MockTransport(
@@ -44,13 +44,13 @@ async def test_chat_structured_returns_validated_payload():
         timeout_s=5.0,
     )
     assert isinstance(result, BookInsightPayload)
-    assert result.summary == "A foundational sci-fi novel."
+    assert result.intro == "A foundational sci-fi novel."
 
 
 @pytest.mark.asyncio
 async def test_chat_structured_retries_once_on_validation_error():
-    bad = {"schema_version": 1, "summary": 42}  # summary must be str|None
-    good = {"schema_version": 1, "summary": "ok", "confidence": "low"}
+    bad = {"schema_version": 2, "intro": 42}  # intro must be str|None
+    good = {"schema_version": 2, "intro": "ok", "confidence": "low"}
     seen: list[str] = []
 
     def handler(req: httpx.Request) -> httpx.Response:
@@ -68,14 +68,14 @@ async def test_chat_structured_retries_once_on_validation_error():
     out = await client.chat_structured(
         system="s", user="u", schema=BookInsightPayload, timeout_s=5.0
     )
-    assert out.summary == "ok"
+    assert out.intro == "ok"
     assert len(seen) == 2
     assert "validation" in seen[1].lower()
 
 
 @pytest.mark.asyncio
 async def test_chat_structured_raises_after_two_validation_failures():
-    bad = {"schema_version": 1, "summary": 42}
+    bad = {"schema_version": 2, "intro": 42}
     handler = httpx.MockTransport(
         lambda req: httpx.Response(200, json=_make_chat_response(json.dumps(bad)))
     )
@@ -107,7 +107,7 @@ async def test_authorization_header_sent_when_key_present():
         seen["auth"] = req.headers.get("Authorization")
         return httpx.Response(
             200,
-            json=_make_chat_response(json.dumps({"schema_version": 1, "confidence": "low"})),
+            json=_make_chat_response(json.dumps({"schema_version": 2, "confidence": "low"})),
         )
 
     client = AIClient(
@@ -128,7 +128,7 @@ async def test_no_auth_header_when_key_absent():
         seen["auth"] = req.headers.get("Authorization")
         return httpx.Response(
             200,
-            json=_make_chat_response(json.dumps({"schema_version": 1, "confidence": "low"})),
+            json=_make_chat_response(json.dumps({"schema_version": 2, "confidence": "low"})),
         )
 
     client = AIClient(

--- a/server/tests/unit/test_ai_prompts.py
+++ b/server/tests/unit/test_ai_prompts.py
@@ -6,9 +6,9 @@ from opds_sync.core.ai.prompts import (
 )
 
 
-def test_prompt_version_is_string():
-    assert isinstance(PROMPT_VERSION, str)
-    assert PROMPT_VERSION  # non-empty
+def test_prompt_version_is_v2():
+    """v2 schema requires v2 prompt — they share a cache key."""
+    assert PROMPT_VERSION == "2"
 
 
 def test_user_prompt_includes_metadata_fields():
@@ -27,7 +27,7 @@ def test_user_prompt_includes_metadata_fields():
     assert "Science Fiction" in text
 
 
-def test_user_prompt_includes_citations():
+def test_user_prompt_includes_citations_but_strips_urls():
     bundle = MetadataBundle(title="Foundation")
     cite = Citation(
         kind="wikipedia",
@@ -36,8 +36,11 @@ def test_user_prompt_includes_citations():
         snippet="Foundation is a 1951 science fiction novel by Isaac Asimov.",
     )
     text = compose_user_prompt(bundle, citations=[cite])
-    assert "Wikipedia" in text or "wikipedia" in text
+    assert "Wikipedia" in text
     assert "1951 science fiction novel" in text
+    # URLs belong in the structured `sources` field returned by the server,
+    # not in the prompt body — saves tokens.
+    assert "https://" not in text
 
 
 def test_user_prompt_marks_series_authoritative_when_in_bundle():
@@ -53,29 +56,23 @@ def test_user_prompt_marks_series_authoritative_when_in_bundle():
 
 
 def test_system_prompt_describes_role_and_output_constraints():
-    assert "book" in SYSTEM_PROMPT.lower()
-    assert "json" in SYSTEM_PROMPT.lower()
+    low = SYSTEM_PROMPT.lower()
+    assert "book" in low
+    assert "json" in low
+    # Reading order is load-bearing for the UI.
+    assert "intro" in low and "analysis" in low and "content_warnings" in low
+    # Reader-safety scope for warnings (not themes).
+    assert "warnings" in low
 
 
-def test_style_block_emitted_when_non_default():
+def test_tone_hint_emitted_when_non_default():
     bundle = MetadataBundle(title="Foundation")
-    style = AiStyle(
-        tone="scholarly",
-        length="deep",
-        author_focus="detailed",
-        include_spoilers=True,
-        interests=["historical_context"],
-    )
-    text = compose_user_prompt(bundle, citations=[], style=style)
-    low = text.lower()
-    assert "scholarly" in low
-    assert "deep" in low or "detailed" in low
-    assert "historical_context" in low or "historical context" in low
-    assert "spoiler" in low  # spoilers permitted line
+    text = compose_user_prompt(bundle, citations=[], style=AiStyle(tone="scholarly"))
+    assert "scholarly" in text.lower() or "analytical" in text.lower()
 
 
-def test_style_omitted_when_all_defaults():
-    """Defaults must not bloat the prompt — quota matters."""
+def test_tone_hint_omitted_when_default():
+    """Default tone must not bloat the prompt — quota matters."""
     bundle = MetadataBundle(title="Foundation")
     text_no_style = compose_user_prompt(bundle, citations=[])
     text_default_style = compose_user_prompt(bundle, citations=[], style=AiStyle())
@@ -85,5 +82,14 @@ def test_style_omitted_when_all_defaults():
 def test_feedback_block_appended_on_regeneration():
     bundle = MetadataBundle(title="Foundation")
     text = compose_user_prompt(bundle, citations=[], feedback="Author bio was wrong.")
-    assert "feedback" in text.lower()
+    low = text.lower()
+    assert "feedback" in low
     assert "Author bio was wrong." in text
+    # Regenerate feedback is for factual fixes, not personalization.
+    assert "factual" in low or "corrections" in low
+
+
+def test_trailing_instruction_is_concise():
+    bundle = MetadataBundle(title="Foundation")
+    text = compose_user_prompt(bundle, citations=[])
+    assert text.rstrip().endswith("Return BookInsightPayload JSON only.")

--- a/server/tests/unit/test_ai_schemas.py
+++ b/server/tests/unit/test_ai_schemas.py
@@ -2,8 +2,11 @@ import pytest
 from pydantic import ValidationError
 
 from opds_sync.api.ai_schemas import (
+    AiStyle,
     BookInsightPayload,
     InsightLookupBody,
+    InsightRegenerateBody,
+    SeriesInsight,
 )
 
 
@@ -11,13 +14,48 @@ def test_payload_round_trip_minimal():
     p = BookInsightPayload(confidence="high")
     again = BookInsightPayload.model_validate_json(p.model_dump_json())
     assert again.confidence == "high"
-    assert again.schema_version == 1
-    assert again.summary is None
+    assert again.schema_version == 2
+    assert again.intro is None
+    assert again.analysis is None
 
 
 def test_payload_extra_fields_rejected():
     with pytest.raises(ValidationError):
-        BookInsightPayload.model_validate({"schema_version": 1, "fictional_field": "no"})
+        BookInsightPayload.model_validate({"schema_version": 2, "fictional_field": "no"})
+
+
+def test_payload_dropped_v1_fields_rejected():
+    # v1 had summary/themes/tone/suggested_for/notes — none should validate under v2.
+    for stale in ("summary", "themes", "tone", "suggested_for", "notes", "content_advisory"):
+        with pytest.raises(ValidationError):
+            BookInsightPayload.model_validate({stale: "x"})
+
+
+def test_payload_key_order_matches_reading_order():
+    """Schema field order steers the model's generation order on response_format."""
+    keys = list(BookInsightPayload.model_fields.keys())
+    expected = [
+        "intro",
+        "author",
+        "series",
+        "analysis",
+        "content_warnings",
+        "confidence",
+        "schema_version",
+    ]
+    assert keys == expected
+
+
+def test_series_insight_accepts_context():
+    s = SeriesInsight.model_validate(
+        {"name": "Foundation", "position": 1, "context": "Book 1 of 7."}
+    )
+    assert s.context == "Book 1 of 7."
+
+
+def test_series_insight_rejects_v1_total_known():
+    with pytest.raises(ValidationError):
+        SeriesInsight.model_validate({"name": "Foundation", "total_known": 7})
 
 
 def test_lookup_body_requires_content_hash():
@@ -38,27 +76,24 @@ def test_lookup_body_metadata_id_optional():
     assert b.bundle.title == "Foundation"
 
 
-def test_style_defaults():
-    from opds_sync.api.ai_schemas import AiStyle
-
+def test_style_only_tone_remains():
     s = AiStyle()
     assert s.tone == "neutral"
-    assert s.length == "standard"
-    assert s.author_focus == "moderate"
-    assert s.include_spoilers is False
-    assert "themes" in s.interests
+    assert list(AiStyle.model_fields.keys()) == ["tone"]
 
 
 def test_style_rejects_unknown_tone():
-    from opds_sync.api.ai_schemas import AiStyle
-
     with pytest.raises(ValidationError):
         AiStyle.model_validate({"tone": "snarky"})
 
 
-def test_regenerate_requires_reason():
-    from opds_sync.api.ai_schemas import InsightRegenerateBody
+def test_style_rejects_v1_knobs():
+    for stale in ("length", "author_focus", "include_spoilers", "interests"):
+        with pytest.raises(ValidationError):
+            AiStyle.model_validate({"tone": "neutral", stale: "anything"})
 
+
+def test_regenerate_requires_reason():
     with pytest.raises(ValidationError):
         InsightRegenerateBody.model_validate(
             {

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -19,8 +19,9 @@ class FakeAIClient:
     def __init__(self) -> None:
         self.calls: list[dict] = []
         self.next_payload: dict[str, Any] = {
-            "schema_version": 1,
-            "summary": "A foundational sci-fi novel.",
+            "schema_version": 2,
+            "intro": "A foundational sci-fi novel.",
+            "analysis": "Asimov's Foundation imagines a galactic empire on the brink of collapse.",
             "confidence": "high",
         }
 
@@ -72,7 +73,7 @@ async def test_cache_hit_short_circuits(session: AsyncSession, make_orchestrator
     second_orch = make_orchestrator()
     second = await second_orch.generate(session, ident, bundle, user_id="u2")
 
-    assert first.payload.summary == second.payload.summary
+    assert first.payload.intro == second.payload.intro
     assert second_orch.ai.calls == []
     assert second_orch.retriever.wiki_calls == 0
 
@@ -112,7 +113,7 @@ async def test_concurrent_generations_collapse_to_one_model_call(
         orch.generate(session, ident, bundle, user_id="u3"),
     )
     assert len(orch.ai.calls) == 1
-    assert {r.payload.summary for r in results} == {"A foundational sci-fi novel."}
+    assert {r.payload.intro for r in results} == {"A foundational sci-fi novel."}
 
 
 @pytest.mark.asyncio
@@ -125,9 +126,9 @@ async def test_invalidate_drops_cached_row(session: AsyncSession, make_orchestra
     assert n == 1
 
     second = make_orchestrator()
-    second.ai.next_payload = {"schema_version": 1, "summary": "fresh", "confidence": "low"}
+    second.ai.next_payload = {"schema_version": 2, "intro": "fresh", "confidence": "low"}
     out = await second.generate(session, ident, MetadataBundle(title="X"), user_id="u1")
-    assert out.payload.summary == "fresh"
+    assert out.payload.intro == "fresh"
 
 
 @pytest.mark.asyncio
@@ -141,8 +142,8 @@ async def test_get_returns_none_on_miss(session: AsyncSession, make_orchestrator
 async def test_series_from_bundle_persists_into_payload(session: AsyncSession, make_orchestrator):
     orch = make_orchestrator()
     orch.ai.next_payload = {
-        "schema_version": 1,
-        "summary": "ok",
+        "schema_version": 2,
+        "intro": "ok",
         "series": {"name": "WrongName", "position": 99},
         "confidence": "low",
     }
@@ -187,7 +188,7 @@ async def test_cache_hits_bypass_budget(session, make_orchestrator):
     ident = DocumentIdentity(metadata_id=None, content_hash="ch-cache-hit")
     await orch.generate(session, ident, MetadataBundle(title="X"), user_id="u-cache")
     out = await orch.generate(session, ident, MetadataBundle(title="X"), user_id="u-cache")
-    assert out.payload.summary == "A foundational sci-fi novel."
+    assert out.payload.intro == "A foundational sci-fi novel."
 
 
 @pytest.mark.asyncio
@@ -195,7 +196,7 @@ async def test_regenerate_supersedes_and_records_lineage(session, make_orchestra
     orch = make_orchestrator()
     ident = DocumentIdentity(metadata_id=None, content_hash="ch-regen")
     await orch.generate(session, ident, MetadataBundle(title="X"), user_id="u1")
-    orch.ai.next_payload = {"schema_version": 1, "summary": "fixed", "confidence": "high"}
+    orch.ai.next_payload = {"schema_version": 2, "intro": "fixed", "confidence": "high"}
     second = await orch.regenerate(
         session,
         ident,
@@ -203,7 +204,7 @@ async def test_regenerate_supersedes_and_records_lineage(session, make_orchestra
         user_id="u1",
         reason="Author bio was wrong.",
     )
-    assert second.payload.summary == "fixed"
+    assert second.payload.intro == "fixed"
 
     rows = (
         (
@@ -246,6 +247,40 @@ async def test_style_threaded_into_prompt(session, make_orchestrator):
         ident,
         MetadataBundle(title="X"),
         user_id="u-style",
-        style=AiStyle(tone="scholarly", include_spoilers=True),
+        style=AiStyle(tone="scholarly"),
     )
-    assert any("scholarly" in call["user"].lower() for call in orch.ai.calls)
+    assert any(
+        "scholarly" in call["user"].lower() or "analytical" in call["user"].lower()
+        for call in orch.ai.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_different_tones_generate_separate_cache_rows(session, make_orchestrator):
+    """Two users with different tones must get their own rows — no cross-tone leak."""
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-tones")
+    bundle = MetadataBundle(title="X")
+
+    await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(tone="neutral"))
+    await orch.generate(session, ident, bundle, user_id="u2", style=AiStyle(tone="scholarly"))
+
+    rows = (
+        (await session.execute(select(BookInsight).where(BookInsight.content_hash == "ch-tones")))
+        .scalars()
+        .all()
+    )
+    assert {r.tone for r in rows} == {"neutral", "scholarly"}
+    assert len(orch.ai.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_same_tone_shares_cache_across_users(session, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-shared-tone")
+    bundle = MetadataBundle(title="X")
+
+    await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(tone="scholarly"))
+    await orch.generate(session, ident, bundle, user_id="u2", style=AiStyle(tone="scholarly"))
+
+    assert len(orch.ai.calls) == 1


### PR DESCRIPTION
## Summary

Reshapes the AI book-insight payload after a real-cluster smoke and an Architect review surfaced two issues with v1:

1. **Fragmented analysis.** The flat 9-field layout split synopsis-adjacent content across `summary` / `themes` / `tone` / `suggested_for` / `notes`, which costs schema slots, reads poorly top-down, and produced miscategorised `content_advisory` entries (the live smoke had \"Political intrigue\" landing in advisories — that's a theme, not a reader-safety concern).
2. **Cache-leak vector in `AiStyle`.** Tone was baked into the prompt but **not** part of the cache key, so one user's \"scholarly\" generation could be served to another user who'd set \"casual\". Other `AiStyle` knobs (`length`, `author_focus`, `include_spoilers`, `interests`) had the same problem AND were never wired to the Settings UI.

## What changed

### Payload v2 (`BookInsightPayload`)
Reading-order field layout — `intro → author → series → analysis → content_warnings → confidence`. `response_format: json_schema` preserves declared order so the model generates keys in narrative order.

| v1 | v2 | rationale |
|---|---|---|
| `summary` | `intro` | name implies brevity (1-2 sentences) |
| `themes`, `tone`, `suggested_for`, `notes` | `analysis` (single ~80-130 word paragraph) | 4 fragmented fields → one coherent block |
| `content_advisory` | `content_warnings` | tightened scope: reader-safety only (violence / sexual content / abuse / self-harm / slurs / addiction / body horror). Not themes, genre, politics, or plot mechanics. |
| `AuthorInsight.nationality`, `active_years` | dropped (fold into `bio`) | high-risk identity facts; saves slots |
| `SeriesInsight.total_known` | `context` (free-form one-liner) | canon counts are unstable |
| `schema_version: 1` | `schema_version: 2` | combined with `PROMPT_VERSION=\"2\"` strands old cache rows; no data migration |

### Tone-keyed cache
- `AiStyle` reduced to a single field (`tone`). The dropped knobs were dead weight on the wire and the leak vector.
- New `tone` column on `book_insights` (migration `0004_ai_insight_tone.py`). Default `'neutral'` backfills existing rows.
- Both partial unique indexes rewritten to include `tone` so per-tone rows coexist for the same identity.
- Orchestrator threads tone through `_cache_lookup` / `get` / `generate` / `regenerate`. Per-`(identity, tone)` lock so two users with different tones don't serialize through one lock.
- `/insights/get` now reads the caller's tone from prefs (still no opt-in required — shared-cache reads stay user-agnostic at the row level).
- `_style_from_pref` tolerates pre-v2 prefs JSON by filtering to `AiStyle.model_fields` before validation.

### System prompt
Cut the \"Goals\" preamble (token waste, restated field names). Allows series inference from training knowledge when metadata is silent AND the series is canonically unambiguous (Foundation was returning `null` even for the canonical case). User-prompt composer drops citation URLs from the body (already in `sources`), tightens the trailing instruction, and the feedback block now scopes regen feedback to factual corrections only.

### Android
DTOs mirror the schema. `InsightCards.kt` reorders to match (intro → author → series → analysis → content_warnings) and drops the old `ThemesCard`. `AiRepository.setStyleTone` is simpler since `tone` is `AiStyle`'s only field.

### Docs
`docs/sync-api.md` updated for the slim `AiStyle`, tone-in-cache-key behavior, and v2 payload shape.

## Test plan
- [x] `cd server && pytest tests/unit -v` — 59 passed
- [x] `cd server && pytest tests/integration -v` — 15 passed
- [x] `scripts/dgradle :data:ai:test :app:testDebugUnitTest` — BUILD SUCCESSFUL
- [x] `ruff check . && ruff format --check .` — clean
- [ ] Re-smoke against the cluster after deploy: `/ai/v1/config` should still report ok; `/ai/v1/insights/lookup` for Foundation should now populate `intro` + `analysis`, return `series` filled from training knowledge, and put nothing theme-shaped in `content_warnings`.
- [ ] Settings → AI → Tone: changing tone and reopening BookDetail should trigger a fresh generation rather than serving another user's cached row.