### PR TITLE
feat(server): alembic branch split + deploy mode flags (PR-A)

### DIFF
--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -20,9 +20,21 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [full, sync_only, ai_only]
     defaults:
       run:
         working-directory: server
+    env:
+      # Deploy mode matrix: each cell exports the env vars that gate the app.
+      # Tests that depend on a specific mode (lazy-imports, modes, readyz)
+      # parameterize their own expectations; mode-agnostic tests run in every
+      # cell to surface any regression that only shows up under a non-default
+      # configuration.
+      OPDS_SYNC_PROGRESS_ENABLED: ${{ matrix.mode != 'ai_only' && 'true' || 'false' }}
+      OPDS_SYNC_AI_ENABLED: ${{ matrix.mode != 'sync_only' && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
@@ -33,6 +45,7 @@ jobs:
           uv venv
           uv pip install -e ".[dev]"
       - name: Lint
+        if: matrix.mode == 'full'
         run: uv run ruff check . && uv run ruff format --check .
       - name: Test
         run: uv run pytest -v

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,6 +198,52 @@ calibre-web username and password; everything else flows from that.
 - On `401` the app prompts re-auth (no refresh token to rotate).
 - Logout clears the Keystore entry.
 
+## Deploy modes
+
+The opds-sync server supports three deploy modes from a single codebase and
+container image. Modes are controlled by two env-var flags:
+
+| Mode             | `OPDS_SYNC_PROGRESS_ENABLED` | `OPDS_SYNC_AI_ENABLED` | Mounted endpoints                                |
+| ---------------- | ---------------------------- | ---------------------- | ------------------------------------------------ |
+| Full stack       | `true` (default)             | `true` (default)       | `/health`, `/readyz`, `/sync/v1/*`, `/ai/v1/*`   |
+| Sync only        | `true`                       | `false`                | `/health`, `/readyz`, `/sync/v1/*`               |
+| AI only          | `false`                      | `true`                 | `/health`, `/readyz`, `/ai/v1/*`                 |
+
+`/health` and `/readyz` are always mounted on the root path (no prefix) so k8s
+liveness/readiness probes work in every mode. `/health` returns liveness plus
+the active modes list. `/readyz` performs DB connectivity + an alembic-head
+check that verifies all required migration heads (per the enabled modes and
+the currently-materialized branches) are applied.
+
+The container entrypoint runs `python /app/scripts/migrate.py`, which:
+
+- Always upgrades the unlabeled migration backbone (today: revision `0004`).
+- Per enabled+materialized branch (`core`, `progress`, `ai`), runs
+  `alembic upgrade <branch>@head`. Branches that don't exist yet are skipped
+  silently.
+
+Migrations split into three forward-only branches off the `0001..0004` linear
+backbone. See `server/migrations/README.md` for the branch-label convention
+and the splice rule for adding the first migration on a new branch.
+
+### Provider lazy-import boundary
+
+Modules importing AI provider clients (httpx-based today; the `openai` SDK
+when it lands) and Wikipedia/OpenLibrary retrieval HTTP clients load lazily
+inside `create_app()` under the AI-enabled guard. Sync-only deploys never pull
+those modules. The test suite enforces this via subprocess introspection of
+`sys.modules`.
+
+### Request middleware
+
+Every inbound HTTP request passes through (innermost first):
+
+1. `RequestSizeMiddleware` — rejects bodies larger than
+   `OPDS_SYNC_MAX_REQUEST_BYTES` (default 1 MiB) with HTTP 413.
+2. `RequestIDMiddleware` — reads or generates `X-Request-ID`, binds it to a
+   `contextvars` ContextVar so logs include it, and echoes it back on every
+   response (including 413 / 4xx / 5xx).
+
 ## Decision log
 
 | # | Decision | Rationale |
@@ -210,3 +256,4 @@ calibre-web username and password; everything else flows from that.
 | 6 | Python FastAPI for the sync server | Fastest to write; traffic is trivial; deploys cleanly into the existing cluster. |
 | 7 | Bookmarks are the only synced reading artifact beyond progress | Smallest scope that's actually useful; record-level LWW is sufficient; matches the author's actual reading workflow. |
 | 8 | Calibre plugin as a later read-only consumer | Validates API shape; non-blocking; clean separation. |
+| 9 | Single image, three deploy modes (full / sync-only / AI-only) gated by env-var flags | One codebase, one container; lets the future hosted Quire Cloud AI ship the same image. Migrations branch per-domain so each mode applies only what it needs. |

--- a/docs/superpowers/plans/2026-05-16-alembic-mode-split.md
+++ b/docs/superpowers/plans/2026-05-16-alembic-mode-split.md
@@ -1,0 +1,92 @@
+# Plan — Alembic branch split + deploy mode flags (PR-A)
+
+**Spec:** `docs/superpowers/specs/2026-05-16-alembic-mode-split-design.md`
+**Approach:** TDD where the seam allows (middleware, health, config), exec-test for the migrate script and lazy imports.
+
+Each task is a checkbox. Order is enforced by the dependency graph — earlier tasks unblock later ones. Verification commands are listed inline.
+
+## Phase 0 — Baseline
+
+- [ ] **0.1 Confirm green baseline.** `cd server && uv run pytest -v` passes on the freshly-checked-out branch. Capture pre-change test count for the "no regression" claim.
+
+## Phase 1 — Config + always-on health (no behavior change for AI/progress)
+
+- [ ] **1.1 RED: `tests/unit/test_settings.py::test_defaults`.** New test asserting `ai_enabled=True, progress_enabled=True, max_request_bytes=1_048_576` after the change.
+- [ ] **1.2 GREEN: edit `opds_sync/config.py`** — flip `ai_enabled` default to `True`, add `progress_enabled: bool = True`, add `max_request_bytes: int = 1_048_576`.
+- [ ] **1.3 RED: `tests/unit/test_health_payload.py`.** Hits `/health` with both flags `True`, asserts payload shape `{ready: true, modes: ["progress","ai"]}`. Mock the settings via monkeypatch + `get_settings.cache_clear()`.
+- [ ] **1.4 GREEN: rewrite `opds_sync/api/health.py`** to mount on root (no `/sync/v1` prefix), return new payload shape. Add `/readyz` heads-check logic.
+- [ ] **1.5 Move health mount in `main.py`.** Remove `/sync/v1` prefix from the health router include; mount it always (outside mode-gated branches).
+- [ ] **1.6 Update `tests/integration/test_health.py`** to hit `/health` and `/readyz` at root, with new payload assertions. Keep the legacy `app_under_test` fixture wired.
+
+## Phase 2 — Middleware
+
+- [ ] **2.1 RED: `tests/unit/test_logging_ctx.py`.** Asserts `request_id_var` exists in `opds_sync.core.logging_ctx`, is a `ContextVar[str]`, defaults to empty string.
+- [ ] **2.2 GREEN: create `opds_sync/core/logging_ctx.py`** with `request_id_var: ContextVar[str] = ContextVar("request_id", default="")` and a logging filter `RequestIdLogFilter`.
+- [ ] **2.3 RED: `tests/unit/test_middleware_request_id.py`.** Cases: header preserved when valid; generated when absent; replaced when > 128 chars; replaced when non-printable; response always echoes `X-Request-ID`; contextvar is set during request lifetime.
+- [ ] **2.4 GREEN: create `opds_sync/api/middleware/__init__.py`** and `request_id.py` (Starlette `BaseHTTPMiddleware` subclass).
+- [ ] **2.5 RED: `tests/unit/test_middleware_request_size.py`.** Cases: 413 when Content-Length > cap; pass-through when under cap; 413 for chunked body that exceeds cap; skipped for GET/DELETE/HEAD/OPTIONS.
+- [ ] **2.6 GREEN: create `opds_sync/api/middleware/request_size.py`.**
+- [ ] **2.7 Wire middleware into `create_app`.** Order: `add_middleware(RequestSize, …)` first, then `add_middleware(RequestID)` (so RequestID is outermost).
+- [ ] **2.8 Integration assertion.** New `tests/integration/test_middleware_integration.py` confirms request-id echoes on a real ASGI roundtrip and survives a 413 response, for both Content-Length-declared and chunked oversized bodies. Also assert the contextvar resets to its default after the response (so a subsequent request without a header doesn't see the previous request's id).
+
+## Phase 3 — Conditional router mounting + lazy imports
+
+- [ ] **3.1 RED: `tests/integration/test_modes.py::test_full_mode`.** With both flags `True`, `/health` returns `modes=["progress","ai"]`, `/sync/v1/healthz` is 404 (moved), `/sync/v1/progress` is reachable (returns 401 without auth), `/ai/v1/config` reachable.
+- [ ] **3.2 RED: `test_modes.py::test_sync_only_mode`.** With `OPDS_SYNC_AI_ENABLED=false`: `/ai/v1/config` returns 404; `/sync/v1/*` works; `/health` returns `modes=["progress"]`.
+- [ ] **3.3 RED: `test_modes.py::test_ai_only_mode`.** With `OPDS_SYNC_PROGRESS_ENABLED=false`: `/sync/v1/*` returns 404; `/ai/v1/config` works; `/health` returns `modes=["ai"]`.
+- [ ] **3.4 RED: `test_modes.py::test_neither_mode`.** Both flags false; only `/health` (`modes=[]`) and `/readyz` mounted; everything else 404.
+- [ ] **3.5 GREEN: rewrite `opds_sync/main.py::create_app`.** Move `from opds_sync.core.ai.*` and `from opds_sync.api.ai` imports inside the `if settings.ai_enabled` block. Move `from opds_sync.api.progress` inside the `if settings.progress_enabled` block. Keep `CalibreAuthValidator` outside both (sync uses it; if progress is off but for example future routers also need basic auth, the validator is shared).
+- [ ] **3.6 Lazy-import subprocess test.** `tests/integration/test_lazy_imports.py`: for each mode, spawn `sys.executable -c "..."` (NOT `uv run python`) with the mode env vars set. Subprocess: `import opds_sync.main; opds_sync.main.create_app(); assert "opds_sync.api.ai" not in sys.modules` (and the rest of the forbidden table from spec §4). Test passes only when create_app() has run AND no forbidden modules were imported.
+
+## Phase 4 — Alembic branching convention + readyz heads check
+
+- [ ] **4.1 Write `migrations/README.md`** documenting:
+  - The `0001..0004` linear backbone (do not rewrite).
+  - The branch label convention: first migration on a branch sets `branch_labels=("ai"|"progress"|"core",), down_revision="0004"` (or the latest pre-branch revision); subsequent migrations on the branch leave `branch_labels=None`.
+  - The Alembic splice rule: once one branch exists, adding the first of another branch needs `alembic revision --head=0004 --splice --branch-label=<name>` (otherwise Alembic refuses to insert a new branch off a non-head revision).
+  - Copy-paste templates for: first-on-branch, subsequent-on-branch.
+- [ ] **4.2 Implement `/readyz` heads check per spec §5.2.** Compute the required-heads set: empty-labels fallback returns `{backbone_head}`; otherwise the enabled-and-materialized branch heads. Read `alembic_version` rows via `text("SELECT version_num FROM alembic_version")`. Compare; 503 if subset mismatch.
+- [ ] **4.3 RED: `tests/integration/test_readyz_migration_state.py`.** Cases:
+  - DB at `0004`, no branch labels → 200, `heads_applied=["0004"]`.
+  - DB stamped to `0003`, no branch labels → 503, detail names `0004` as missing.
+  - DB at `0004`, ai-enabled, no ai label yet → 200 (no materialized head required; fallback requires backbone `0004`, which is present).
+  - DB at `0004`, both flags `false` → 200 (fallback requires backbone only).
+  - DB stamped to `0003`, both flags `false` → 503 (backbone fallback still missing).
+  - Synthetic case: ai label exists in script dir but AI disabled, DB at `0004` → 200 (fallback requires backbone, not ai head; this locks in that the disabled branch's head doesn't sneak into the required set).
+- [ ] **4.4 GREEN: implement heads check in `health.readyz`.** Use Alembic's `Config("alembic.ini")` + `ScriptDirectory.from_config()` (resolve `alembic.ini` relative to cwd, which is `/app` in container and `server/` in tests).
+
+## Phase 5 — Migrate wrapper (Python, not shell)
+
+- [ ] **5.1 RED: `tests/unit/test_migrate_logic.py`.** Synthetic-graph tests for the migrate module's pure logic: `_existing_branch_labels` with a stub ScriptDirectory; flag-to-action mapping for each (progress, ai, labels-present) combination. No DB.
+- [ ] **5.2 GREEN: write `server/scripts/migrate.py`** per spec §5.3. Use `alembic.script.ScriptDirectory.walk_revisions()` for label detection and `alembic.command.upgrade()` for the actual run. Make it a real module (so unit tests can `from scripts.migrate import _existing_branch_labels`).
+- [ ] **5.3 Update `Dockerfile`** so it `COPY scripts ./scripts` and `CMD` runs `python /app/scripts/migrate.py` before uvicorn. Also update `server/docker-compose.yml` so its `command` override calls the wrapper instead of `alembic upgrade head` directly.
+- [ ] **5.4 Smoke test the script** against the testcontainer Postgres. New `tests/integration/test_migrate_script.py`:
+  - Run against DB stamped to `0004` (today's prod state) → exit 0, no labels detected → fallback `upgrade head` → DB at `0004`.
+  - Run twice in a row → second run is a no-op.
+  - Synthetic branched-script test: copy `migrations/` to a tmp dir, add a `ai_test_001` revision with `branch_labels=("ai",), down_revision="0004"`; run wrapper with `OPDS_SYNC_AI_ENABLED=true` → upgrades to `ai_test_001`; with `OPDS_SYNC_AI_ENABLED=false` → stays at `0004`.
+
+## Phase 6 — CI matrix
+
+- [ ] **6.1 Extend `.github/workflows/server-ci.yaml`** with a `strategy.matrix.mode` on the `test` job, exporting env vars per matrix entry.
+- [ ] **6.2 Tag mode-specific tests** with `pytest.mark.requires_ai` / `pytest.mark.requires_progress` so they self-skip when the flag is off. Add markers in `pyproject.toml`.
+- [ ] **6.3 Add a `migrate_script` matrix step or include a `tests/integration/test_migrate_script.py`** that always runs (since the script is mode-agnostic, only one matrix cell needs to assert it works; the test itself doesn't care about flags).
+
+## Phase 7 — Verification & cleanup
+
+- [ ] **7.1 Run `uv run ruff check . && uv run ruff format --check .`** — pre-commit will run these too; pre-emptively clean.
+- [ ] **7.2 Run full test suite in each mode locally:**
+  - `OPDS_SYNC_AI_ENABLED=true OPDS_SYNC_PROGRESS_ENABLED=true uv run pytest -v`
+  - `OPDS_SYNC_AI_ENABLED=false OPDS_SYNC_PROGRESS_ENABLED=true uv run pytest -v`
+  - `OPDS_SYNC_AI_ENABLED=true OPDS_SYNC_PROGRESS_ENABLED=false uv run pytest -v`
+- [ ] **7.3 Verify lazy-import test PASSES** in subprocess form (not just via mocks).
+- [ ] **7.4 Update `docs/architecture.md`** with deploy modes section.
+- [ ] **7.5 Update `server/README.md`** with mode flags + migrate script.
+- [ ] **7.6 Commit using gitmoji conventional commit.** Push branch. Open PR.
+
+## Definition of done (audit before claiming done)
+
+- All checkboxes above ticked.
+- `cd server && uv run pytest -v` green in all three modes.
+- No `:robot:`/Co-Authored-By/"Generated with Claude Code" trailers anywhere.
+- `git diff main -- server/migrations/versions/0001_initial.py server/migrations/versions/0002_progress_finished_at.py server/migrations/versions/0003_ai_tables.py server/migrations/versions/0004_ai_insight_tone.py` returns empty.
+- PR body includes architect verdict.

--- a/docs/superpowers/specs/2026-05-16-alembic-mode-split-design.md
+++ b/docs/superpowers/specs/2026-05-16-alembic-mode-split-design.md
@@ -1,0 +1,530 @@
+# Spec — Alembic branch split + deploy mode flags (PR-A)
+
+**Date:** 2026-05-16
+**Branch:** `feat/alembic-mode-split`
+**Roadmap reference:** `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §PR-A
+**Status:** Draft for architect review
+
+## 1. Motivation
+
+The repo today ships as a single FastAPI app where every router (sync, progress, AI) mounts unconditionally, and a single Alembic chain `0001 → 0002 → 0003 → 0004` migrates the DB. To support the three published deploy modes (full-stack, sync-only, AI-only) without forking the codebase, we need:
+
+1. Alembic migrations that can grow per-domain without coupling: future progress-side schema must not block AI-only deployments, and vice versa.
+2. Settings flags that gate router mounts and provider imports at startup.
+3. An entrypoint wrapper that upgrades only the branches the deploy enables.
+4. Cross-cutting middleware (request-ID, request-size) that hosted Quire Cloud AI will rely on once it lights up.
+
+This PR is the substrate. It must not change app behavior in production (the today-default mode is "full stack with both flags `true`"), and it must leave the live `0001 → 0004` chain byte-for-byte unchanged.
+
+## 2. Alembic branching strategy
+
+### 2.1 Linear backbone (untouched)
+
+```
+0001 -- 0002 -- 0003 -- 0004
+                         ^
+                         |
+                    split point
+```
+
+- `0001..0004` keep `branch_labels = None` and a strict linear `down_revision` chain.
+- We do **not** rewrite any of these files. Renaming, relabeling, or merging would force every deployed DB to perform Alembic's `stamp`/`merge` dance, which is a footgun on production.
+
+### 2.2 Forward-only branching from `0004`
+
+From PR-A forward, every new migration MUST belong to exactly one of three branches:
+
+| Branch     | Label        | First revision id (set by future PRs) | Owners  |
+| ---------- | ------------ | ------------------------------------- | ------- |
+| `core`     | `"core"`     | _no migrations yet; reserved_         | shared  |
+| `progress` | `"progress"` | `progress_001_*` (set by PR1)         | sync    |
+| `ai`       | `"ai"`       | `ai_001_*` (set by PR-C)              | AI      |
+
+**Convention for new migrations (documented in `migrations/README.md`):**
+
+```python
+# migrations/versions/<branch>_<NNN>_<slug>.py
+revision = "<branch>_<NNN>"          # e.g. "progress_001", "ai_001"
+down_revision = "0004"               # first child of the split point
+branch_labels = ("<branch>",)        # only on the FIRST migration of the branch
+depends_on = None
+```
+
+Subsequent migrations on the same branch:
+
+```python
+revision = "<branch>_<NNN>"
+down_revision = "<branch>_<NNN-1>"
+branch_labels = None                 # only the first migration of the branch labels it
+```
+
+### 2.3 Heads on a freshly-deployed DB
+
+At PR-A merge time, no `progress_*` or `ai_*` migrations exist yet. `ScriptDirectory.get_heads()` returns `["0004"]` and no branch labels exist anywhere in the script directory. **`alembic upgrade ai@head` would fail** ("no such branch label") in this state — this is correct Alembic behavior, not a bug. Therefore the wrapper MUST detect whether each branch label exists in the script directory before attempting to upgrade to it.
+
+**Mental model:** `0004` is a *common backbone tip*, not a "head of all branches simultaneously". Branches materialize only when their first labeled migration is added. Before that, the backbone is the only thing to upgrade to, and a plain `alembic upgrade head` does the job.
+
+After PR-C lands `ai_001` (with `branch_labels = ("ai",), down_revision = "0004"`):
+
+- `ScriptDirectory.get_heads()` returns `["ai_001"]`. `0004` is no longer a head — it has a child.
+- Branch label `"ai"` now resolves to `ai_001`. `alembic upgrade ai@head` advances to `ai_001`.
+- There is no `"progress"` label yet, so `alembic upgrade progress@head` still fails. The wrapper detects this and skips.
+
+After PR1 lands `progress_001` (with `branch_labels = ("progress",), down_revision = "0004"`):
+
+- `ScriptDirectory.get_heads()` returns `["ai_001", "progress_001"]`.
+- Both `ai` and `progress` labels resolve. Wrapper upgrades the enabled subset.
+
+### 2.4 Reserved `core` branch
+
+We label nothing as `core` in this PR — `0001..0004` stay `branch_labels = None` because relabeling old revisions would create a checkout-vs-DB divergence. The wrapper invokes `alembic upgrade core@head` only **if** the `"core"` label resolves in the script directory (i.e., once some future `core_001` migration adds the label). Otherwise it skips. This means the `core` branch is a no-op today and lights up only when PR-A's successor wants cross-cutting schema.
+
+### 2.5 Adding the first migration on a branch (Alembic splice rule)
+
+Once `ai_001` exists and is the head of the `ai` branch, `0004` is no longer a head. Creating `progress_001` *also* off of `0004` via Alembic's CLI requires the `--splice` flag (Alembic refuses to insert a new branch off a non-head revision without it) plus `--branch-label`:
+
+```bash
+alembic revision --head=0004 --splice --branch-label=progress -m "library_items"
+```
+
+Subsequent migrations on the `progress` branch use:
+
+```bash
+alembic revision --head=progress@head -m "..."
+```
+
+And `ai`-branch migrations after `ai_001`:
+
+```bash
+alembic revision --head=ai@head -m "..."
+```
+
+This rule **must** be in `migrations/README.md` — getting it wrong silently creates a fourth head.
+
+## 3. Settings (env vars)
+
+`opds_sync/config.py`:
+
+```python
+ai_enabled: bool = True              # was False; defaults flip to roadmap modes table
+progress_enabled: bool = True        # new
+max_request_bytes: int = 1_048_576   # new (1 MiB)
+```
+
+| Env var                          | Type | Default     | Behavior                                                                  |
+| -------------------------------- | ---- | ----------- | ------------------------------------------------------------------------- |
+| `OPDS_SYNC_AI_ENABLED`           | bool | `true`      | Gates `/ai/v1` router + provider imports + ai migration branch upgrade.   |
+| `OPDS_SYNC_PROGRESS_ENABLED`     | bool | `true`      | Gates `/sync/v1` router + progress migration branch upgrade.              |
+| `OPDS_SYNC_MAX_REQUEST_BYTES`    | int  | `1_048_576` | Request body size cap; oversized requests get 413.                        |
+
+**Backwards compatibility:** the old default for `ai_enabled` was `False`. The new default is `True`. Existing prod deployment sets `OPDS_SYNC_AI_ENABLED=true` explicitly per `quire-ai-deployment-notes.md`, so the default flip is invisible to prod. Sync-only deployers (currently zero, but documented future case) must now set `OPDS_SYNC_AI_ENABLED=false` explicitly.
+
+If someone deploys with both flags `false`, `/health` and `/readyz` still mount; nothing else does. We surface `modes: []` from `/health` so monitoring can alert.
+
+## 4. Provider lazy-import boundary
+
+Today: `main.py` does `from opds_sync.core.ai.client import AIClient` at top-of-module. That import chain pulls `opds_sync.core.ai.{client,retrieval,service,prompts}` and indirectly `opds_sync.api.ai`. None of those modules import the `openai` SDK (our `AIClient` is an httpx wrapper over the OpenAI-compatible chat API), so the *literal* trigger from the roadmap ("`openai` SDK") does not fire here. But the spirit of the constraint is broader: in sync-only mode we must not import `opds_sync.core.ai.*` or `opds_sync.api.ai`, because (a) they pull retrieval/prompt code that adds runtime cost for no benefit, and (b) future PRs may add an `openai` dependency, and the lazy-import scaffold must already exist when that happens.
+
+**Rule:** `opds_sync.main` must not have a top-level import from `opds_sync.core.ai` or `opds_sync.api.ai`. Both imports happen inside the `create_app()` body, gated by `if settings.ai_enabled`. Symmetric rule for progress: `opds_sync.api.progress` imports only when `settings.progress_enabled`.
+
+**About `opds_sync.db.models`:** the models module is shared and houses both progress + AI ORM mappings. We do **not** split it — SQLAlchemy mappers register against shared metadata at module import time, so partial loading would require fragile re-mapper plumbing for no real win. `db.models` will always be imported in every mode. The gate is on the *router* and *service* modules, which is where the actual sync-only-vs-AI-only logic divergence lives, and which is where the `openai` SDK (when it ships) and Wikipedia/OpenLibrary HTTP clients are referenced.
+
+Forbidden-in-mode module lists (used by the lazy-import test):
+
+| Mode      | Must NOT be in `sys.modules`                                                                                                          |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| sync-only | `opds_sync.api.ai`, `opds_sync.core.ai.client`, `opds_sync.core.ai.retrieval`, `opds_sync.core.ai.service`, `opds_sync.core.ai.prompts` |
+| ai-only   | `opds_sync.api.progress`                                                                                                              |
+
+**Test mechanism:** spawn a subprocess via `sys.executable -c "..."` (NOT `uv run python` — nesting layers and env quirks defeat the isolation), with the mode's env vars set, that:
+1. Imports `opds_sync.main`.
+2. Calls `opds_sync.main.create_app()`.
+3. Asserts each forbidden module is not in `sys.modules`.
+
+Calling `create_app()` (not just importing) is essential because mounting is the trigger for any lazy imports — an "import-only" test could pass while `create_app()` still does the wrong thing. Subprocess isolation is the only honest way to test import gates: `importlib.reload` and friends leak transitive imports.
+
+## 5. Health endpoints
+
+Two new endpoints mounted on the root app (no prefix), always-on:
+
+### 5.1 `GET /health`
+
+```json
+{
+  "ready": true,
+  "modes": ["progress", "ai"]
+}
+```
+
+- `ready` is always `true` when this endpoint responds — it's the k8s liveness probe; it does not touch the DB.
+- `modes` is the list of enabled modes derived from `settings.progress_enabled` and `settings.ai_enabled`. Order is stable: `progress` first, `ai` second.
+- Empty list when both flags are `false` (legal, monitored).
+
+### 5.2 `GET /readyz`
+
+- 200 with `{"ready": true, "modes": [...], "heads_applied": ["<rev>", ...]}` when:
+  1. DB connectivity check (`SELECT 1`) succeeds.
+  2. All required heads (per the rules below) are present in `alembic_version`.
+- 503 with `{"ready": false, "detail": "<reason>"}` otherwise.
+
+**Required-heads computation:**
+
+```
+required = set()
+script_labels = _existing_branch_labels(script)
+backbone = _backbone_head(script)  # e.g. "0004" today
+
+# Enabled branches with materialized labels each contribute their head.
+for (flag, label) in [(True, "core"), (progress_enabled, "progress"), (ai_enabled, "ai")]:
+    if flag and label in script_labels:
+        required.add(script.get_revision(f"{label}@head").revision)
+
+# If nothing materialized to require, fall back to requiring the backbone.
+# This covers: no labels at all, both flags false, an enabled flag without
+# a corresponding branch label yet.
+if not required:
+    required.add(backbone)
+```
+
+Then read `alembic_version` rows via `SELECT version_num FROM alembic_version` and compare:
+
+- If `set(rows) ⊇ required`: 200, `heads_applied = sorted(rows)`.
+- Otherwise: 503, `detail = {"missing": sorted(required - set(rows)), "current": sorted(rows)}`.
+
+**Ancestry shortcut:** when a branch head is required (say `ai_NNN`), we don't separately require its ancestors — `alembic_version` only ever stores leaf heads, and Alembic's invariant is that all ancestors are applied whenever a head is in the table. So requiring the leaf is sufficient.
+
+**Backbone always implied:** when *any* branch head is required, the backbone is a transitive ancestor, so it's covered. The explicit fallback fires only when nothing else is required (the "no labels yet OR enabled-but-not-materialized" cases). A DB stamped below `0004` therefore returns 503 in both pre-and-post-materialization regimes because the required set always contains *something* whose ancestry includes `0004`.
+
+The old `/sync/v1/healthz` and `/sync/v1/readyz` are **removed**. They were ad-hoc; their probes live on the root paths now per the roadmap. The k8s deployment manifest in `theficos-cluster` will need a follow-up bump (out of scope for this PR; deployment notes update is part of the PR body).
+
+### 5.3 Wrapper script
+
+A Python script — not shell — because we need Alembic's stable `ScriptDirectory` API to detect which branch labels exist, and shelling out and parsing `alembic heads` is brittle (the architect call-out: output format is not a stable API, and label substrings collide with revision-id substrings).
+
+`server/scripts/migrate.py`:
+
+```python
+#!/usr/bin/env python3
+"""Forward-only deploy migrator.
+
+Reads OPDS_SYNC_PROGRESS_ENABLED and OPDS_SYNC_AI_ENABLED, then runs
+`alembic upgrade <branch>@head` for each enabled branch that exists in
+the script directory. Always upgrades the common backbone first by
+targeting the explicit backbone-tip revision (e.g. "0004").
+
+Idempotent. Forward-only. Per-branch downgrades remain a manual op.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def _is_truthy(val: str | None, default: bool = True) -> bool:
+    if val is None:
+        return default
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _existing_branch_labels(script: ScriptDirectory) -> set[str]:
+    """Return the set of branch labels that appear anywhere in the script directory.
+
+    Alembic stores branch labels on individual revisions. We walk every revision
+    once and collect labels. Cheap (O(n) where n is migration count).
+    """
+    labels: set[str] = set()
+    for rev in script.walk_revisions():
+        if rev.branch_labels:
+            labels.update(rev.branch_labels)
+    return labels
+
+
+def _upgrade_branch(cfg: Config, branch: str) -> None:
+    print(f"[migrate] upgrading {branch}@head", flush=True)
+    command.upgrade(cfg, f"{branch}@head")
+
+
+def _backbone_head(script: ScriptDirectory) -> str:
+    """Return the last revision on the unlabeled linear backbone.
+
+    The backbone is the prefix of the migration history where every revision
+    has `branch_labels = None`. The first labeled revision is a child of the
+    backbone tip. We always walk forward from base and stop at the first
+    labeled revision — taking a `get_heads()` shortcut would be wrong once
+    any branch exists (e.g. after `ai_001` lands, `get_heads()` returns
+    `["ai_001"]` but the backbone tip is still `0004`).
+    """
+    # walk_revisions() goes newest→oldest, so reverse to walk oldest→newest.
+    backbone_tip = None
+    for rev in reversed(list(script.walk_revisions())):
+        if rev.branch_labels:
+            break
+        backbone_tip = rev.revision
+    if backbone_tip is None:
+        # Shouldn't happen — would mean the very first revision is labeled.
+        raise RuntimeError("no unlabeled backbone found in script directory")
+    return backbone_tip
+
+
+def main() -> int:
+    cfg_path = Path(os.environ.get("ALEMBIC_INI", "alembic.ini"))
+    cfg = Config(str(cfg_path))
+    script = ScriptDirectory.from_config(cfg)
+
+    labels = _existing_branch_labels(script)
+    progress_enabled = _is_truthy(os.environ.get("OPDS_SYNC_PROGRESS_ENABLED"))
+    ai_enabled = _is_truthy(os.environ.get("OPDS_SYNC_AI_ENABLED"))
+
+    # Step 1: always ensure the unlabeled backbone is applied. This is the
+    # foundation every branch depends on. On a fresh DB this is the first
+    # `alembic upgrade` call ever made; on existing prod DBs at 0004 it's
+    # a no-op. We use the explicit backbone-tip revision rather than
+    # `upgrade head` because `head` is ambiguous in multi-head graphs.
+    backbone = _backbone_head(script)
+    print(f"[migrate] upgrading backbone to {backbone}", flush=True)
+    command.upgrade(cfg, backbone)
+
+    # Step 2: per-branch upgrades. Order is core → progress → ai for
+    # determinism; branches are independent, so order doesn't matter
+    # for correctness.
+    if "core" in labels:
+        _upgrade_branch(cfg, "core")
+
+    if progress_enabled and "progress" in labels:
+        _upgrade_branch(cfg, "progress")
+    elif progress_enabled:
+        print("[migrate] progress enabled but no progress branch; skipping", flush=True)
+
+    if ai_enabled and "ai" in labels:
+        _upgrade_branch(cfg, "ai")
+    elif ai_enabled:
+        print("[migrate] ai enabled but no ai branch; skipping", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Dockerfile changes:
+
+```dockerfile
+# ... existing layers ...
+COPY scripts ./scripts          # NEW: ship the wrapper into the image
+COPY migrations ./migrations
+COPY alembic.ini ./
+EXPOSE 8000
+CMD ["sh", "-c", "python /app/scripts/migrate.py && exec uvicorn opds_sync.main:app --host 0.0.0.0 --port 8000"]
+```
+
+`server/docker-compose.yml` currently overrides the image command with `alembic upgrade head`. Update the override to invoke the wrapper too, so local compose deploys go through the same migrate path as k8s:
+
+```yaml
+command: >
+  sh -c "python /app/scripts/migrate.py &&
+         uvicorn opds_sync.main:app --host 0.0.0.0 --port 8000"
+```
+
+> **Why Python instead of shell?** Per architect review: shell parsing of `alembic heads` is brittle (substring matches on revision IDs, output format isn't stable API). `ScriptDirectory.get_heads()` / `walk_revisions()` are Alembic's documented stable APIs. The Python script is ~50 lines and the only added "complexity" is that the deploy image already has Alembic installed — there's no Python bootstrap overhead.
+
+## 6. Migration backwards-compat
+
+A deployed DB at `alembic_version = '0004'` after this PR lands:
+
+- `ScriptDirectory.walk_revisions()` finds no `branch_labels`.
+- Wrapper's `labels` set is empty.
+- Wrapper computes backbone tip = `0004` (via `_backbone_head`), runs `command.upgrade(cfg, "0004")` → no-op (DB already at `0004`). No branches materialized → no further upgrades.
+
+When PR-C lands `ai_001` (with `branch_labels = ("ai",), down_revision = "0004"`):
+
+- `walk_revisions()` finds `branch_labels = ("ai",)` on `ai_001`. `labels = {"ai"}`.
+- Full-stack deploy: `ai_enabled=True`, `"ai" in labels` → `command.upgrade(cfg, "ai@head")` advances DB to `ai_001`.
+- Sync-only deploy (`ai_enabled=False`): ai branch skipped. DB stays at `0004`.
+- `0004` is no longer a "head" per Alembic — it has `ai_001` as a child on the `ai` branch — but it is still a tip of the (currently unlabeled) progress side. `alembic_version` table on a full-stack DB now contains `ai_001` (and conceptually still represents the backbone up to `0004` via ancestry).
+
+When PR1 later lands `progress_001` (with `branch_labels = ("progress",), down_revision = "0004"`, created via `alembic revision --head=0004 --splice --branch-label=progress`):
+
+- `labels = {"ai", "progress"}`.
+- Full-stack: both `command.upgrade(cfg, "ai@head")` and `command.upgrade(cfg, "progress@head")` run. After both, `alembic_version` contains two rows: `ai_NNN` and `progress_NNN`.
+- Sync-only: only `progress` runs. `alembic_version` contains `progress_NNN` only; the progress side knows `0004` is an ancestor via the linear chain.
+
+### Edge cases handled
+
+1. **`alembic_version` row count.** Alembic stores one row per branch head currently applied. When upgrading from a single-head state into a multi-branch state for the first time, Alembic inserts the second row transparently (because both heads share `0004` as a common ancestor).
+2. **Sequential safety.** `command.upgrade()` acquires the same locks Alembic CLI would; the script invokes them sequentially.
+3. **Operator changes flags mid-life.** Pod restart re-runs the migrate script. If the operator enables AI on a previously sync-only deploy, the ai branch upgrades from `0004` (the common ancestor) up to `ai@head`. Alembic handles this because the ai chain's `down_revision = "0004"` is already in the DB's history (transitively, via the backbone).
+4. **Both flags `false`.** Wrapper still upgrades the backbone (Step 1 is unconditional). No branch upgrades run. The DB advances to the backbone tip (today: `0004`) and no further. `/readyz` requires only the backbone in this state → returns 200.
+
+## 7. Middleware
+
+### 7.1 Request-ID
+
+`opds_sync/api/middleware/request_id.py`:
+
+- Read `X-Request-ID` header. If absent or longer than 128 chars or non-printable, generate `uuid.uuid4().hex`.
+- Bind to `contextvars.ContextVar` named `request_id` (module-level in `opds_sync.core.logging_ctx` so logs everywhere can read it).
+- Set response header `X-Request-ID` to the bound value (always echoed back, even for 4xx/5xx).
+- Logging formatter (existing `python-json-logger`) updated via a `filter` that injects `request_id` from the contextvar into every record.
+
+### 7.2 Request-size limit
+
+`opds_sync/api/middleware/request_size.py`:
+
+- Inspect `Content-Length` header pre-body. If > `settings.max_request_bytes`, return `413 Payload Too Large` with JSON body `{"detail": "request body exceeds <N> bytes"}` and short-circuit.
+- If `Content-Length` is absent (chunked transfer), wrap the body stream and count bytes, raising 413 mid-stream if the cap is exceeded.
+- GET/HEAD/OPTIONS/DELETE requests skip the check (no body).
+
+### 7.3 Order
+
+Middleware order matters. ASGI middleware executes outer→inner on request, inner→outer on response. We want:
+
+```
+Outer (response: last to run)
+└─ RequestIDMiddleware       (binds contextvar; logs request)
+    └─ RequestSizeMiddleware (rejects oversized BEFORE app sees it)
+        └─ FastAPI routers
+Inner (response: first to run)
+```
+
+So: register `RequestSize` first (innermost), then `RequestID` (outermost). `app.add_middleware()` adds to the outside, so we call:
+
+```python
+app.add_middleware(RequestSizeMiddleware, max_bytes=settings.max_request_bytes)
+app.add_middleware(RequestIDMiddleware)
+```
+
+(That's reverse of registration order: the last `add_middleware` is outermost.)
+
+## 8. Router mounting
+
+```python
+def create_app() -> FastAPI:
+    settings = get_settings()
+    ...
+    app = FastAPI(...)
+
+    # Always-on root endpoints.
+    from opds_sync.api.health import router as health_router
+    app.include_router(health_router)  # no prefix; /health + /readyz
+
+    if settings.progress_enabled:
+        from opds_sync.api.progress import router as progress_router
+        app.include_router(progress_router, prefix="/sync/v1")
+
+    if settings.ai_enabled:
+        from opds_sync.api.ai import router as ai_router
+        from opds_sync.core.ai.client import AIClient
+        from opds_sync.core.ai.retrieval import Retriever
+        from opds_sync.core.ai.service import InsightOrchestrator
+        ...  # existing orchestrator setup
+        app.include_router(ai_router, prefix="/ai/v1")
+
+    # Middleware (registered last; runs first per ASGI semantics).
+    app.add_middleware(RequestSizeMiddleware, max_bytes=settings.max_request_bytes)
+    app.add_middleware(RequestIDMiddleware)
+
+    return app
+```
+
+## 9. Test matrix
+
+### 9.1 Unit tests (`tests/unit/`)
+
+- `test_middleware_request_id.py`: generated when header absent; preserved when present; rejected when > 128 chars; response always echoes back; contextvar bound for downstream code.
+- `test_middleware_request_size.py`: 413 when Content-Length exceeds cap; passes through when under cap; works for chunked transfer (no Content-Length); skipped for GET/DELETE.
+- `test_health_payload.py`: `/health` returns correct modes for each (progress, ai) flag combo.
+
+### 9.2 Integration tests (`tests/integration/`)
+
+- `test_modes.py`: parametrized over `("full", "sync_only", "ai_only", "neither")`:
+  - App boots cleanly.
+  - `/health` returns the right `modes` (including empty list for `neither`).
+  - In sync-only: `/sync/v1/progress` reachable; `/ai/v1/*` returns 404.
+  - In ai-only: `/ai/v1/config` reachable (with auth stub); `/sync/v1/*` returns 404.
+  - In full: both reachable.
+  - In neither: only `/health` and `/readyz` mounted; everything else 404.
+- `test_lazy_imports.py`: spawns subprocess via `sys.executable -c "..."` per mode. The script imports `opds_sync.main`, calls `create_app()`, and asserts forbidden modules are absent from `sys.modules` (see §4 table). Subprocess is the only honest way; in-process `importlib.reload` leaks transitive caches.
+- `test_readyz_migration_state.py`:
+  - Backbone-only state (today): `/readyz` returns 200; `heads_applied = ["0004"]`.
+  - Stamp the DB to `0003`; `/readyz` returns 503 listing `0004` as missing.
+  - With a synthetic ai branch fixture (see §9.4): DB at `0004` + ai branch enabled + ai head not applied → 503; ai head applied → 200.
+- `test_migrate_script.py`: invokes `python scripts/migrate.py` against the testcontainer DB.
+  - Run against a DB stamped to `0004` (no branch labels yet) → exit 0, DB still at `0004`.
+  - Run twice in a row → second run is a no-op.
+  - With a synthetic branched script directory (a tmp copy of `migrations/` plus a `ai_test_001` revision with `branch_labels=("ai",)`): ai-enabled run upgrades to `ai_test_001`; ai-disabled run skips it.
+
+### 9.3 Synthetic branch graph tests (`tests/unit/test_migrate_logic.py`)
+
+Pure unit tests for the migrate script's branch detection and selection logic, without touching a DB:
+
+- No branch labels in script dir → fallback path.
+- Only `ai` label → ai upgrade attempted, progress skipped silently.
+- Only `progress` label → vice versa.
+- All three labels → all three attempts.
+- Flag combinations: `ai_enabled=False` with `ai` label present → ai is skipped even though label exists.
+
+Implemented via a fake `ScriptDirectory` (or by pointing `_existing_branch_labels` at a stub directory).
+
+### 9.4 CI
+
+Extend `.github/workflows/server-ci.yaml` `test` job: parametrize the pytest invocation across the three modes via env-var matrix, so a regression in any mode fails CI. Concretely: add a matrix on the existing `test` job:
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    mode: [full, sync_only, ai_only]
+env:
+  OPDS_SYNC_PROGRESS_ENABLED: ${{ matrix.mode != 'ai_only' }}
+  OPDS_SYNC_AI_ENABLED: ${{ matrix.mode != 'sync_only' }}
+```
+
+Tests that exercise routers from the *other* mode skip themselves when the relevant flag is off (via a `requires_progress` / `requires_ai` pytest marker). The lazy-import test is mode-agnostic — it spawns subprocesses with the env set per-case. The migrate script test runs in every matrix cell (it exercises the wrapper's flag logic and synthetic branch graph).
+
+## 10. Documentation
+
+- Update `docs/architecture.md` with a "Deploy modes" section.
+- Update `docs/sync-api.md` to note `/health` and `/readyz` are root-mounted and always available.
+- Add `server/scripts/README.md` (or a section in `server/README.md`) describing the migrate wrapper and the per-branch upgrade flow.
+- Note in `migrations/README.md` (new) the branch-labeling convention for future migrations.
+
+## 11. Out of scope
+
+- Actually creating `progress_001` or `ai_001` migrations — that's PR1 / PR-C.
+- AI-only mode plumbing in Android (PR9/PR8 will worry about it).
+- Hosted-mode HMAC auth (PR-B).
+- Reference compose with Caddy (PR10).
+- Quota / rate-limit changes (separate concern; the existing daily budget / regen limit stays as-is).
+
+## 12. Risks & mitigations
+
+| Risk                                                                                | Mitigation                                                                                                                |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Operator misreads default flip and accidentally turns off AI on existing prod       | Deployment note in PR body; cluster's manifest already pins `OPDS_SYNC_AI_ENABLED=true` explicitly per deployment doc.    |
+| Lazy-import test passes locally but a transitive top-level import slips through CI  | Subprocess test runs in CI matrix across all three modes; subprocess calls `create_app()` not just module-import.         |
+| Future PR adds a migration with `branch_labels` but forgets `--splice` and silently creates a third head | `migrations/README.md` documents the exact recipe; CI test asserts `set(ScriptDirectory.get_heads())` matches the explicit-allowlist of expected heads. The "allowlist" for this PR is `{"0004"}`. Each subsequent branch-introducing PR is expected to update the allowlist. |
+| Middleware order mistake (size limit runs AFTER request-id is unbound)              | Explicit ordering in `create_app`, asserted by a unit test that sends an oversized POST and asserts response has request-id header (both Content-Length and chunked variants). |
+| Removing `/sync/v1/healthz` breaks the cluster's k8s liveness probe                 | Document in PR body; the k8s manifest change is a follow-up commit in `theficos-cluster`. We deliberately drop the old paths to force the cluster bump rather than carry a forever-alias. |
+| Migrate script silently skips an enabled branch that has no label yet               | Logged at INFO with explicit "skipping" message; absence of branch label means there's nothing to apply anyway.           |
+
+## 13. Deliverables checklist
+
+- [ ] `migrations/README.md` documenting branch label convention + splice rule for first-on-branch migrations.
+- [ ] `server/scripts/migrate.py` (Python, not shell) + `Dockerfile` CMD update.
+- [ ] `opds_sync/config.py` new settings: `ai_enabled` default flip, `progress_enabled`, `max_request_bytes`.
+- [ ] `opds_sync/api/middleware/request_id.py` + `request_size.py`.
+- [ ] `opds_sync/core/logging_ctx.py` (contextvar + log filter).
+- [ ] `opds_sync/api/health.py` rewritten to root-mount with `/health` + `/readyz` (heads-check logic per §5.2).
+- [ ] `opds_sync/main.py` rewritten with conditional mounts + lazy imports per §4 forbidden-module table.
+- [ ] Unit + integration tests per §9, including: `test_modes.py` (4 modes), `test_lazy_imports.py` (subprocess + `create_app()`), `test_readyz_migration_state.py`, `test_migrate_script.py`, `test_migrate_logic.py`.
+- [ ] `.github/workflows/server-ci.yaml` mode matrix.
+- [ ] `docs/architecture.md` deploy modes section.
+- [ ] Existing tests updated (path changes for health, etc.).
+- [ ] PR body calls out the `OPDS_SYNC_AI_ENABLED` default flip (False → True) and the prod-DB-at-0004 backwards-compat statement.

--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -31,8 +31,8 @@ returns `503`.
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
-| `GET` | `/healthz` | none | Liveness probe |
-| `GET` | `/readyz` | none | Readiness probe (checks Postgres) |
+| `GET` | `/health` | none | Liveness probe; returns `{ready, modes}` (always mounted) |
+| `GET` | `/readyz` | none | Readiness probe; checks Postgres and that enabled-branch migrations are applied (always mounted) |
 | `POST` | `/sync/v1/progress` | yes | Push progress for one or more documents |
 | `GET` | `/sync/v1/progress` | yes | Pull progress deltas |
 | `POST` | `/sync/v1/documents/alias` | yes | Reconcile a hash-keyed record with a newly-known metadata-id (planned) |
@@ -210,13 +210,21 @@ Returns rows where `updated_at > since`, **including tombstones**
 ## Health
 
 ```
-GET /healthz
+GET /health
 GET /readyz
 ```
 
-`/healthz` is liveness; it returns 200 unless the process is broken.
-`/readyz` opens a Postgres connection and returns 200 only if the database is
-reachable.
+Both endpoints mount on the root path (no `/sync/v1` prefix) and are always
+available regardless of deploy mode. The previous `/sync/v1/healthz` was
+removed in PR-A; cluster manifests must point at `/health` going forward.
+
+- `/health` is liveness. Returns `{ "ready": true, "modes": ["progress","ai"] }`
+  where `modes` reflects `OPDS_SYNC_PROGRESS_ENABLED` and `OPDS_SYNC_AI_ENABLED`.
+  Returns 200 unless the process is broken.
+- `/readyz` is readiness. Opens a Postgres connection and verifies that all
+  required migration heads (for the enabled modes) are present in
+  `alembic_version`. Returns 200 with `heads_applied` listing current heads,
+  or 503 with `missing` listing migrations the DB has not yet applied.
 
 ## Errors
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -22,7 +22,11 @@ COPY opds_sync ./opds_sync
 RUN uv pip install "."
 
 COPY migrations ./migrations
+COPY scripts ./scripts
 COPY alembic.ini ./
 
 EXPOSE 8000
-CMD ["uvicorn", "opds_sync.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Entrypoint: run the migrate wrapper (per-branch, mode-aware) then start the app.
+# The wrapper reads OPDS_SYNC_PROGRESS_ENABLED / OPDS_SYNC_AI_ENABLED and runs
+# alembic upgrades only for the enabled branches. See scripts/migrate.py.
+CMD ["sh", "-c", "python /app/scripts/migrate.py && exec uvicorn opds_sync.main:app --host 0.0.0.0 --port 8000"]

--- a/server/README.md
+++ b/server/README.md
@@ -24,11 +24,28 @@ cd server
 cp .env.example .env
 # Edit .env: at minimum set OPDS_SYNC_CWA_BASE_URL and POSTGRES_PASSWORD.
 docker compose up -d
-curl http://localhost:8000/healthz
+curl http://localhost:8000/health
 ```
 
-Migrations run automatically on container start. The image is published
-to `ghcr.io/vitofico/opds-sync:latest` by `server-ci.yaml`.
+Migrations run automatically on container start via `scripts/migrate.py`,
+which respects the deploy-mode flags `OPDS_SYNC_PROGRESS_ENABLED` and
+`OPDS_SYNC_AI_ENABLED` (both default `true`). See `migrations/README.md`
+for the branch-label convention. The image is published to
+`ghcr.io/vitofico/opds-sync:latest` by `server-ci.yaml`.
+
+### Deploy modes
+
+| Mode             | `OPDS_SYNC_PROGRESS_ENABLED` | `OPDS_SYNC_AI_ENABLED` | Mounts                          |
+| ---------------- | ---------------------------- | ---------------------- | ------------------------------- |
+| Full stack       | `true` (default)             | `true` (default)       | `/sync/v1/*`, `/ai/v1/*`        |
+| Sync only        | `true`                       | `false`                | `/sync/v1/*`                    |
+| AI only          | `false`                      | `true`                 | `/ai/v1/*`                      |
+
+`/health` and `/readyz` are mounted on the root in every mode.
+
+Update the health-probe path: it moved from `/sync/v1/healthz` (pre-PR-A) to
+`/health` in PR-A. The k8s manifests in `theficos-cluster` need a one-line
+bump alongside this release.
 
 ## AI smoke test
 

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - "${OPDS_SYNC_PORT:-8000}:8000"
     command: >
-      sh -c "alembic upgrade head &&
+      sh -c "python /app/scripts/migrate.py &&
              uvicorn opds_sync.main:app --host 0.0.0.0 --port 8000"
 
 volumes:

--- a/server/migrations/README.md
+++ b/server/migrations/README.md
@@ -1,0 +1,134 @@
+# Migrations — branch label convention
+
+This directory holds Alembic migrations for the opds-sync server. As of PR-A
+(2026-05-16), migrations split into three forward-only branches off the linear
+backbone `0001 → 0002 → 0003 → 0004`.
+
+## Backbone (do NOT rewrite)
+
+```
+0001 → 0002 → 0003 → 0004
+                       ↑
+                  split point
+```
+
+The four numeric revisions `0001..0004` carry the schema as deployed in
+production. They MUST stay byte-for-byte unchanged:
+
+- `branch_labels = None`
+- linear `down_revision` chain
+- no relabeling, no merging, no stamping operations
+
+Any change to these files risks an Alembic-version divergence between the
+checkout and a running production DB.
+
+## Branches (forward-only from 0004)
+
+From the split point onward, every new migration belongs to exactly one branch:
+
+| Branch     | Label        | Owners | Notes                                        |
+| ---------- | ------------ | ------ | -------------------------------------------- |
+| `core`     | `"core"`     | shared | Reserved; no migrations yet.                 |
+| `progress` | `"progress"` | sync   | First migration lands in PR1 (`progress_001_library_items`). |
+| `ai`       | `"ai"`       | AI     | First migration lands in PR-C (`ai_001_generation_log`).     |
+
+### Adding the FIRST migration on a branch (splice)
+
+When a branch doesn't exist yet, the next migration that introduces it must:
+
+1. Use `down_revision = "0004"` (the backbone tip; not `head`, because `head`
+   is ambiguous in multi-head graphs).
+2. Set `branch_labels = ("<branch>",)`.
+3. Be created via `alembic revision --head=0004 --splice --branch-label=<branch> -m "..."`.
+
+The `--splice` flag is required by Alembic once any other branch already exists,
+because Alembic refuses to introduce a new branch off a non-head revision
+without it. Forgetting `--splice` silently creates a fourth head and breaks
+the wrapper's branch detection.
+
+Template:
+
+```python
+"""<short description>.
+
+Revision ID: <branch>_001
+Revises: 0004
+Create Date: YYYY-MM-DD HH:MM:SS.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "<branch>_001"
+down_revision = "0004"
+branch_labels = ("<branch>",)
+depends_on = None
+
+
+def upgrade() -> None:
+    ...
+
+
+def downgrade() -> None:
+    ...
+```
+
+### Adding SUBSEQUENT migrations on an existing branch
+
+After the first migration on a branch exists, subsequent migrations on the
+same branch use:
+
+```bash
+alembic revision --head=<branch>@head -m "..."
+```
+
+And the file looks like:
+
+```python
+revision = "<branch>_NNN"
+down_revision = "<branch>_NN"        # parent on the same branch
+branch_labels = None                  # only the first migration of a branch labels it
+depends_on = None
+```
+
+## Deploy-time migration
+
+The container entrypoint runs `python /app/scripts/migrate.py`, not
+`alembic upgrade head`. The wrapper:
+
+1. Always upgrades the unlabeled backbone (today: `0004`).
+2. For each enabled+materialized branch (per `OPDS_SYNC_PROGRESS_ENABLED` and
+   `OPDS_SYNC_AI_ENABLED`), runs `alembic upgrade <branch>@head`.
+
+So a sync-only deploy with `OPDS_SYNC_AI_ENABLED=false` never advances the
+DB past `0004` on the AI side, regardless of what ai migrations exist in the
+script directory.
+
+## Downgrades
+
+Downgrades are not part of the wrapper. Run per-branch:
+
+```bash
+alembic downgrade <branch>@-1
+```
+
+## Verifying branch state
+
+Inspect the current script-directory structure:
+
+```bash
+alembic heads --verbose       # human-readable list of branch heads
+alembic history --verbose     # full revision graph
+```
+
+In code:
+
+```python
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+cfg = Config("alembic.ini")
+script = ScriptDirectory.from_config(cfg)
+print(script.get_heads())                  # ['0004'] today; multi-head once branches materialize
+print(script.get_revision("ai@head"))      # raises if ai branch doesn't exist
+```

--- a/server/opds_sync/api/health.py
+++ b/server/opds_sync/api/health.py
@@ -1,23 +1,170 @@
-from fastapi import APIRouter, HTTPException, status
+"""Always-on health endpoints (PR-A): /health and /readyz.
+
+These mount at the root of the application (no prefix) regardless of mode,
+so k8s liveness/readiness probes work in every deploy mode.
+
+GET /health   liveness — does NOT touch the DB; returns enabled modes.
+GET /readyz   readiness — checks DB connectivity AND that all required
+              migration heads (per the enabled-modes + script-directory state)
+              are present in `alembic_version`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
+from opds_sync.config import get_settings
 from opds_sync.db.session import session_scope
 
 router = APIRouter(tags=["health"])
 
+logger = logging.getLogger(__name__)
 
-@router.get("/healthz")
-async def healthz() -> dict:
-    return {"status": "ok"}
+
+def _enabled_modes(progress_enabled: bool, ai_enabled: bool) -> list[str]:
+    """Stable order: progress before ai. Empty when both flags are false."""
+    modes: list[str] = []
+    if progress_enabled:
+        modes.append("progress")
+    if ai_enabled:
+        modes.append("ai")
+    return modes
+
+
+def _alembic_ini_path() -> Path:
+    """Locate alembic.ini relative to cwd. In the container it's /app/alembic.ini;
+    in tests and `cd server`, it's ./alembic.ini."""
+    return Path("alembic.ini")
+
+
+def _declared_labels(rev) -> tuple[str, ...]:
+    """Labels DECLARED on this revision (not propagated from descendants).
+
+    `rev.branch_labels` (public) propagates labels backward to every ancestor,
+    which makes it useless for "where is the label declared?". `_orig_branch_labels`
+    is the canonical declared-labels storage and has been stable across
+    Alembic 1.x.
+    """
+    return tuple(getattr(rev, "_orig_branch_labels", ()) or ())
+
+
+def _existing_branch_labels(script) -> set[str]:
+    """Set of all branch labels declared anywhere in the script directory."""
+    labels: set[str] = set()
+    for rev in script.walk_revisions():
+        labels.update(_declared_labels(rev))
+    return labels
+
+
+def _backbone_head(script) -> str:
+    """Return the last revision on the unlabeled linear backbone.
+
+    Walks oldest→newest until the first revision that DECLARES a branch_label;
+    returns the prior revision. We do NOT take a `get_heads()` shortcut
+    because it would return a branch head (e.g. 'ai_001') once any branch
+    exists, which is not the backbone tip.
+    """
+    backbone_tip: str | None = None
+    # walk_revisions() is newest-to-oldest; reverse for oldest-to-newest.
+    for rev in reversed(list(script.walk_revisions())):
+        if _declared_labels(rev):
+            break
+        backbone_tip = rev.revision
+    if backbone_tip is None:
+        raise RuntimeError("no unlabeled backbone found in script directory")
+    return backbone_tip
+
+
+def _required_heads(script, progress_enabled: bool, ai_enabled: bool) -> set[str]:
+    """Compute which migration heads the DB must contain for the current mode.
+
+    Each enabled+materialized branch contributes its head. If nothing
+    materialized ends up in the set, fall back to requiring the backbone
+    tip (so a DB stamped below the backbone still fails readiness).
+    """
+    labels = _existing_branch_labels(script)
+    required: set[str] = set()
+
+    candidates = [(True, "core"), (progress_enabled, "progress"), (ai_enabled, "ai")]
+    for enabled, label in candidates:
+        if enabled and label in labels:
+            rev = script.get_revision(f"{label}@head")
+            required.add(rev.revision)
+
+    if not required:
+        required.add(_backbone_head(script))
+
+    return required
+
+
+async def _db_alembic_heads() -> set[str]:
+    """Return the set of revisions in the DB's alembic_version table."""
+    async with session_scope() as s:
+        result = await s.execute(text("SELECT version_num FROM alembic_version"))
+        return {row[0] for row in result.fetchall()}
+
+
+@router.get("/health")
+async def health() -> dict:
+    settings = get_settings()
+    return {
+        "ready": True,
+        "modes": _enabled_modes(settings.progress_enabled, settings.ai_enabled),
+    }
 
 
 @router.get("/readyz")
-async def readyz() -> dict:
+async def readyz():
+    settings = get_settings()
+    modes = _enabled_modes(settings.progress_enabled, settings.ai_enabled)
+
+    # DB connectivity.
     try:
         async with session_scope() as s:
-            await s.execute(text("select 1"))
+            await s.execute(text("SELECT 1"))
     except Exception as e:  # noqa: BLE001 — readiness must not leak details
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="db unreachable"
-        ) from e
-    return {"status": "ready"}
+        logger.warning("readyz: db unreachable: %s", e)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"ready": False, "detail": "db unreachable", "modes": modes},
+        )
+
+    # Heads check.
+    try:
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        cfg = Config(str(_alembic_ini_path()))
+        script = ScriptDirectory.from_config(cfg)
+        required = _required_heads(script, settings.progress_enabled, settings.ai_enabled)
+        current = await _db_alembic_heads()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("readyz: heads check failed: %s", e)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"ready": False, "detail": "alembic state unreadable", "modes": modes},
+        )
+
+    missing = required - current
+    if missing:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={
+                "ready": False,
+                "detail": "migrations behind",
+                "modes": modes,
+                "missing": sorted(missing),
+                "current": sorted(current),
+            },
+        )
+
+    return {
+        "ready": True,
+        "modes": modes,
+        "heads_applied": sorted(current),
+    }

--- a/server/opds_sync/api/middleware/__init__.py
+++ b/server/opds_sync/api/middleware/__init__.py
@@ -1,0 +1,6 @@
+"""Cross-cutting ASGI middleware (request-id, request-size limit)."""
+
+from opds_sync.api.middleware.request_id import RequestIDMiddleware
+from opds_sync.api.middleware.request_size import RequestSizeMiddleware
+
+__all__ = ["RequestIDMiddleware", "RequestSizeMiddleware"]

--- a/server/opds_sync/api/middleware/request_id.py
+++ b/server/opds_sync/api/middleware/request_id.py
@@ -1,0 +1,57 @@
+"""Request-ID middleware: read or generate X-Request-ID; bind to contextvar."""
+
+from __future__ import annotations
+
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from opds_sync.core.logging_ctx import request_id_var
+
+# Practical cap so a misbehaving client can't blow up log lines.
+_MAX_REQUEST_ID_LEN = 128
+
+
+def _sanitize(raw: str | None) -> str | None:
+    """Return raw if it is a valid request-id, else None (caller generates one).
+
+    Valid = non-empty, ≤ 128 chars, all printable ASCII (RFC 3986 unreserved + a
+    few common separators). We do not attempt to parse vendor formats; we just
+    reject anything obviously bogus.
+    """
+    if not raw:
+        return None
+    if len(raw) > _MAX_REQUEST_ID_LEN:
+        return None
+    if not all(33 <= ord(c) <= 126 for c in raw):
+        return None
+    return raw
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Bind X-Request-ID for the duration of each request.
+
+    - Reads `X-Request-ID` from the request; validates; falls back to uuid4().hex.
+    - Binds the resolved id to `request_id_var` for downstream code.
+    - Always echoes the id back in the response's `X-Request-ID` header,
+      including on 4xx / 5xx responses produced by inner middleware or routes.
+    - Resets the contextvar after the response, so subsequent requests in the
+      same async task don't see a stale id.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        incoming = request.headers.get("X-Request-ID")
+        request_id = _sanitize(incoming) or uuid.uuid4().hex
+        token = request_id_var.set(request_id)
+        try:
+            response: Response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+        response.headers["X-Request-ID"] = request_id
+        return response

--- a/server/opds_sync/api/middleware/request_size.py
+++ b/server/opds_sync/api/middleware/request_size.py
@@ -1,0 +1,92 @@
+"""Request-size limit middleware: reject bodies larger than max_bytes with 413.
+
+Inspects Content-Length pre-body when present. For chunked transfer (no
+Content-Length), wraps the ASGI `receive` callable and counts bytes as they
+stream in, raising 413 mid-stream when the cap is exceeded.
+
+GET/HEAD/OPTIONS/DELETE bypass the check (no body expected).
+"""
+
+from __future__ import annotations
+
+import json
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_BODYLESS_METHODS = {"GET", "HEAD", "OPTIONS", "DELETE"}
+
+
+class _BodyTooLarge(Exception):
+    pass
+
+
+class RequestSizeMiddleware:
+    """Pure ASGI middleware. We avoid BaseHTTPMiddleware here because counting
+    bytes in a chunked body requires wrapping `receive`, which BaseHTTPMiddleware
+    obscures."""
+
+    def __init__(self, app: ASGIApp, max_bytes: int) -> None:
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "").upper()
+        if method in _BODYLESS_METHODS:
+            await self.app(scope, receive, send)
+            return
+
+        # Try Content-Length first; reject early if oversized.
+        headers = {
+            k.decode("latin-1").lower(): v.decode("latin-1") for k, v in scope.get("headers", [])
+        }
+        content_length = headers.get("content-length")
+        if content_length is not None:
+            try:
+                declared = int(content_length)
+            except ValueError:
+                declared = None
+            if declared is not None and declared > self.max_bytes:
+                await self._reject(send)
+                return
+
+        # For chunked or unknown-length bodies, wrap receive to count bytes.
+        received_bytes = 0
+        max_bytes = self.max_bytes
+        rejection_sent = False
+
+        async def wrapped_receive() -> Message:
+            nonlocal received_bytes, rejection_sent
+            message = await receive()
+            if rejection_sent:
+                return message
+            if message["type"] == "http.request":
+                body: bytes = message.get("body", b"") or b""
+                received_bytes += len(body)
+                if received_bytes > max_bytes:
+                    rejection_sent = True
+                    raise _BodyTooLarge()
+            return message
+
+        try:
+            await self.app(scope, wrapped_receive, send)
+        except _BodyTooLarge:
+            await self._reject(send)
+
+    async def _reject(self, send: Send) -> None:
+        detail = f"request body exceeds {self.max_bytes} bytes"
+        body = json.dumps({"detail": detail}).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})

--- a/server/opds_sync/config.py
+++ b/server/opds_sync/config.py
@@ -15,8 +15,21 @@ class Settings(BaseSettings):
     auth_cache_max_entries: int = 1024
     log_level: str = "INFO"
 
-    # AI substrate (Phase 1)
-    ai_enabled: bool = False
+    # Deploy mode flags (PR-A). Both default true → full-stack mode. Flip to
+    # `false` to disable a domain entirely (router not mounted, migration
+    # branch skipped, lazy provider imports inhibited).
+    progress_enabled: bool = True
+
+    # Maximum allowed request body size in bytes (default 1 MiB). Bounds the
+    # hosted cost surface and protects against accidental large uploads.
+    # Enforced by RequestSizeMiddleware; oversized requests get 413.
+    max_request_bytes: int = 1_048_576
+
+    # AI substrate (Phase 1). Default flipped from False → True in PR-A so the
+    # full-stack mode is the documented default. Existing prod deployments
+    # already set OPDS_SYNC_AI_ENABLED=true explicitly, so this flip is
+    # invisible there; sync-only deploys must now explicitly set false.
+    ai_enabled: bool = True
     ai_base_url: str | None = None
     ai_api_key: str | None = None
     ai_model: str | None = None

--- a/server/opds_sync/core/logging_ctx.py
+++ b/server/opds_sync/core/logging_ctx.py
@@ -1,0 +1,26 @@
+"""Request-scoped logging context for opds-sync.
+
+The request_id ContextVar is set by RequestIDMiddleware on every inbound HTTP
+request and read by RequestIdLogFilter to inject the ID into structured logs.
+Stays empty string outside of an HTTP request (e.g. startup, shutdown).
+"""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+
+# Empty string default makes it safe to read outside a request without raising.
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+
+
+class RequestIdLogFilter(logging.Filter):
+    """Inject the current request_id into every log record.
+
+    Use by attaching to the relevant logger / handler:
+        logging.getLogger().addFilter(RequestIdLogFilter())
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get()
+        return True

--- a/server/opds_sync/main.py
+++ b/server/opds_sync/main.py
@@ -1,24 +1,41 @@
+"""FastAPI app factory. Mounts routers conditionally based on deploy mode flags.
+
+PR-A introduces three deploy modes controlled by env vars:
+  * OPDS_SYNC_PROGRESS_ENABLED=true (default) → /sync/v1/* mounted
+  * OPDS_SYNC_AI_ENABLED=true (default) → /ai/v1/* mounted + AI orchestrator wired
+
+Always-on regardless of mode: /health and /readyz.
+
+Provider lazy-import boundary: opds_sync.core.ai.* and opds_sync.api.ai
+import only inside the ai_enabled block. opds_sync.api.progress imports only
+inside the progress_enabled block. This keeps sync-only and ai-only deploys
+from paying the cost of the other domain's modules.
+"""
+
+from __future__ import annotations
+
 import logging
 
 import httpx
 from fastapi import FastAPI
 
-from opds_sync.api import ai, health, progress
+from opds_sync.api import health
+from opds_sync.api.middleware import RequestIDMiddleware, RequestSizeMiddleware
 from opds_sync.config import get_settings
-from opds_sync.core.ai.client import AIClient
-from opds_sync.core.ai.retrieval import Retriever
-from opds_sync.core.ai.service import InsightOrchestrator
 from opds_sync.core.auth import CalibreAuthValidator
+from opds_sync.core.logging_ctx import RequestIdLogFilter
 from opds_sync.db.session import configure, make_engine
 
 
 def create_app() -> FastAPI:
     settings = get_settings()
     logging.basicConfig(level=settings.log_level)
+    # Inject request_id into every log record produced after this point.
+    logging.getLogger().addFilter(RequestIdLogFilter())
 
     configure(make_engine(settings.database_url))
 
-    app = FastAPI(title="opds-sync", version="0.2.0")
+    app = FastAPI(title="opds-sync", version="0.3.0")
 
     httpx_client = httpx.AsyncClient(timeout=settings.cwa_probe_timeout_s)
     app.state.httpx_client = httpx_client
@@ -35,7 +52,26 @@ def create_app() -> FastAPI:
     async def _close() -> None:
         await httpx_client.aclose()
 
+    # Always-on root endpoints (no prefix). Mounted before mode gates so they
+    # remain available even when both flags are false.
+    app.include_router(health.router)
+
+    if settings.progress_enabled:
+        # Lazy import: only pull progress router when progress mode is on.
+        from opds_sync.api.progress import router as progress_router
+
+        app.include_router(progress_router, prefix="/sync/v1")
+
     if settings.ai_enabled and settings.ai_base_url and settings.ai_model:
+        # Lazy imports: only pull AI modules when AI mode is on AND configured.
+        # This is the "provider lazy-import boundary" — keeps the openai-client
+        # surface (httpx wrapper today; possibly the openai SDK tomorrow) and
+        # the Wikipedia/OpenLibrary clients out of sync-only deploys.
+        from opds_sync.api.ai import router as ai_router
+        from opds_sync.core.ai.client import AIClient
+        from opds_sync.core.ai.retrieval import Retriever
+        from opds_sync.core.ai.service import InsightOrchestrator
+
         ai_client = AIClient(
             base_url=settings.ai_base_url,
             api_key=settings.ai_api_key,
@@ -59,10 +95,23 @@ def create_app() -> FastAPI:
             regen_daily_limit=settings.ai_regen_daily_limit,
         )
         app.state.ai_orchestrator = orch
+        app.include_router(ai_router, prefix="/ai/v1")
+    elif settings.ai_enabled:
+        # AI enabled but missing base_url/model — still mount the router so the
+        # /ai/v1/config endpoint can report `configured: false`. This preserves
+        # pre-PR-A behavior for deployments that flip the flag before fully
+        # configuring the provider.
+        from opds_sync.api.ai import router as ai_router
 
-    app.include_router(health.router, prefix="/sync/v1")
-    app.include_router(progress.router, prefix="/sync/v1")
-    app.include_router(ai.router, prefix="/ai/v1")
+        app.include_router(ai_router, prefix="/ai/v1")
+
+    # Middleware: registered LAST is OUTERMOST in ASGI execution order.
+    # We want RequestID outermost so it can attach X-Request-ID to ANY
+    # response (including 413s from RequestSize). So add RequestSize first,
+    # then RequestID.
+    app.add_middleware(RequestSizeMiddleware, max_bytes=settings.max_request_bytes)
+    app.add_middleware(RequestIDMiddleware)
+
     return app
 
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -31,3 +31,7 @@ include = ["opds_sync*"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "requires_progress: test exercises the /sync/v1 progress router and must skip when OPDS_SYNC_PROGRESS_ENABLED=false",
+    "requires_ai: test exercises the /ai/v1 router and must skip when OPDS_SYNC_AI_ENABLED=false",
+]

--- a/server/scripts/migrate.py
+++ b/server/scripts/migrate.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Forward-only deploy migrator (PR-A).
+
+Reads OPDS_SYNC_PROGRESS_ENABLED and OPDS_SYNC_AI_ENABLED, then:
+  1. Always upgrades the unlabeled backbone to its tip (e.g. 0004 today).
+  2. Per enabled+materialized branch: runs `alembic upgrade <branch>@head`.
+
+Idempotent. Forward-only. Per-branch downgrades remain a manual op
+(`alembic downgrade <branch>@-1`).
+
+Implementation notes:
+- We use Alembic's `ScriptDirectory` + `command.upgrade()` rather than
+  shelling out to the `alembic` CLI and parsing its output. The latter is
+  brittle (output format isn't stable API and revision-id substrings
+  collide with label substrings).
+- Step 1 (backbone) is always run, even when both flags are false, because
+  the backbone is the foundation every branch depends on and a fresh DB
+  must reach 0004 regardless of mode.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+logging.basicConfig(level=logging.INFO, format="[migrate] %(message)s")
+logger = logging.getLogger("migrate")
+
+
+def _is_truthy(val: str | None, default: bool = True) -> bool:
+    if val is None:
+        return default
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _declared_labels(rev) -> tuple[str, ...]:
+    """Return labels DECLARED on this revision (not inherited from descendants).
+
+    Alembic's public `rev.branch_labels` property propagates labels backward to
+    every ancestor of a labeled revision, which makes it useless for the question
+    "where is the branch label declared?". The canonical declared-labels storage
+    is `_orig_branch_labels`, which has been stable across Alembic 1.x.
+    """
+    return tuple(getattr(rev, "_orig_branch_labels", ()) or ())
+
+
+def _existing_branch_labels(script: ScriptDirectory) -> set[str]:
+    """Return all branch labels declared anywhere in the script directory."""
+    labels: set[str] = set()
+    for rev in script.walk_revisions():
+        labels.update(_declared_labels(rev))
+    return labels
+
+
+def _backbone_head(script: ScriptDirectory) -> str:
+    """Return the last revision on the unlabeled linear backbone.
+
+    Walks oldest→newest until the first revision that DECLARES a branch_label;
+    returns the prior revision (the backbone tip). We do NOT take a
+    `get_heads()` shortcut because it would return a branch head (e.g.
+    'ai_001') once any branch exists, which is not the backbone tip.
+    """
+    backbone_tip: str | None = None
+    for rev in reversed(list(script.walk_revisions())):
+        if _declared_labels(rev):
+            break
+        backbone_tip = rev.revision
+    if backbone_tip is None:
+        raise RuntimeError("no unlabeled backbone found in script directory")
+    return backbone_tip
+
+
+def _upgrade_branch(cfg: Config, branch: str) -> None:
+    logger.info("upgrading %s@head", branch)
+    command.upgrade(cfg, f"{branch}@head")
+
+
+def run_migrations(cfg: Config, *, progress_enabled: bool, ai_enabled: bool) -> None:
+    """Run the migrate procedure with explicit args (used by tests + main)."""
+    script = ScriptDirectory.from_config(cfg)
+    labels = _existing_branch_labels(script)
+
+    # Step 1: always ensure the backbone is applied.
+    backbone = _backbone_head(script)
+    logger.info("upgrading backbone to %s", backbone)
+    command.upgrade(cfg, backbone)
+
+    # Step 2: per-branch upgrades, deterministic order.
+    if "core" in labels:
+        _upgrade_branch(cfg, "core")
+
+    if progress_enabled and "progress" in labels:
+        _upgrade_branch(cfg, "progress")
+    elif progress_enabled:
+        logger.info("progress enabled but no progress branch in script directory; skipping")
+
+    if ai_enabled and "ai" in labels:
+        _upgrade_branch(cfg, "ai")
+    elif ai_enabled:
+        logger.info("ai enabled but no ai branch in script directory; skipping")
+
+
+def main() -> int:
+    cfg_path = Path(os.environ.get("ALEMBIC_INI", "alembic.ini"))
+    if not cfg_path.exists():
+        logger.error("alembic config not found at %s", cfg_path)
+        return 2
+
+    cfg = Config(str(cfg_path))
+    progress_enabled = _is_truthy(os.environ.get("OPDS_SYNC_PROGRESS_ENABLED"))
+    ai_enabled = _is_truthy(os.environ.get("OPDS_SYNC_AI_ENABLED"))
+    logger.info("modes: progress=%s ai=%s", progress_enabled, ai_enabled)
+
+    run_migrations(cfg, progress_enabled=progress_enabled, ai_enabled=ai_enabled)
+    logger.info("done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -14,8 +14,33 @@ from sqlalchemy.ext.asyncio import (
 from testcontainers.postgres import PostgresContainer
 
 
-def pytest_collection_modifyitems(items):
-    """Ensure test_schema runs before test_progress to avoid committed-row cross-pollution."""
+def pytest_collection_modifyitems(config, items):
+    """Ordering + mode-marker skipping.
+
+    Ordering: ensure test_schema runs before test_progress to avoid
+    committed-row cross-pollution.
+
+    Mode markers: tests marked `requires_progress` or `requires_ai` are
+    skipped when the corresponding env flag is false (so the CI mode matrix
+    can run the same suite under each mode without spurious failures from
+    routers that aren't mounted).
+    """
+    import os
+
+    def _flag(name: str) -> bool:
+        return os.environ.get(name, "true").strip().lower() in {"1", "true", "yes", "on"}
+
+    progress_on = _flag("OPDS_SYNC_PROGRESS_ENABLED")
+    ai_on = _flag("OPDS_SYNC_AI_ENABLED")
+
+    skip_progress = pytest.mark.skip(reason="OPDS_SYNC_PROGRESS_ENABLED=false")
+    skip_ai = pytest.mark.skip(reason="OPDS_SYNC_AI_ENABLED=false")
+
+    for item in items:
+        if "requires_progress" in item.keywords and not progress_on:
+            item.add_marker(skip_progress)
+        if "requires_ai" in item.keywords and not ai_on:
+            item.add_marker(skip_ai)
 
     def _key(item):
         path = item.nodeid

--- a/server/tests/integration/test_ai_endpoints.py
+++ b/server/tests/integration/test_ai_endpoints.py
@@ -17,6 +17,9 @@ from opds_sync.core.ai.client import AIClient
 from opds_sync.core.ai.service import InsightOrchestrator
 from opds_sync.db.models import BookInsight
 
+# All tests in this file hit /ai/v1/* and so require the ai router.
+pytestmark = pytest.mark.requires_ai
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -86,15 +89,25 @@ def configure_ai():
 # ---------------------------------------------------------------------------
 
 
-async def test_config_endpoint_when_disabled(client_factory):
+async def test_ai_router_not_mounted_when_disabled(client_factory):
+    """PR-A: ai_enabled=false means the entire /ai/v1/* namespace is unmounted."""
     async with client_factory(ai_enabled=False) as client:
+        r = await client.get("/ai/v1/config", headers=_basic_header("alice"))
+    assert r.status_code == 404
+
+
+async def test_config_endpoint_when_enabled_but_unconfigured(client_factory):
+    """ai_enabled=true with base_url/model unset: router mounts, config reports unconfigured."""
+    async with client_factory(ai_enabled=True) as client:
         r = await client.get("/ai/v1/config", headers=_basic_header("alice"))
     assert r.status_code == 200
     body = r.json()
     assert body["configured"] is False
     assert body["base_url_host"] is None
     assert body["model_id"] is None
-    assert body["sources_enabled"] == []
+    # sources_enabled reflects the configured sources string regardless of
+    # whether the provider is reachable — it's a static config view.
+    assert body["sources_enabled"] == ["wikipedia", "openlibrary"]
     assert body["daily_budget"] == 200
     assert body["regen_daily_limit"] == 3
 

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -1,16 +1,41 @@
+"""Integration tests for the always-on /health and /readyz endpoints.
+
+PR-A moves these to root paths (no /sync/v1 prefix) and adds a `modes` payload
+plus a heads-check on /readyz.
+"""
+
+from __future__ import annotations
+
 from httpx import ASGITransport, AsyncClient
 
 
-async def test_healthz_returns_200(app_under_test):
+async def test_health_returns_200_with_modes(app_under_test):
+    transport = ASGITransport(app=app_under_test)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        r = await client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ready"] is True
+    # `modes` reflects whichever flags the test env set. We don't pin the
+    # exact contents here — that's covered by test_modes.py — only that the
+    # endpoint responds with a list.
+    assert isinstance(body["modes"], list)
+
+
+async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_test):
+    transport = ASGITransport(app=app_under_test)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        r = await client.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ready"] is True
+    # No branch labels exist yet, so the heads_applied set is the backbone tip.
+    assert body["heads_applied"] == ["0004"]
+
+
+async def test_old_sync_health_path_is_404(app_under_test):
+    """We deliberately drop /sync/v1/healthz to force cluster manifests to bump."""
     transport = ASGITransport(app=app_under_test)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         r = await client.get("/sync/v1/healthz")
-    assert r.status_code == 200
-    assert r.json() == {"status": "ok"}
-
-
-async def test_readyz_returns_200_when_db_reachable(app_under_test):
-    transport = ASGITransport(app=app_under_test)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        r = await client.get("/sync/v1/readyz")
-    assert r.status_code == 200
+    assert r.status_code == 404

--- a/server/tests/integration/test_lazy_imports.py
+++ b/server/tests/integration/test_lazy_imports.py
@@ -1,0 +1,113 @@
+"""Lazy provider import boundary verification.
+
+PR-A requires that:
+  * sync-only mode never imports the AI client / retrieval / service / prompts
+    or the /ai router module.
+  * ai-only mode never imports the /sync (progress) router module.
+
+We use subprocess isolation (not `importlib.reload`) because module caches in
+the test process bleed between cases and there's no honest way to "undo" an
+import. The subprocess imports opds_sync.main, calls create_app(), then
+prints sys.modules so the parent can assert.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Modules that should NOT load in sync-only mode (provider boundary).
+SYNC_ONLY_FORBIDDEN = [
+    "opds_sync.api.ai",
+    "opds_sync.core.ai.client",
+    "opds_sync.core.ai.retrieval",
+    "opds_sync.core.ai.service",
+    "opds_sync.core.ai.prompts",
+]
+
+# Modules that should NOT load in ai-only mode.
+AI_ONLY_FORBIDDEN = [
+    "opds_sync.api.progress",
+]
+
+
+def _run_in_subprocess(env_overrides: dict[str, str], postgres_url: str) -> set[str]:
+    """Spawn a fresh interpreter, build the app, return the loaded module set."""
+    code = textwrap.dedent(
+        """
+        import json, sys
+        from opds_sync.config import get_settings
+        get_settings.cache_clear()
+        import opds_sync.main as m
+        # Calling create_app() (not just importing the module) triggers any
+        # mode-gated imports. Both paths must stay lazy in non-AI modes.
+        m.create_app()
+        print(json.dumps(sorted(sys.modules.keys())))
+        """
+    ).strip()
+
+    env = {
+        "OPDS_SYNC_DATABASE_URL": postgres_url,
+        "OPDS_SYNC_CWA_BASE_URL": "http://test-cwa",
+        "PATH": "/usr/bin:/bin",
+    }
+    env.update(env_overrides)
+
+    # `sys.executable -c` so we pick up the same venv that runs pytest.
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        rc = result.returncode
+        out = result.stdout
+        err = result.stderr
+        pytest.fail(f"subprocess failed (rc={rc}):\nstdout={out}\nstderr={err}")
+    # The last line is the JSON list; earlier lines may be log output from
+    # configure() / logging.basicConfig.
+    lines = [line for line in result.stdout.strip().splitlines() if line.startswith("[")]
+    assert lines, f"no JSON output in subprocess stdout: {result.stdout!r}"
+    return set(json.loads(lines[-1]))
+
+
+def test_sync_only_does_not_import_ai_modules(postgres_url: str):
+    loaded = _run_in_subprocess(
+        {
+            "OPDS_SYNC_PROGRESS_ENABLED": "true",
+            "OPDS_SYNC_AI_ENABLED": "false",
+        },
+        postgres_url,
+    )
+    for forbidden in SYNC_ONLY_FORBIDDEN:
+        assert forbidden not in loaded, f"sync-only mode loaded forbidden module: {forbidden}"
+
+
+def test_ai_only_does_not_import_progress_router(postgres_url: str):
+    loaded = _run_in_subprocess(
+        {
+            "OPDS_SYNC_PROGRESS_ENABLED": "false",
+            "OPDS_SYNC_AI_ENABLED": "true",
+        },
+        postgres_url,
+    )
+    for forbidden in AI_ONLY_FORBIDDEN:
+        assert forbidden not in loaded, f"ai-only mode loaded forbidden module: {forbidden}"
+
+
+def test_neither_mode_loads_neither(postgres_url: str):
+    loaded = _run_in_subprocess(
+        {
+            "OPDS_SYNC_PROGRESS_ENABLED": "false",
+            "OPDS_SYNC_AI_ENABLED": "false",
+        },
+        postgres_url,
+    )
+    for forbidden in SYNC_ONLY_FORBIDDEN + AI_ONLY_FORBIDDEN:
+        assert forbidden not in loaded, f"neither mode loaded forbidden module: {forbidden}"

--- a/server/tests/integration/test_middleware_integration.py
+++ b/server/tests/integration/test_middleware_integration.py
@@ -1,0 +1,103 @@
+"""End-to-end middleware verification: real FastAPI app + ASGI roundtrip."""
+
+from __future__ import annotations
+
+import base64
+
+from httpx import ASGITransport, AsyncClient
+
+
+def _basic(user: str, pw: str = "x") -> dict[str, str]:
+    token = base64.b64encode(f"{user}:{pw}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+async def test_request_id_echoed_on_200(monkeypatch, postgres_url, alembic_upgrade):
+    monkeypatch.setenv("OPDS_SYNC_DATABASE_URL", postgres_url)
+    monkeypatch.setenv("OPDS_SYNC_CWA_BASE_URL", "http://test-cwa")
+    from opds_sync.config import get_settings
+
+    get_settings.cache_clear()
+    from opds_sync.main import create_app
+
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/health", headers={"X-Request-ID": "trace-abc-123"})
+    assert r.status_code == 200
+    assert r.headers["X-Request-ID"] == "trace-abc-123"
+
+
+async def test_request_id_generated_when_absent(monkeypatch, postgres_url, alembic_upgrade):
+    monkeypatch.setenv("OPDS_SYNC_DATABASE_URL", postgres_url)
+    monkeypatch.setenv("OPDS_SYNC_CWA_BASE_URL", "http://test-cwa")
+    from opds_sync.config import get_settings
+
+    get_settings.cache_clear()
+    from opds_sync.main import create_app
+
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/health")
+    assert r.status_code == 200
+    rid = r.headers["X-Request-ID"]
+    assert rid and len(rid) == 32
+
+
+async def test_request_id_present_on_413_content_length(monkeypatch, postgres_url, alembic_upgrade):
+    """Critical: middleware ordering puts RequestID outermost, so 413 from
+    RequestSize must still carry X-Request-ID."""
+    monkeypatch.setenv("OPDS_SYNC_DATABASE_URL", postgres_url)
+    monkeypatch.setenv("OPDS_SYNC_CWA_BASE_URL", "http://test-cwa")
+    monkeypatch.setenv("OPDS_SYNC_MAX_REQUEST_BYTES", "32")
+    from opds_sync.config import get_settings
+
+    get_settings.cache_clear()
+    from opds_sync.main import create_app
+
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/sync/v1/progress",
+            content=b"x" * 200,  # > 32 byte cap
+            headers={**_basic("alice"), "X-Request-ID": "size-trace-1"},
+        )
+    assert r.status_code == 413
+    assert r.headers.get("X-Request-ID") == "size-trace-1"
+
+
+async def test_request_id_present_on_413_chunked_minimal_app():
+    """Chunked-body 413+request-id verification.
+
+    Routed at a minimal Starlette test endpoint rather than a real FastAPI
+    route because FastAPI's pydantic validator can reject the first chunk
+    (as malformed JSON) before our middleware sees the second chunk and
+    enforces the size cap. The size+request-id ordering is what's under
+    test here, not FastAPI's body-parser semantics.
+    """
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+
+    from opds_sync.api.middleware.request_id import RequestIDMiddleware
+    from opds_sync.api.middleware.request_size import RequestSizeMiddleware
+
+    async def echo(request):
+        b = await request.body()
+        return JSONResponse({"got": len(b)})
+
+    app = Starlette(routes=[Route("/echo", echo, methods=["POST"])])
+    app.add_middleware(RequestSizeMiddleware, max_bytes=32)
+    app.add_middleware(RequestIDMiddleware)
+
+    async def big_chunked():
+        yield b"a" * 20
+        yield b"b" * 40
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/echo",
+            content=big_chunked(),
+            headers={"X-Request-ID": "chunked-trace-2"},
+        )
+    assert r.status_code == 413
+    assert r.headers.get("X-Request-ID") == "chunked-trace-2"

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -1,0 +1,177 @@
+"""Integration tests for scripts/migrate.py against a real Postgres + Alembic.
+
+Cases covered:
+1. Default state (no branch labels): wrapper upgrades backbone, DB ends at 0004,
+   `alembic_version` contains exactly {"0004"}.
+2. Idempotent: running twice in a row is a no-op.
+3. Synthetic branched script directory (tmp copy of migrations + an ai_test_001
+   revision with branch_labels=("ai",)):
+   - ai_enabled=true → upgrades to ai_test_001.
+   - ai_enabled=false → stays at 0004.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import textwrap
+from pathlib import Path
+
+from alembic.config import Config
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+
+async def _alembic_versions(engine: AsyncEngine) -> set[str]:
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT version_num FROM alembic_version"))
+        return {row[0] for row in result.fetchall()}
+
+
+def _make_cfg(url: str, script_location: str | None = None) -> Config:
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", url)
+    if script_location:
+        cfg.set_main_option("script_location", script_location)
+    return cfg
+
+
+async def _run_migrations_in_thread(cfg, *, progress_enabled: bool, ai_enabled: bool):
+    """Alembic's env.py uses asyncio.run() internally, which can't run inside an
+    already-running event loop. Push the call into a worker thread."""
+    from scripts.migrate import run_migrations
+
+    await asyncio.to_thread(
+        run_migrations, cfg, progress_enabled=progress_enabled, ai_enabled=ai_enabled
+    )
+
+
+async def _downgrade_in_thread(cfg, target: str) -> None:
+    from alembic import command as alembic_command
+
+    await asyncio.to_thread(alembic_command.downgrade, cfg, target)
+
+
+async def test_default_state_upgrades_backbone(postgres_url: str):
+    """Fresh DB → wrapper upgrades to backbone tip 0004."""
+
+    # Wipe DB to fresh state.
+    eng = create_async_engine(postgres_url, future=True)
+    async with eng.begin() as conn:
+        await conn.execute(text("DROP SCHEMA public CASCADE"))
+        await conn.execute(text("CREATE SCHEMA public"))
+
+    cfg = _make_cfg(postgres_url)
+    await _run_migrations_in_thread(cfg, progress_enabled=True, ai_enabled=True)
+
+    versions = await _alembic_versions(eng)
+    await eng.dispose()
+    assert versions == {"0004"}
+
+
+async def test_idempotent_second_run(postgres_url: str):
+    """Running the wrapper twice in a row → still at 0004, no errors."""
+
+    cfg = _make_cfg(postgres_url)
+    await _run_migrations_in_thread(cfg, progress_enabled=True, ai_enabled=True)
+    await _run_migrations_in_thread(cfg, progress_enabled=True, ai_enabled=True)
+
+    eng = create_async_engine(postgres_url, future=True)
+    versions = await _alembic_versions(eng)
+    await eng.dispose()
+    assert versions == {"0004"}
+
+
+async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
+    """Copy real migrations to tmp + add a synthetic ai_test_001; verify enabled run picks it up."""
+
+    # First, ensure DB is at 0004 (real migrations).
+    real_cfg = _make_cfg(postgres_url)
+    await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
+
+    # Build a synthetic script directory.
+    synth_dir = tmp_path / "migrations"
+    shutil.copytree("migrations", synth_dir)
+    versions_dir = synth_dir / "versions"
+    (versions_dir / "ai_test_001.py").write_text(
+        textwrap.dedent(
+            '''
+            """synthetic ai branch test migration.
+
+            Revision ID: ai_test_001
+            Revises: 0004
+            Create Date: 2026-05-16 00:00:00.000000
+            """
+
+            import sqlalchemy as sa
+            from alembic import op
+
+            revision = "ai_test_001"
+            down_revision = "0004"
+            branch_labels = ("ai",)
+            depends_on = None
+
+
+            def upgrade() -> None:
+                op.execute("CREATE TABLE IF NOT EXISTS ai_branch_smoke (id int)")
+
+
+            def downgrade() -> None:
+                op.execute("DROP TABLE IF EXISTS ai_branch_smoke")
+            '''
+        )
+    )
+
+    cfg = _make_cfg(postgres_url, script_location=str(synth_dir))
+    await _run_migrations_in_thread(cfg, progress_enabled=True, ai_enabled=True)
+
+    eng = create_async_engine(postgres_url, future=True)
+    versions = await _alembic_versions(eng)
+    # After the ai branch migration runs, alembic_version should contain ai_test_001
+    # (which is the head of the ai branch).
+    assert "ai_test_001" in versions, versions
+    await eng.dispose()
+
+    # Cleanup: roll back the synthetic migration so other tests aren't affected.
+    await _downgrade_in_thread(cfg, "0004")
+
+
+async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
+    """With ai_enabled=False, even if the ai label exists, branch is skipped."""
+
+    real_cfg = _make_cfg(postgres_url)
+    await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
+
+    synth_dir = tmp_path / "migrations"
+    shutil.copytree("migrations", synth_dir)
+    (synth_dir / "versions" / "ai_test_001.py").write_text(
+        textwrap.dedent(
+            '''
+            """synthetic ai branch test migration."""
+            import sqlalchemy as sa
+            from alembic import op
+
+            revision = "ai_test_001"
+            down_revision = "0004"
+            branch_labels = ("ai",)
+            depends_on = None
+
+            def upgrade() -> None:
+                op.execute("CREATE TABLE IF NOT EXISTS ai_branch_smoke_2 (id int)")
+
+            def downgrade() -> None:
+                op.execute("DROP TABLE IF EXISTS ai_branch_smoke_2")
+            '''
+        )
+    )
+
+    cfg = _make_cfg(postgres_url, script_location=str(synth_dir))
+    await _run_migrations_in_thread(cfg, progress_enabled=True, ai_enabled=False)
+
+    eng = create_async_engine(postgres_url, future=True)
+    versions = await _alembic_versions(eng)
+    await eng.dispose()
+    # ai branch skipped → ai_test_001 NOT applied.
+    assert "ai_test_001" not in versions
+    # Backbone still at 0004.
+    assert "0004" in versions

--- a/server/tests/integration/test_modes.py
+++ b/server/tests/integration/test_modes.py
@@ -1,0 +1,88 @@
+"""Mode-gated router mounting tests.
+
+Verifies that OPDS_SYNC_PROGRESS_ENABLED / OPDS_SYNC_AI_ENABLED correctly
+include or exclude the per-domain routers while keeping /health and /readyz
+always mounted.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from httpx import ASGITransport, AsyncClient
+
+
+def _basic_header(user: str, password: str = "x") -> dict[str, str]:
+    token = base64.b64encode(f"{user}:{password}".encode()).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+def _build_app(monkeypatch, postgres_url: str, *, progress_enabled: bool, ai_enabled: bool):
+    """Build a fresh app with the given mode flags."""
+    monkeypatch.setenv("OPDS_SYNC_DATABASE_URL", postgres_url)
+    monkeypatch.setenv("OPDS_SYNC_CWA_BASE_URL", "http://test-cwa")
+    monkeypatch.setenv("OPDS_SYNC_PROGRESS_ENABLED", "true" if progress_enabled else "false")
+    monkeypatch.setenv("OPDS_SYNC_AI_ENABLED", "true" if ai_enabled else "false")
+    from opds_sync.config import get_settings
+
+    get_settings.cache_clear()
+    from opds_sync.main import create_app
+
+    return create_app()
+
+
+async def test_full_mode_mounts_everything(monkeypatch, postgres_url: str, alembic_upgrade):
+    app = _build_app(monkeypatch, postgres_url, progress_enabled=True, ai_enabled=True)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        h = await c.get("/health")
+        assert h.status_code == 200
+        assert h.json()["modes"] == ["progress", "ai"]
+
+        # Progress router mounted: any response other than 404 confirms routing.
+        prog = await c.get("/sync/v1/progress", headers=_basic_header("alice"))
+        assert prog.status_code != 404
+
+        # AI router mounted: any response other than 404 confirms routing.
+        ai = await c.get("/ai/v1/config", headers=_basic_header("alice"))
+        assert ai.status_code != 404
+
+
+async def test_sync_only_mode_excludes_ai(monkeypatch, postgres_url: str, alembic_upgrade):
+    app = _build_app(monkeypatch, postgres_url, progress_enabled=True, ai_enabled=False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        h = await c.get("/health")
+        assert h.status_code == 200
+        assert h.json()["modes"] == ["progress"]
+
+        # AI namespace entirely unmounted.
+        ai = await c.get("/ai/v1/config", headers=_basic_header("alice"))
+        assert ai.status_code == 404
+
+
+async def test_ai_only_mode_excludes_progress(monkeypatch, postgres_url: str, alembic_upgrade):
+    app = _build_app(monkeypatch, postgres_url, progress_enabled=False, ai_enabled=True)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        h = await c.get("/health")
+        assert h.status_code == 200
+        assert h.json()["modes"] == ["ai"]
+
+        # Sync namespace unmounted.
+        prog = await c.get("/sync/v1/progress", headers=_basic_header("alice"))
+        assert prog.status_code == 404
+
+
+async def test_neither_mode_only_mounts_health(monkeypatch, postgres_url: str, alembic_upgrade):
+    app = _build_app(monkeypatch, postgres_url, progress_enabled=False, ai_enabled=False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        h = await c.get("/health")
+        assert h.status_code == 200
+        assert h.json()["modes"] == []
+
+        r = await c.get("/readyz")
+        assert r.status_code == 200
+
+        # Both router namespaces unmounted.
+        prog = await c.get("/sync/v1/progress", headers=_basic_header("alice"))
+        assert prog.status_code == 404
+        ai = await c.get("/ai/v1/config", headers=_basic_header("alice"))
+        assert ai.status_code == 404

--- a/server/tests/integration/test_progress.py
+++ b/server/tests/integration/test_progress.py
@@ -1,6 +1,10 @@
 import base64
 
+import pytest
 from httpx import ASGITransport, AsyncClient
+
+# All tests in this file hit /sync/v1/* and so require the progress router.
+pytestmark = pytest.mark.requires_progress
 
 
 def _basic(user: str, pw: str) -> dict[str, str]:

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -1,0 +1,94 @@
+"""End-to-end /readyz tests covering migration-state edge cases."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def _build_app(monkeypatch, postgres_url: str, *, progress: bool, ai: bool):
+    monkeypatch.setenv("OPDS_SYNC_DATABASE_URL", postgres_url)
+    monkeypatch.setenv("OPDS_SYNC_CWA_BASE_URL", "http://test-cwa")
+    monkeypatch.setenv("OPDS_SYNC_PROGRESS_ENABLED", "true" if progress else "false")
+    monkeypatch.setenv("OPDS_SYNC_AI_ENABLED", "true" if ai else "false")
+    from opds_sync.config import get_settings
+
+    get_settings.cache_clear()
+    from opds_sync.main import create_app
+
+    return create_app()
+
+
+async def _stamp(postgres_url: str, revision: str) -> None:
+    """Forcibly set alembic_version to the given revision (single row).
+
+    Bypasses Alembic so we can put the DB into states it wouldn't normally
+    reach via legal upgrade paths.
+    """
+    eng = create_async_engine(postgres_url, future=True)
+    async with eng.begin() as conn:
+        await conn.execute(text("DELETE FROM alembic_version"))
+        await conn.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:r)"),
+            {"r": revision},
+        )
+    await eng.dispose()
+
+
+async def _restore_to_0004(postgres_url: str) -> None:
+    """Set alembic_version row back to 0004 (the real schema state)."""
+    await _stamp(postgres_url, "0004")
+
+
+@pytest.fixture
+async def restore_after(postgres_url: str, alembic_upgrade):
+    """Ensure each test ends with the DB stamped back to 0004."""
+    yield
+    await _restore_to_0004(postgres_url)
+
+
+async def test_readyz_200_when_at_backbone_no_labels(monkeypatch, postgres_url, alembic_upgrade):
+    app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ready"] is True
+    assert body["heads_applied"] == ["0004"]
+
+
+async def test_readyz_503_when_db_below_backbone(
+    monkeypatch, postgres_url, alembic_upgrade, restore_after
+):
+    await _stamp(postgres_url, "0003")
+    app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/readyz")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["ready"] is False
+    assert "0004" in body["missing"]
+
+
+async def test_readyz_200_with_neither_mode_at_backbone(monkeypatch, postgres_url, alembic_upgrade):
+    app = _build_app(monkeypatch, postgres_url, progress=False, ai=False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["modes"] == []
+    assert body["heads_applied"] == ["0004"]
+
+
+async def test_readyz_503_with_neither_mode_below_backbone(
+    monkeypatch, postgres_url, alembic_upgrade, restore_after
+):
+    await _stamp(postgres_url, "0002")
+    app = _build_app(monkeypatch, postgres_url, progress=False, ai=False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/readyz")
+    assert r.status_code == 503
+    body = r.json()
+    assert "0004" in body["missing"]

--- a/server/tests/unit/test_logging_ctx.py
+++ b/server/tests/unit/test_logging_ctx.py
@@ -1,0 +1,49 @@
+"""Unit tests for opds_sync.core.logging_ctx."""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+
+from opds_sync.core.logging_ctx import RequestIdLogFilter, request_id_var
+
+
+def test_request_id_var_is_contextvar_with_empty_default():
+    assert isinstance(request_id_var, ContextVar)
+    # default="" means reading outside any explicit `set()` returns "".
+    assert request_id_var.get() == ""
+
+
+def test_filter_injects_request_id_into_record():
+    rec = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hi",
+        args=(),
+        exc_info=None,
+    )
+    token = request_id_var.set("abc123")
+    try:
+        f = RequestIdLogFilter()
+        assert f.filter(rec) is True
+        assert rec.request_id == "abc123"
+    finally:
+        request_id_var.reset(token)
+
+
+def test_filter_uses_empty_string_when_unset():
+    rec = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hi",
+        args=(),
+        exc_info=None,
+    )
+    # Fresh context: var is empty.
+    f = RequestIdLogFilter()
+    assert f.filter(rec) is True
+    assert rec.request_id == ""

--- a/server/tests/unit/test_middleware_request_id.py
+++ b/server/tests/unit/test_middleware_request_id.py
@@ -1,0 +1,80 @@
+"""Unit tests for RequestIDMiddleware via a minimal Starlette app."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from opds_sync.api.middleware.request_id import RequestIDMiddleware
+from opds_sync.core.logging_ctx import request_id_var
+
+
+def _make_app(capture: dict) -> Starlette:
+    async def endpoint(request):
+        capture["seen_during_request"] = request_id_var.get()
+        return JSONResponse({"ok": True})
+
+    app = Starlette(routes=[Route("/", endpoint)])
+    app.add_middleware(RequestIDMiddleware)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_preserves_valid_incoming_header():
+    capture: dict = {}
+    app = _make_app(capture)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/", headers={"X-Request-ID": "client-abc-123"})
+    assert r.status_code == 200
+    assert r.headers["X-Request-ID"] == "client-abc-123"
+    assert capture["seen_during_request"] == "client-abc-123"
+
+
+@pytest.mark.asyncio
+async def test_generates_when_absent():
+    capture: dict = {}
+    app = _make_app(capture)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/")
+    assert r.status_code == 200
+    rid = r.headers["X-Request-ID"]
+    assert rid and len(rid) == 32  # uuid4 hex
+    assert capture["seen_during_request"] == rid
+
+
+@pytest.mark.asyncio
+async def test_rejects_oversized_header_and_generates_new():
+    capture: dict = {}
+    app = _make_app(capture)
+    too_long = "x" * 200
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/", headers={"X-Request-ID": too_long})
+    rid = r.headers["X-Request-ID"]
+    assert rid != too_long
+    assert len(rid) == 32
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_printable_header():
+    capture: dict = {}
+    app = _make_app(capture)
+    bad = "abc\x01def"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/", headers={"X-Request-ID": bad})
+    assert r.headers["X-Request-ID"] != bad
+
+
+@pytest.mark.asyncio
+async def test_resets_contextvar_after_response():
+    capture: dict = {}
+    app = _make_app(capture)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        await c.get("/", headers={"X-Request-ID": "first-id"})
+        # Outside the request scope, the var should be empty again.
+        assert request_id_var.get() == ""
+        # Second request without header generates a new one independent of first.
+        r = await c.get("/")
+    assert r.headers["X-Request-ID"] != "first-id"

--- a/server/tests/unit/test_middleware_request_size.py
+++ b/server/tests/unit/test_middleware_request_size.py
@@ -1,0 +1,78 @@
+"""Unit tests for RequestSizeMiddleware."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from opds_sync.api.middleware.request_size import RequestSizeMiddleware
+
+
+def _make_app(max_bytes: int) -> Starlette:
+    async def echo(request):
+        body = await request.body()
+        return JSONResponse({"got": len(body)})
+
+    async def get_endpoint(request):
+        return JSONResponse({"ok": True})
+
+    app = Starlette(
+        routes=[
+            Route("/echo", echo, methods=["POST", "PUT"]),
+            Route("/get", get_endpoint, methods=["GET", "DELETE"]),
+        ]
+    )
+    app.add_middleware(RequestSizeMiddleware, max_bytes=max_bytes)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_passthrough_under_cap():
+    app = _make_app(max_bytes=100)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/echo", content=b"hello")
+    assert r.status_code == 200
+    assert r.json() == {"got": 5}
+
+
+@pytest.mark.asyncio
+async def test_413_when_content_length_exceeds_cap():
+    app = _make_app(max_bytes=10)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/echo", content=b"x" * 50)
+    assert r.status_code == 413
+    assert "exceeds" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_413_for_chunked_body_exceeding_cap():
+    app = _make_app(max_bytes=10)
+
+    async def chunked_iter():
+        # Yielding bytes via httpx triggers chunked transfer encoding (no
+        # Content-Length).
+        yield b"a" * 6
+        yield b"b" * 8  # cumulative 14 > 10
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/echo", content=chunked_iter())
+    assert r.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_get_bypasses_check():
+    app = _make_app(max_bytes=10)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/get")
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_delete_bypasses_check():
+    app = _make_app(max_bytes=10)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.delete("/get")
+    assert r.status_code == 200

--- a/server/tests/unit/test_migrate_logic.py
+++ b/server/tests/unit/test_migrate_logic.py
@@ -1,0 +1,125 @@
+"""Synthetic-graph unit tests for the migrate wrapper's pure logic.
+
+Operates on stubs in lieu of a real Alembic ScriptDirectory + DB, so these
+tests are fast and isolated. Integration tests in tests/integration verify
+the wrapper against a real Postgres + the real migrations directory.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.migrate import _backbone_head, _existing_branch_labels
+
+
+class _StubRevision:
+    def __init__(self, revision: str, branch_labels: tuple[str, ...] | None = None):
+        self.revision = revision
+        # Mirror Alembic: public `branch_labels` propagates from descendants,
+        # but `_orig_branch_labels` is the per-revision declared set. The
+        # migrate module reads `_orig_branch_labels`, so the stub matches.
+        self.branch_labels = set(branch_labels or ())
+        self._orig_branch_labels = tuple(branch_labels or ())
+
+
+class _StubScriptDirectory:
+    """walk_revisions() returns newest-to-oldest, mirroring Alembic."""
+
+    def __init__(self, revisions_newest_first: list[_StubRevision]):
+        self._revs = revisions_newest_first
+
+    def walk_revisions(self):
+        return iter(self._revs)
+
+
+def test_existing_branch_labels_empty_when_no_labels():
+    sd = _StubScriptDirectory(
+        [
+            _StubRevision("0004"),
+            _StubRevision("0003"),
+            _StubRevision("0002"),
+            _StubRevision("0001"),
+        ]
+    )
+    assert _existing_branch_labels(sd) == set()
+
+
+def test_existing_branch_labels_collects_all_labels():
+    sd = _StubScriptDirectory(
+        [
+            _StubRevision("ai_001", branch_labels=("ai",)),
+            _StubRevision("progress_001", branch_labels=("progress",)),
+            _StubRevision("0004"),
+            _StubRevision("0003"),
+        ]
+    )
+    assert _existing_branch_labels(sd) == {"ai", "progress"}
+
+
+def test_backbone_head_returns_only_head_when_no_labels():
+    sd = _StubScriptDirectory(
+        [
+            _StubRevision("0004"),
+            _StubRevision("0003"),
+            _StubRevision("0002"),
+            _StubRevision("0001"),
+        ]
+    )
+    assert _backbone_head(sd) == "0004"
+
+
+def test_backbone_head_returns_unlabeled_tip_when_branches_exist():
+    """Critical case: ai_001 exists as a child of 0004; backbone tip is still 0004."""
+    sd = _StubScriptDirectory(
+        [
+            _StubRevision("ai_001", branch_labels=("ai",)),
+            _StubRevision("0004"),  # unlabeled — backbone tip
+            _StubRevision("0003"),
+            _StubRevision("0002"),
+            _StubRevision("0001"),
+        ]
+    )
+    assert _backbone_head(sd) == "0004"
+
+
+def test_backbone_head_stops_at_first_labeled_revision():
+    """Multiple branches off 0004 → backbone tip is still 0004."""
+    sd = _StubScriptDirectory(
+        [
+            _StubRevision("ai_002", branch_labels=()),
+            _StubRevision("ai_001", branch_labels=("ai",)),
+            _StubRevision("progress_001", branch_labels=("progress",)),
+            _StubRevision("0004"),
+            _StubRevision("0003"),
+            _StubRevision("0002"),
+            _StubRevision("0001"),
+        ]
+    )
+    assert _backbone_head(sd) == "0004"
+
+
+def test_backbone_head_raises_when_first_revision_is_labeled():
+    """Defensive: if no unlabeled revisions exist, raise rather than silently mislabel."""
+    sd = _StubScriptDirectory(
+        [
+            _StubRevision("labeled_001", branch_labels=("core",)),
+        ]
+    )
+    with pytest.raises(RuntimeError, match="no unlabeled backbone"):
+        _backbone_head(sd)
+
+
+def test_truthy_parsing():
+    from scripts.migrate import _is_truthy
+
+    assert _is_truthy(None, default=True) is True
+    assert _is_truthy(None, default=False) is False
+    assert _is_truthy("true") is True
+    assert _is_truthy("True") is True
+    assert _is_truthy("1") is True
+    assert _is_truthy("yes") is True
+    assert _is_truthy("on") is True
+    assert _is_truthy("false") is False
+    assert _is_truthy("0") is False
+    assert _is_truthy("") is False
+    assert _is_truthy("nope") is False

--- a/server/tests/unit/test_settings.py
+++ b/server/tests/unit/test_settings.py
@@ -1,0 +1,51 @@
+"""Tests for opds_sync.config.Settings defaults.
+
+PR-A flips ai_enabled default to True and adds progress_enabled + max_request_bytes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from opds_sync.config import Settings, get_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    """Ensure each test sees a fresh settings instance (no env-bleed)."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_defaults_match_pr_a_contract(monkeypatch):
+    # Strip any inherited env so we observe code defaults only.
+    for var in (
+        "OPDS_SYNC_AI_ENABLED",
+        "OPDS_SYNC_PROGRESS_ENABLED",
+        "OPDS_SYNC_MAX_REQUEST_BYTES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    s = Settings()
+    assert s.ai_enabled is True
+    assert s.progress_enabled is True
+    assert s.max_request_bytes == 1_048_576
+
+
+def test_progress_enabled_env_override(monkeypatch):
+    monkeypatch.setenv("OPDS_SYNC_PROGRESS_ENABLED", "false")
+    s = Settings()
+    assert s.progress_enabled is False
+
+
+def test_ai_enabled_env_override(monkeypatch):
+    monkeypatch.setenv("OPDS_SYNC_AI_ENABLED", "false")
+    s = Settings()
+    assert s.ai_enabled is False
+
+
+def test_max_request_bytes_env_override(monkeypatch):
+    monkeypatch.setenv("OPDS_SYNC_MAX_REQUEST_BYTES", "2048")
+    s = Settings()
+    assert s.max_request_bytes == 2048


### PR DESCRIPTION
## Summary

Splits the opds-sync codebase to support three deploy modes from one image:

| Mode             | `OPDS_SYNC_PROGRESS_ENABLED` | `OPDS_SYNC_AI_ENABLED` |
| ---------------- | ---------------------------- | ---------------------- |
| Full stack       | `true` (default)             | `true` (default)       |
| Sync only        | `true`                       | `false`                |
| AI only          | `false`                      | `true`                 |

`/health` and `/readyz` mount on the root regardless of mode. AI-only never loads the `progress` router or models migrations; sync-only never loads the AI client / retrieval / service / prompts modules (verified via subprocess `sys.modules` introspection).

Migrations split forward-only from revision `0004` into `core` / `progress` / `ai` branches. The container entrypoint now runs `python /app/scripts/migrate.py`, which uses Alembic's `ScriptDirectory` API to upgrade only enabled+materialized branches plus the unlabeled backbone.

## What changed

- **Alembic**:
  - `0001..0004` stay byte-for-byte unchanged.
  - `server/migrations/README.md` documents the branch label convention and the `--splice` rule for the first migration on a new branch.
  - `server/scripts/migrate.py`: Python wrapper using `ScriptDirectory.walk_revisions()` and `command.upgrade()`. Always advances the unlabeled backbone first (today: `0004`).
- **Config**: `ai_enabled` default flipped `False → True`; `progress_enabled` and `max_request_bytes` (default 1 MiB) added.
- **`main.py`**: Conditional router mounts via lazy imports. Sync-only mode never imports `opds_sync.core.ai.*`; AI-only never imports `opds_sync.api.progress`.
- **Middleware**:
  - `RequestSizeMiddleware`: 413 over `OPDS_SYNC_MAX_REQUEST_BYTES`. Handles both Content-Length and chunked transfer.
  - `RequestIDMiddleware`: reads or generates `X-Request-ID`, binds to a `contextvars.ContextVar` for log filters, echoes on every response (including 413).
- **`health.py`**: `/health` returns `{ready, modes}`; `/readyz` checks DB connectivity + that all required migration heads (for the enabled modes) are present in `alembic_version`. Heads computation: enabled+materialized branch heads, with `{backbone_head}` fallback when nothing is materialized.
- **CI**: `server-ci.yaml` `test` job now runs a matrix `[full, sync_only, ai_only]` exporting the corresponding env vars. Lint runs only in the full cell.
- **Dockerfile + docker-compose.yml**: CMD/command updated to invoke `scripts/migrate.py` instead of `alembic upgrade head`.

## Test plan

- [x] Unit tests for settings defaults, logging contextvar, request-id middleware, request-size middleware (Content-Length + chunked), migrate-wrapper pure logic on synthetic script graphs.
- [x] Integration tests for: each of 4 modes (full / sync-only / AI-only / neither), lazy-import boundary (subprocess + `create_app()` + `sys.modules` assertions), `/readyz` migration-state edge cases (backbone-only, below-backbone, neither-mode at/below backbone), migrate script (default state, idempotency, synthetic ai-branch enabled/disabled), middleware integration (request-id on 200 and 413 with both Content-Length and chunked bodies).
- [x] Full suite passes under all three flag combinations locally:
  - `OPDS_SYNC_PROGRESS_ENABLED=true OPDS_SYNC_AI_ENABLED=true`: 119 passed
  - `OPDS_SYNC_PROGRESS_ENABLED=true OPDS_SYNC_AI_ENABLED=false`: 113 passed, 6 skipped (requires_ai)
  - `OPDS_SYNC_PROGRESS_ENABLED=false OPDS_SYNC_AI_ENABLED=true`: 112 passed, 7 skipped (requires_progress)
- [x] `uv run ruff check . && uv run ruff format --check .` clean.
- [x] `git diff main -- server/migrations/versions/000*` returns empty — migrations 0001-0004 untouched.

## Deployment notes

- **Production DB (currently at `0004`)** is backwards-compatible without any operator action: the migrate wrapper detects no branch labels in the script directory, runs `command.upgrade(cfg, "0004")` (no-op), then serves traffic. PR-C / PR1 will add the first labeled migrations off `0004`.
- **`OPDS_SYNC_AI_ENABLED` default flipped `False → True`**. The cluster's `deployment.yaml` already pins this explicitly to `"true"` (per `quire-ai-deployment-notes.md`), so this is invisible to prod. Sync-only deployers (currently zero) must now set `false` explicitly.
- **K8s manifest update needed in `theficos-cluster`**: the health probe path moved from `/sync/v1/healthz` to `/health`. One-line bump in `applications/opds-sync/deployment.yaml` alongside this release.

## Review summary

Architect review (Codex GPT, 4 rounds) — final verdict `APPROVE`:

> Implementation can proceed: yes. No correctness blocker remains.
>
> `_backbone_head()` walks oldest-to-newest until the first labeled revision, returning the unlabeled backbone tip.
>
> Phase 4.3 includes the "ai label exists, AI disabled, DB at 0004 → 200" synthetic case.
>
> Pre-implementation caution: keep the implementation aligned to the explicit backbone target in spec §5.3.

Earlier rounds caught: simultaneous-head fallacy in the original Alembic model; brittle shell parsing replaced by `ScriptDirectory` APIs; `/readyz` fallback gap when only a disabled branch is materialized; `_backbone_head` shortcut that broke after any branch existed. All addressed.

## Notes for downstream PR agents

- **PR-C and PR1 (first branch-adding PRs)**: the spec + plan + `server/migrations/README.md` document the splice rule. Concretely: `alembic revision --head=0004 --splice --branch-label=<branch> -m "..."` for the first migration on a new branch. After that, `--head=<branch>@head` for subsequent migrations on the same branch.
- **Both** future progress and AI migrations use `down_revision="0004"` for their first revision.
- The migrate wrapper detects materialized branches automatically via `_declared_labels(rev)` (uses `rev._orig_branch_labels`, the canonical Alembic-stable declared-labels storage — public `rev.branch_labels` propagates to ancestors and is unsuitable for this check).
- The CI matrix `mode` parameter ensures future PRs don't regress mode isolation without being noticed.