### PR TITLE
feat(server): ai_generation_log table + cache-key tenant audit

### DIFF
--- a/docs/superpowers/plans/2026-05-16-ai-generation-log.md
+++ b/docs/superpowers/plans/2026-05-16-ai-generation-log.md
@@ -1,0 +1,1835 @@
+# `ai_generation_log` Table + Cache-Key Tenant Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce the `ai_generation_log` table on the `ai` alembic branch as the per-call tenant audit trail, codify the cache-integrity invariant as a regression test, fix PR-A test fallout from materializing the first `ai` branch, and stop reading `book_insights.generated_by` for any decision.
+
+**Architecture:** A new `AIGenerationLog` SQLAlchemy model is migrated in `migrations/versions/ai_001_generation_log.py` (first migration on the `ai` branch, `down_revision = "0004"`, `branch_labels = ("ai",)` per PR-A's convention). The `InsightOrchestrator` writes one log row per `get()`-hit / `generate()` / `regenerate()` call, capturing `tenant_id` (per-call kwarg, default `"local"`), `subject` (the existing `user_id` arg), `request_id` (from PR-A's `request_id_var` ContextVar), `model_id`, `prompt_version`, `latency_ms`, and `status` (`hit`/`miss`). Errors emit a structured log line instead of a DB row. A parametrized integration test asserts no shared-cache table carries a tenant column. Test fixtures are adjusted to use the production-mode-aware migration wrapper.
+
+**Tech Stack:** Python 3.12 · FastAPI · SQLAlchemy 2 (async) · Alembic · PostgreSQL 16 (testcontainers) · pytest / pytest-asyncio · uv
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `server/migrations/versions/ai_001_generation_log.py` | Create | First labeled migration on `ai` branch; creates `ai_generation_log` table + indexes. |
+| `server/opds_sync/db/models.py` | Modify | Add `AIGenerationLog` model; add cache-integrity invariant docstrings above `BookInsight` and `ExternalSourceCacheEntry`. |
+| `server/opds_sync/core/ai/service.py` | Modify | Add per-call `tenant_id` kwarg on `get/generate/regenerate`; emit one log row per call via `_log_generation` helper; structured error log on AI client raise; mark `generated_by` write deprecated. |
+| `server/opds_sync/api/ai.py` | Modify | Pass `user_id` + `tenant_id="local"` into all orchestrator calls (including `get()`). |
+| `server/tests/conftest.py` | Modify | Replace `alembic_upgrade` fixture body with `scripts.migrate.run_migrations(cfg, progress_enabled=True, ai_enabled=True)`. |
+| `server/tests/unit/conftest.py` | Modify | Add `ai_generation_log` to truncate list with `CASCADE`. |
+| `server/tests/unit/test_ai_service.py` | Modify | Add 9 unit tests (hit/miss/get/coalesce/request-id/tenant default/tenant override/error-log). |
+| `server/tests/integration/test_schema.py` | Modify | Add `test_ai_generation_log_table_exists` + `test_ai_generation_log_round_trip`. |
+| `server/tests/integration/test_ai_audit_log.py` | Create | Two-tenant convergence test using **separate sessions**: one insight, two log rows, distinct tenants. |
+| `server/tests/integration/test_cache_key_audit.py` | Create | Parametrized regression test asserting shared-cache tables carry no tenant columns. |
+| `server/tests/integration/test_readyz_migration_state.py` | Modify | Update assertions: `["0004"]` → `["ai_001"]` for the "AI head" test; stamp to `0004` for the "neither mode" test. |
+
+---
+
+## Working directory
+
+All paths below are relative to `/Users/vito/repos/quire/.claude/worktrees/pr-c-ai-generation-log` (the PR-C worktree).
+
+All `pytest` / `alembic` invocations run from the `server/` subdirectory:
+
+```bash
+cd /Users/vito/repos/quire/.claude/worktrees/pr-c-ai-generation-log/server
+uv run pytest ...
+```
+
+---
+
+### Task 1: Migration `ai_001_generation_log` + introspection test
+
+**Files:**
+- Create: `server/migrations/versions/ai_001_generation_log.py`
+- Modify: `server/tests/integration/test_schema.py`
+
+- [ ] **Step 1: Write the failing test asserting the table exists after migrations**
+
+Append to `server/tests/integration/test_schema.py`:
+
+```python
+import pytest
+from sqlalchemy import inspect
+
+
+@pytest.mark.requires_ai
+async def test_ai_generation_log_table_exists(engine) -> None:
+    """ai_001 migration creates the table with the right columns + indexes + FK."""
+
+    def _introspect(sync_conn) -> dict:
+        insp = inspect(sync_conn)
+        cols = {c["name"]: c for c in insp.get_columns("ai_generation_log")}
+        idx_names = {i["name"] for i in insp.get_indexes("ai_generation_log")}
+        fks = insp.get_foreign_keys("ai_generation_log")
+        return {"cols": cols, "idx": idx_names, "fks": fks}
+
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_introspect)
+
+    expected_cols = {
+        "id",
+        "book_insight_id",
+        "tenant_id",
+        "subject",
+        "request_id",
+        "model_id",
+        "prompt_version",
+        "latency_ms",
+        "status",
+        "error_class",
+        "created_at",
+    }
+    assert expected_cols.issubset(info["cols"].keys())
+    assert "ix_ai_generation_log_tenant_created" in info["idx"]
+    assert "ix_ai_generation_log_book_insight" in info["idx"]
+    fk = next((f for f in info["fks"] if f["referred_table"] == "book_insights"), None)
+    assert fk is not None, "expected FK to book_insights"
+    assert fk["constrained_columns"] == ["book_insight_id"]
+    assert fk["options"].get("ondelete", "").upper() == "CASCADE"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/vito/repos/quire/.claude/worktrees/pr-c-ai-generation-log/server
+uv run pytest tests/integration/test_schema.py::test_ai_generation_log_table_exists -v
+```
+
+Expected: FAIL with `NoSuchTableError` or `KeyError: 'ai_generation_log'`.
+
+- [ ] **Step 3: Create the migration file**
+
+Create `server/migrations/versions/ai_001_generation_log.py`:
+
+```python
+"""ai_001_generation_log: per-call tenant audit log keyed to book_insights.
+
+First migration on the `ai` branch (per PR-A's branching convention).
+
+Schema:
+- ai_generation_log records one row per AI insight call (hit, miss; errors
+  go to structured logs because they have no FK target). It is the future
+  billing/audit substrate; the shared cache table `book_insights` stays
+  tenant-blind.
+- FK on book_insight_id is ON DELETE CASCADE: invalidating an insight cleans
+  up its audit children.
+- The check constraint accepts 'hit' | 'miss' | 'error' to remain forward-
+  compatible with a future PR that introduces error rows (via nullable FK or
+  sentinel rows). PR-C only emits 'hit' and 'miss'.
+
+Revision ID: ai_001
+Revises: 0004
+Create Date: 2026-05-16 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_001"
+down_revision = "0004"
+branch_labels = ("ai",)
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_generation_log",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "book_insight_id",
+            sa.BigInteger(),
+            sa.ForeignKey("book_insights.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tenant_id",
+            sa.String(),
+            nullable=False,
+            server_default=sa.text("'local'"),
+        ),
+        sa.Column("subject", sa.String(), nullable=False),
+        sa.Column("request_id", sa.String(), nullable=True),
+        sa.Column("model_id", sa.String(), nullable=False),
+        sa.Column("prompt_version", sa.String(), nullable=False),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("error_class", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "status IN ('hit', 'miss', 'error')",
+            name="ck_ai_generation_log_status",
+        ),
+    )
+    op.create_index(
+        "ix_ai_generation_log_tenant_created",
+        "ai_generation_log",
+        ["tenant_id", "created_at"],
+    )
+    op.create_index(
+        "ix_ai_generation_log_book_insight",
+        "ai_generation_log",
+        ["book_insight_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_ai_generation_log_book_insight", table_name="ai_generation_log"
+    )
+    op.drop_index(
+        "ix_ai_generation_log_tenant_created", table_name="ai_generation_log"
+    )
+    op.drop_table("ai_generation_log")
+```
+
+- [ ] **Step 4: Verify alembic recognizes the branch**
+
+```bash
+cd /Users/vito/repos/quire/.claude/worktrees/pr-c-ai-generation-log/server
+uv run alembic heads --verbose
+```
+
+Expected: `Rev: ai_001 (head)` with `Branch names: ai` and `Parent: 0004`.
+
+- [ ] **Step 5: Run the introspection test to verify it passes**
+
+```bash
+uv run pytest tests/integration/test_schema.py::test_ai_generation_log_table_exists -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full test suite — expect some readyz failures now**
+
+```bash
+uv run pytest -q 2>&1 | tail -20
+```
+
+Expected: 2 failures in `test_readyz_migration_state.py` (heads_applied mismatch). These are addressed in Task 2. All other tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/vito/repos/quire/.claude/worktrees/pr-c-ai-generation-log
+git add server/migrations/versions/ai_001_generation_log.py server/tests/integration/test_schema.py
+git commit -m ":sparkles: feat(server): ai_001 migration — ai_generation_log table"
+```
+
+---
+
+### Task 2: Fix PR-A test fallout (conftest + readyz tests)
+
+**Files:**
+- Modify: `server/tests/conftest.py`
+- Modify: `server/tests/integration/test_readyz_migration_state.py`
+
+- [ ] **Step 1: Update `alembic_upgrade` fixture to use the mode-aware wrapper**
+
+In `server/tests/conftest.py`, replace the `alembic_upgrade` fixture body:
+
+```python
+@pytest.fixture(scope="session")
+def alembic_upgrade(postgres_url: str) -> None:
+    # Use the production mode-aware wrapper instead of `alembic upgrade head`.
+    # `head` is ambiguous once multiple branches exist; the wrapper handles
+    # backbone + per-branch upgrades correctly. We pass both flags true so
+    # the test schema reaches `ai@head` and (eventually) `progress@head`.
+    cfg = AlembicConfig("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", postgres_url)
+    from scripts.migrate import run_migrations
+
+    run_migrations(cfg, progress_enabled=True, ai_enabled=True)
+```
+
+- [ ] **Step 2: Update readyz assertions for `ai_001` head**
+
+In `server/tests/integration/test_readyz_migration_state.py`:
+
+(a) Rename and update `test_readyz_200_when_at_backbone_no_labels`:
+
+```python
+async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
+    """With ai_001 materialized and ai mode on, the required head is ai@head."""
+    app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ready"] is True
+    assert body["heads_applied"] == ["ai_001"]
+```
+
+(b) Update `test_readyz_200_with_neither_mode_at_backbone` to stamp the DB to `0004` before checking (the session fixture brings the DB up to `ai_001`, which is not the "neither mode at backbone" scenario this test is asserting):
+
+```python
+async def test_readyz_200_with_neither_mode_at_backbone(
+    monkeypatch, postgres_url, alembic_upgrade, restore_after
+):
+    """With neither mode enabled, backbone tip (0004) is the only required head.
+
+    Stamp the DB to 0004 explicitly because the session-scoped fixture brings
+    everything up to ai@head; we want to exercise the "fresh sync-only deploy
+    that never materialized the ai branch" code path.
+    """
+    await _stamp(postgres_url, "0004")
+    app = _build_app(monkeypatch, postgres_url, progress=False, ai=False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["modes"] == []
+    assert body["heads_applied"] == ["0004"]
+```
+
+Note: `restore_after` already exists in the file and stamps back to `0004` post-test, so subsequent tests start clean.
+
+- [ ] **Step 3: Run the readyz tests to verify they pass**
+
+```bash
+uv run pytest tests/integration/test_readyz_migration_state.py -v
+```
+
+Expected: all 4 readyz tests PASS.
+
+- [ ] **Step 4: Run the full suite to confirm no regressions**
+
+```bash
+uv run pytest -q
+```
+
+Expected: 120 passed (119 prior + 1 new schema test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/tests/conftest.py server/tests/integration/test_readyz_migration_state.py
+git commit -m ":white_check_mark: test(server): mode-aware migrate fixture + readyz expects ai@head"
+```
+
+---
+
+### Task 3: ORM model `AIGenerationLog` + invariant comments + truncate fix
+
+**Files:**
+- Modify: `server/opds_sync/db/models.py`
+- Modify: `server/tests/unit/conftest.py`
+- Modify: `server/tests/integration/test_schema.py`
+
+- [ ] **Step 1: Write the failing ORM round-trip test**
+
+Append to `server/tests/integration/test_schema.py`:
+
+```python
+@pytest.mark.requires_ai
+async def test_ai_generation_log_round_trip(session) -> None:
+    """ORM model writes and reads ai_generation_log rows."""
+    from opds_sync.db.models import AIGenerationLog, BookInsight
+
+    insight = BookInsight(
+        metadata_id=None,
+        content_hash="ch-rt-log",
+        model_id="m1",
+        prompt_version="p1",
+        tone="neutral",
+        sources_used=[],
+        payload={"schema_version": 2, "intro": "x", "confidence": "low"},
+        sources=[],
+        generated_by="legacy-write",
+    )
+    session.add(insight)
+    await session.flush()
+
+    log = AIGenerationLog(
+        book_insight_id=insight.id,
+        subject="alice",
+        model_id="m1",
+        prompt_version="p1",
+        status="miss",
+        latency_ms=123,
+    )
+    session.add(log)
+    await session.commit()
+    await session.refresh(log)
+
+    assert log.id is not None
+    assert log.tenant_id == "local"  # server default
+    assert log.created_at is not None
+    assert log.request_id is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+uv run pytest tests/integration/test_schema.py::test_ai_generation_log_round_trip -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'AIGenerationLog'`.
+
+- [ ] **Step 3: Add the model + invariant docstrings**
+
+In `server/opds_sync/db/models.py`:
+
+(a) Immediately above the `BookInsight` class, prepend:
+
+```python
+# ============================================================================
+# Cache-integrity invariant (PR-C, 2026-05-16)
+# ----------------------------------------------------------------------------
+# `book_insights` is a SHARED CACHE: one row serves every tenant who requests
+# the same identity+model+prompt+tone. The cross-tenant cache-hit property is
+# load-bearing for hosted Quire Cloud AI economics.
+#
+# Therefore this table MUST NOT carry `user_id`, `tenant_id`, `subject`, or
+# any other principal column read for cache decisions. Per-call audit and
+# billing attribution live in `ai_generation_log` (FK to book_insights.id).
+#
+# `generated_by` is grandfathered: a NOT NULL column from before this
+# invariant existed. PR-C stops reading it; a follow-up will null it; a
+# later migration will drop it. Until then it is write-only legacy.
+# ============================================================================
+class BookInsight(Base):
+    ...
+```
+
+(b) Immediately above `ExternalSourceCacheEntry`, prepend:
+
+```python
+# Cache-integrity invariant: shared cache, MUST NOT carry tenant columns.
+# See the comment above BookInsight for the full rule.
+class ExternalSourceCacheEntry(Base):
+    ...
+```
+
+(c) Append at the end of the file:
+
+```python
+class AIGenerationLog(Base):
+    """Per-call audit row anchored to `book_insights.id`.
+
+    One row per `get()`-hit / `generate()` / `regenerate()` call, regardless of
+    cache state. Future billing rollups query `(tenant_id, created_at)`; the
+    audit UI queries `(book_insight_id)`.
+
+    `status` is permissive ('hit' | 'miss' | 'error') so a future PR can
+    introduce error rows without a schema bump. PR-C only emits 'hit' and
+    'miss'; errors go to structured logs because they have no FK target.
+    """
+
+    __tablename__ = "ai_generation_log"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('hit', 'miss', 'error')",
+            name="ck_ai_generation_log_status",
+        ),
+        Index("ix_ai_generation_log_tenant_created", "tenant_id", "created_at"),
+        Index("ix_ai_generation_log_book_insight", "book_insight_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    book_insight_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("book_insights.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("'local'"), default="local"
+    )
+    subject: Mapped[str] = mapped_column(String, nullable=False)
+    request_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    model_id: Mapped[str] = mapped_column(String, nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String, nullable=False)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    error_class: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+```
+
+- [ ] **Step 4: Update `tests/unit/conftest.py` truncate to handle the new FK child**
+
+In `server/tests/unit/conftest.py`, replace the truncate block:
+
+```python
+@pytest.fixture(autouse=True)
+async def _truncate_external_source_cache(request, engine: AsyncEngine):
+    if "session" not in request.fixturenames:
+        return
+    async with engine.begin() as conn:
+        # CASCADE because ai_generation_log has an FK on book_insights.id;
+        # truncating book_insights without CASCADE raises in PostgreSQL.
+        await conn.execute(
+            text(
+                "TRUNCATE TABLE ai_generation_log, external_source_cache, "
+                "book_insights, ai_usage_daily CASCADE"
+            )
+        )
+```
+
+- [ ] **Step 5: Run the round-trip test to verify it passes**
+
+```bash
+uv run pytest tests/integration/test_schema.py::test_ai_generation_log_round_trip -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite — no regressions**
+
+```bash
+uv run pytest -q
+```
+
+Expected: 121 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/opds_sync/db/models.py server/tests/unit/conftest.py server/tests/integration/test_schema.py
+git commit -m ":sparkles: feat(server): AIGenerationLog ORM model + cache-integrity invariant comments"
+```
+
+---
+
+### Task 4: Cache-key audit regression test
+
+**Files:**
+- Create: `server/tests/integration/test_cache_key_audit.py`
+
+- [ ] **Step 1: Write the audit test (it will pass on the existing schema)**
+
+Create `server/tests/integration/test_cache_key_audit.py`:
+
+```python
+"""Cache-integrity invariant: shared-cache tables MUST NOT carry tenant columns.
+
+This regression test is *future-proof*: as PR2 (insight_identity_aliases) and
+PR3 (book_themes) land, their model classes must be added to the parametrize
+list. If a future PR accidentally adds `user_id` to a shared cache table,
+this test fails at CI time, by design.
+
+`generated_by` on BookInsight is grandfathered and explicitly allow-listed
+with a comment pointing to the deprecation plan (PR-C stops reading it; a
+follow-up nulls it; a later migration drops it).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import inspect
+
+from opds_sync.db.models import BookInsight, ExternalSourceCacheEntry
+
+FORBIDDEN_COLUMNS = frozenset(
+    {"user_id", "tenant_id", "subject", "principal_id"}
+)
+
+# Grandfathered legacy columns per table. PR-C stops READING `generated_by`;
+# a follow-up will null then drop it. Until dropped, it stays in the schema.
+GRANDFATHERED: dict[str, frozenset[str]] = {
+    "book_insights": frozenset({"generated_by"}),
+}
+
+SHARED_CACHE_TABLES = [
+    pytest.param(BookInsight, id="book_insights"),
+    pytest.param(ExternalSourceCacheEntry, id="external_source_cache"),
+    # Future entries (add when the model lands):
+    # pytest.param(BookTheme, id="book_themes"),           # PR3
+    # pytest.param(InsightIdentityAlias, id="insight_identity_aliases"),  # PR2
+]
+
+
+@pytest.mark.requires_ai
+@pytest.mark.parametrize("model_cls", SHARED_CACHE_TABLES)
+async def test_shared_cache_table_has_no_tenant_columns(engine, model_cls) -> None:
+    table_name = model_cls.__tablename__
+
+    def _columns(sync_conn) -> set[str]:
+        insp = inspect(sync_conn)
+        return {c["name"] for c in insp.get_columns(table_name)}
+
+    async with engine.connect() as conn:
+        cols = await conn.run_sync(_columns)
+
+    grandfathered = GRANDFATHERED.get(table_name, frozenset())
+    offending = (cols & FORBIDDEN_COLUMNS) - grandfathered
+    assert not offending, (
+        f"shared-cache table {table_name!r} carries forbidden tenant columns: "
+        f"{sorted(offending)}. Per the cache-integrity invariant, tenant audit "
+        f"belongs in ai_generation_log, not on the shared cache row."
+    )
+```
+
+- [ ] **Step 2: Run the test — it should pass immediately**
+
+```bash
+uv run pytest tests/integration/test_cache_key_audit.py -v
+```
+
+Expected: PASS for both `book_insights` and `external_source_cache`.
+
+- [ ] **Step 3: Quick mechanic-verification one-liner**
+
+```bash
+uv run python -c "
+from opds_sync.db.models import BookInsight
+existing = {c.name for c in BookInsight.__table__.columns}
+existing.add('user_id')
+from tests.integration.test_cache_key_audit import FORBIDDEN_COLUMNS, GRANDFATHERED
+grandfathered = GRANDFATHERED.get('book_insights', frozenset())
+offending = (existing & FORBIDDEN_COLUMNS) - grandfathered
+assert offending == {'user_id'}, offending
+print('audit-test mechanic verified')
+"
+```
+
+Expected: `audit-test mechanic verified`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/tests/integration/test_cache_key_audit.py
+git commit -m ":white_check_mark: test(server): cache-integrity invariant audit test"
+```
+
+---
+
+### Task 5: Service writes `'miss'` and `'hit'` rows + per-call `tenant_id` kwarg
+
+**Files:**
+- Modify: `server/opds_sync/core/ai/service.py`
+- Modify: `server/tests/unit/test_ai_service.py`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Append to `server/tests/unit/test_ai_service.py`:
+
+```python
+from opds_sync.db.models import AIGenerationLog  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_generate_miss_writes_log_row(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-log-miss")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.status == "miss"
+    assert row.subject == "alice"
+    assert row.tenant_id == "local"  # default when kwarg omitted
+    assert row.model_id == "test-model"
+    assert row.prompt_version == "t1"
+    assert row.latency_ms is not None and row.latency_ms >= 0
+    assert row.error_class is None
+    assert row.book_insight_id is not None
+
+
+@pytest.mark.asyncio
+async def test_second_generate_writes_hit_row_with_same_fk(
+    session: AsyncSession, make_orchestrator
+):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-log-hit")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="bob")
+
+    rows = (
+        (await session.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert [r.status for r in rows] == ["miss", "hit"]
+    assert [r.subject for r in rows] == ["alice", "bob"]
+    assert rows[0].book_insight_id == rows[1].book_insight_id
+    assert rows[1].latency_ms == 0  # cache lookup cost
+
+
+@pytest.mark.asyncio
+async def test_log_uses_passed_tenant_id(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-tenant-kwarg")
+    await orch.generate(
+        session, ident, MetadataBundle(title="X"), user_id="alice", tenant_id="acme"
+    )
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].tenant_id == "acme"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+uv run pytest tests/unit/test_ai_service.py::test_generate_miss_writes_log_row tests/unit/test_ai_service.py::test_second_generate_writes_hit_row_with_same_fk tests/unit/test_ai_service.py::test_log_uses_passed_tenant_id -v
+```
+
+Expected: all three FAIL (no log rows being written; `tenant_id` kwarg unrecognized).
+
+- [ ] **Step 3: Update `service.py` — imports**
+
+In `server/opds_sync/core/ai/service.py`, update the model import and add the ContextVar import:
+
+```python
+from opds_sync.core.logging_ctx import request_id_var
+from opds_sync.db.models import AIGenerationLog, AIUsageDaily, BookInsight
+```
+
+- [ ] **Step 4: Add the `_log_generation` helper to `InsightOrchestrator`**
+
+Insert this method on the class (e.g., after `_acquire_identity_lock`):
+
+```python
+async def _log_generation(
+    self,
+    session: AsyncSession,
+    *,
+    book_insight_id: int,
+    subject: str,
+    tenant_id: str,
+    status: str,
+    latency_ms: int | None,
+    error_class: str | None = None,
+) -> None:
+    """Stage one ai_generation_log row. Caller commits the surrounding tx."""
+    session.add(
+        AIGenerationLog(
+            book_insight_id=book_insight_id,
+            tenant_id=tenant_id,
+            subject=subject,
+            request_id=(request_id_var.get() or None),
+            model_id=self.model_id,
+            prompt_version=self.prompt_version,
+            latency_ms=latency_ms,
+            status=status,
+            error_class=error_class,
+        )
+    )
+```
+
+- [ ] **Step 5: Update `generate()` signature + body**
+
+Replace the existing `generate()` method with:
+
+```python
+async def generate(
+    self,
+    session: AsyncSession,
+    ident: DocumentIdentity,
+    bundle: MetadataBundle,
+    *,
+    user_id: str,
+    style: AiStyle | None = None,
+    tenant_id: str = "local",
+) -> BookInsightResponse:
+    tone = _tone_of(style)
+    row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=True)
+    if row is not None:
+        await self._log_generation(
+            session,
+            book_insight_id=row.id,
+            subject=user_id,
+            tenant_id=tenant_id,
+            status="hit",
+            latency_ms=0,
+        )
+        await session.commit()
+        return self._row_to_response(row)
+
+    lock = await self._acquire_identity_lock(ident, tone=tone)
+    async with lock:
+        row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=True)
+        if row is not None:
+            await self._log_generation(
+                session,
+                book_insight_id=row.id,
+                subject=user_id,
+                tenant_id=tenant_id,
+                status="hit",
+                latency_ms=0,
+            )
+            await session.commit()
+            return self._row_to_response(row)
+
+        await self._reserve_budget(session, user_id=user_id, is_regen=False)
+        await self._bucket.acquire()
+        row = await self._do_generate(
+            session,
+            ident,
+            bundle,
+            user_id=user_id,
+            tenant_id=tenant_id,
+            style=style,
+            tone=tone,
+            feedback=None,
+            previous_insight_ids=None,
+        )
+        return self._row_to_response(row)
+```
+
+- [ ] **Step 6: Update `regenerate()` signature + body**
+
+Replace the existing `regenerate()` method with:
+
+```python
+async def regenerate(
+    self,
+    session: AsyncSession,
+    ident: DocumentIdentity,
+    bundle: MetadataBundle,
+    *,
+    user_id: str,
+    reason: str,
+    style: AiStyle | None = None,
+    tenant_id: str = "local",
+) -> BookInsightResponse:
+    """Supersede the existing live row (if any) and generate a fresh one."""
+    tone = _tone_of(style)
+    lock = await self._acquire_identity_lock(ident, tone=tone)
+    async with lock:
+        existing = await self._cache_lookup(session, ident, tone=tone, allow_backfill=False)
+        previous_ids: list[int] = []
+        if existing is not None:
+            previous_ids = list(existing.previous_insight_ids or [])
+            previous_ids.append(existing.id)
+            existing.superseded_at = datetime.now(UTC)
+            await session.commit()
+
+        await self._reserve_budget(session, user_id=user_id, is_regen=True)
+        await self._bucket.acquire()
+        row = await self._do_generate(
+            session,
+            ident,
+            bundle,
+            user_id=user_id,
+            tenant_id=tenant_id,
+            style=style,
+            tone=tone,
+            feedback=reason,
+            previous_insight_ids=previous_ids or None,
+        )
+        return self._row_to_response(row)
+```
+
+- [ ] **Step 7: Update `_do_generate()` to accept `tenant_id`, log the `miss` row, and handle errors**
+
+Replace the entire `_do_generate` method with:
+
+```python
+async def _do_generate(
+    self,
+    session: AsyncSession,
+    ident: DocumentIdentity,
+    bundle: MetadataBundle,
+    *,
+    user_id: str,
+    tenant_id: str,
+    style: AiStyle | None,
+    tone: str,
+    feedback: str | None,
+    previous_insight_ids: list[int] | None,
+) -> BookInsight:
+    async with self._sem:
+        citations = await self._retrieve(session, bundle)
+        user_prompt = compose_user_prompt(bundle, citations, style=style, feedback=feedback)
+        t0 = time.monotonic()
+        try:
+            payload = await self.ai.chat_structured(
+                system=SYSTEM_PROMPT,
+                user=user_prompt,
+                schema=BookInsightPayload,
+                timeout_s=self._ai_timeout_s,
+            )
+        except Exception as e:
+            # Errors don't produce an ai_generation_log row (no FK target).
+            # The structured log line is the operator-facing audit trail;
+            # request_id is attached by RequestIdLogFilter (record.request_id).
+            latency_ms = int((time.monotonic() - t0) * 1000)
+            logger.warning(
+                "event=ai.generate.error tenant_id=%s subject=%s model=%s "
+                "prompt_version=%s latency_ms=%d error_class=%s",
+                tenant_id,
+                user_id,
+                self.model_id,
+                self.prompt_version,
+                latency_ms,
+                type(e).__name__,
+            )
+            raise
+        latency_ms = int((time.monotonic() - t0) * 1000)
+        logger.info(
+            "ai.generate content_hash=%s model=%s latency_ms=%d sources=%s regen=%s",
+            ident.content_hash,
+            self.model_id,
+            latency_ms,
+            ",".join(sorted({c.kind for c in citations})) or "-",
+            bool(feedback),
+        )
+
+    if bundle.series_name:
+        payload.series = SeriesInsight(
+            name=bundle.series_name,
+            position=bundle.series_position,
+        )
+
+    sources = list(citations)
+    sources.append(Citation(kind="model", title=self.model_id, snippet="generated"))
+    row = BookInsight(
+        metadata_id=ident.metadata_id,
+        content_hash=ident.content_hash,
+        model_id=self.model_id,
+        prompt_version=self.prompt_version,
+        tone=tone,
+        sources_used=list({c.kind for c in citations}),
+        payload=payload.model_dump(),
+        sources=[c.model_dump() for c in sources],
+        # generated_by is grandfathered: NOT NULL legacy column. PR-C still
+        # WRITES it (to satisfy the constraint) but NEVER READS it. A
+        # follow-up PR will null then drop it. The replacement audit trail
+        # is AIGenerationLog (FK from book_insight_id).
+        generated_by=user_id,
+        previous_insight_ids=previous_insight_ids,
+    )
+    session.add(row)
+    await session.flush()  # populate row.id before logging
+    await self._log_generation(
+        session,
+        book_insight_id=row.id,
+        subject=user_id,
+        tenant_id=tenant_id,
+        status="miss",
+        latency_ms=latency_ms,
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
+```
+
+- [ ] **Step 8: Run the three new tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_ai_service.py::test_generate_miss_writes_log_row tests/unit/test_ai_service.py::test_second_generate_writes_hit_row_with_same_fk tests/unit/test_ai_service.py::test_log_uses_passed_tenant_id -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run the full suite to confirm no regressions**
+
+```bash
+uv run pytest -q
+```
+
+Expected: 124 passed (121 prior + 3 new).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add server/opds_sync/core/ai/service.py server/tests/unit/test_ai_service.py
+git commit -m ":sparkles: feat(server): orchestrator writes ai_generation_log per call"
+```
+
+---
+
+### Task 6: `get()` logs `'hit'` on cache hit; threads `user_id` + `tenant_id`
+
+**Files:**
+- Modify: `server/opds_sync/core/ai/service.py`
+- Modify: `server/opds_sync/api/ai.py`
+- Modify: `server/tests/unit/test_ai_service.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `server/tests/unit/test_ai_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_hit_writes_log_row(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-get-hit")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+    # baseline: one miss row from the generate
+    assert len((await session.execute(select(AIGenerationLog))).scalars().all()) == 1
+
+    out = await orch.get(session, ident, user_id="alice")
+    assert out is not None
+
+    rows = (
+        (await session.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert rows[1].status == "hit"
+    assert rows[1].latency_ms == 0
+
+
+@pytest.mark.asyncio
+async def test_get_miss_writes_no_log_row(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-get-miss")
+    assert await orch.get(session, ident) is None
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert rows == []
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+uv run pytest tests/unit/test_ai_service.py::test_get_hit_writes_log_row tests/unit/test_ai_service.py::test_get_miss_writes_no_log_row -v
+```
+
+Expected: `test_get_hit_writes_log_row` FAILS (no row written on hit). `test_get_miss_writes_no_log_row` PASSES (no rows written ever — `get()` doesn't log yet).
+
+- [ ] **Step 3: Update `get()` to thread `user_id` + `tenant_id` and log on hit**
+
+In `server/opds_sync/core/ai/service.py`, replace the `get()` method body:
+
+```python
+async def get(
+    self,
+    session: AsyncSession,
+    ident: DocumentIdentity,
+    *,
+    user_id: str | None = None,
+    style: AiStyle | None = None,
+    tenant_id: str = "local",
+) -> BookInsightResponse | None:
+    tone = _tone_of(style)
+    row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=False)
+    if row is None:
+        return None
+    if user_id is not None:
+        await self._log_generation(
+            session,
+            book_insight_id=row.id,
+            subject=user_id,
+            tenant_id=tenant_id,
+            status="hit",
+            latency_ms=0,
+        )
+        await session.commit()
+    return self._row_to_response(row)
+```
+
+`user_id=None` (no audit) remains the test-only path for fast cache probes that don't need an audit row.
+
+- [ ] **Step 4: Update API call sites to pass `user_id` and `tenant_id="local"`**
+
+In `server/opds_sync/api/ai.py`, find the four orchestrator call sites:
+
+```bash
+grep -n "orch\.get\|orch\.generate\|orch\.regenerate" server/opds_sync/api/ai.py
+```
+
+Update each to add `tenant_id="local"`, and update the `orch.get(...)` call to also include `user_id=user_id`. Example for the GET endpoint (line ~212):
+
+Before:
+```python
+out = await orch.get(session, body.identity, style=style)
+```
+
+After:
+```python
+out = await orch.get(session, body.identity, user_id=user_id, style=style, tenant_id="local")
+```
+
+For `orch.generate(...)` and `orch.regenerate(...)` (lines ~161 and ~186), append `tenant_id="local"` to the kwargs. `user_id` is already passed.
+
+(Hardcoded `"local"` is the explicit PR-B seam. PR-B will replace these with `principal.tenant_id`.)
+
+- [ ] **Step 5: Run new tests + full suite**
+
+```bash
+uv run pytest tests/unit/test_ai_service.py::test_get_hit_writes_log_row tests/unit/test_ai_service.py::test_get_miss_writes_no_log_row -v
+uv run pytest -q
+```
+
+Expected: both new tests PASS; full suite green (126 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/opds_sync/core/ai/service.py server/opds_sync/api/ai.py server/tests/unit/test_ai_service.py
+git commit -m ":sparkles: feat(server): orchestrator.get() logs hit rows; API threads tenant_id=local"
+```
+
+---
+
+### Task 7: Coalesced waiters each get their own log row + request_id propagation tests
+
+**Files:**
+- Modify: `server/tests/unit/test_ai_service.py`
+
+- [ ] **Step 1: Write the failing/regression tests**
+
+Append to `server/tests/unit/test_ai_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_concurrent_generations_emit_one_miss_and_n_minus_one_hits(
+    session: AsyncSession, make_orchestrator
+):
+    """Coalesced waiters: one model call but N log rows, one per waiter.
+
+    Uses the existing shared-session pattern (mirrors test_concurrent_generations_
+    collapse_to_one_model_call). Cross-session FK visibility is exercised by the
+    multi-tenant integration test instead.
+    """
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-coalesce-log")
+    bundle = MetadataBundle(title="Coalesce")
+
+    await asyncio.gather(
+        orch.generate(session, ident, bundle, user_id="u1"),
+        orch.generate(session, ident, bundle, user_id="u2"),
+        orch.generate(session, ident, bundle, user_id="u3"),
+    )
+
+    assert len(orch.ai.calls) == 1
+
+    rows = (
+        (await session.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 3
+    statuses = sorted(r.status for r in rows)
+    assert statuses == ["hit", "hit", "miss"]
+    # All three FK the same insight
+    assert len({r.book_insight_id for r in rows}) == 1
+    # Three distinct subjects
+    assert sorted(r.subject for r in rows) == ["u1", "u2", "u3"]
+
+
+@pytest.mark.asyncio
+async def test_log_carries_request_id_when_set(
+    session: AsyncSession, make_orchestrator
+):
+    from opds_sync.core.logging_ctx import request_id_var
+
+    token = request_id_var.set("test-req-abc123")
+    try:
+        orch = make_orchestrator()
+        ident = DocumentIdentity(metadata_id=None, content_hash="ch-req-id")
+        await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+    finally:
+        request_id_var.reset(token)
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].request_id == "test-req-abc123"
+
+
+@pytest.mark.asyncio
+async def test_log_default_tenant_id_is_local(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-tenant-default")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].tenant_id == "local"
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+uv run pytest tests/unit/test_ai_service.py::test_concurrent_generations_emit_one_miss_and_n_minus_one_hits tests/unit/test_ai_service.py::test_log_carries_request_id_when_set tests/unit/test_ai_service.py::test_log_default_tenant_id_is_local -v
+```
+
+Expected: all PASS (Task 5/6 already wired the implementation; these are regression guards).
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+uv run pytest -q
+```
+
+Expected: 129 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/tests/unit/test_ai_service.py
+git commit -m ":white_check_mark: test(server): coalesce, request_id, tenant_id default regression tests"
+```
+
+---
+
+### Task 8: Fix root-logger filter attachment so child-logger records get request_id
+
+**Files:**
+- Modify: `server/opds_sync/main.py`
+- Modify: `server/tests/unit/test_logging_ctx.py` (or new test)
+
+**Why this task:** PR-A attaches `RequestIdLogFilter` to the root logger via `logging.getLogger().addFilter(...)`. Python's logging propagation does NOT apply logger-level filters from parent loggers to records originating in child loggers. As a result, records emitted by `opds_sync.core.ai.service` (like the new `event=ai.generate.error` warning) reach the root logger's handlers without `record.request_id` set. Fix: attach the filter to the root logger's handler(s) instead, so it runs on any record routed through those handlers (including propagated ones).
+
+- [ ] **Step 1: Write a failing test asserting propagation correctness**
+
+Append to `server/tests/unit/test_logging_ctx.py`:
+
+```python
+import logging
+
+import pytest
+
+from opds_sync.core.logging_ctx import RequestIdLogFilter, request_id_var
+
+
+def _attach_filter_like_main(filt: logging.Filter) -> list[logging.Handler]:
+    """Mirror main.py's intended attachment: filter on each root handler."""
+    root = logging.getLogger()
+    attached: list[logging.Handler] = []
+    for h in root.handlers:
+        h.addFilter(filt)
+        attached.append(h)
+    return attached
+
+
+def test_filter_attached_to_root_handler_applies_to_child_logger_records(caplog):
+    """Records emitted by a CHILD logger must end up with request_id when the
+    filter is attached to the root logger's handler (not the root logger).
+
+    This is the production-faithful attachment that ai.generate.error relies on.
+    """
+    logging.basicConfig(level=logging.WARNING)  # ensure a root handler exists
+    filt = RequestIdLogFilter()
+    attached = _attach_filter_like_main(filt)
+    token = request_id_var.set("rid-propagation-test")
+    try:
+        child = logging.getLogger("opds_sync.core.ai.service")
+        with caplog.at_level(logging.WARNING, logger="opds_sync.core.ai.service"):
+            child.warning("hello from child")
+    finally:
+        request_id_var.reset(token)
+        for h in attached:
+            h.removeFilter(filt)
+
+    # The caplog handler is installed on root; the filter runs on its records.
+    rec = next(r for r in caplog.records if r.getMessage() == "hello from child")
+    assert getattr(rec, "request_id", "") == "rid-propagation-test"
+```
+
+- [ ] **Step 2: Run to see whether the failure mode actually exists today**
+
+```bash
+uv run pytest tests/unit/test_logging_ctx.py::test_filter_attached_to_root_handler_applies_to_child_logger_records -v
+```
+
+If FAIL: confirms the bug; proceed to fix in Step 3.
+If PASS: the local pytest setup may already propagate-and-filter correctly via `caplog`; document but still proceed (the production fix is harmless).
+
+- [ ] **Step 3: Update `main.py` to attach the filter to handlers**
+
+In `server/opds_sync/main.py`, replace:
+
+```python
+    logging.basicConfig(level=settings.log_level)
+    # Inject request_id into every log record produced after this point.
+    logging.getLogger().addFilter(RequestIdLogFilter())
+```
+
+with:
+
+```python
+    logging.basicConfig(level=settings.log_level)
+    # Inject request_id into every log record routed through the root
+    # handlers. Logger-level filters on the root logger do NOT apply to
+    # records propagated up from child loggers, so we attach the filter to
+    # the handlers themselves. Idempotent if create_app() runs more than
+    # once (e.g., in tests).
+    _filter = RequestIdLogFilter()
+    for _h in logging.getLogger().handlers:
+        if not any(isinstance(f, RequestIdLogFilter) for f in _h.filters):
+            _h.addFilter(_filter)
+```
+
+- [ ] **Step 3b: Update `logging_ctx.py` docstring**
+
+In `server/opds_sync/core/logging_ctx.py`, replace the misleading example in `RequestIdLogFilter.__doc__`:
+
+```python
+class RequestIdLogFilter(logging.Filter):
+    """Inject the current request_id into every log record.
+
+    IMPORTANT: attach to HANDLERS, not to loggers. Logger-level filters do
+    NOT apply to records propagated up from child loggers — only to records
+    logged directly to that logger. The production wiring lives in
+    `main.py::create_app()`; mirror it in tests by adding the filter to
+    `caplog.handler` or to your own handler instance.
+    """
+```
+
+- [ ] **Step 4: Verify the new test passes and no existing tests broke**
+
+```bash
+uv run pytest tests/unit/test_logging_ctx.py -v
+uv run pytest -q
+```
+
+Expected: new test PASS; full suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/opds_sync/main.py server/tests/unit/test_logging_ctx.py
+git commit -m ":bug: fix(server): attach RequestIdLogFilter to root handlers so child-logger records get request_id"
+```
+
+---
+
+### Task 9: Error path emits structured log line (no DB row)
+
+**Files:**
+- Modify: `server/tests/unit/test_ai_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/unit/test_ai_service.py`:
+
+```python
+class _ExplodingAIClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def chat_structured(self, *, system, user, schema, timeout_s):
+        self.calls.append({"system": system, "user": user})
+        raise RuntimeError("simulated provider failure")
+
+
+@pytest.mark.asyncio
+async def test_generate_error_emits_structured_log(session: AsyncSession, caplog):
+    """Errors emit a structured `event=ai.generate.error` warning carrying
+    tenant_id, subject, model, prompt_version, error_class. The request_id
+    ContextVar is read by the log filter (attached to caplog's handler) and
+    surfaces as record.request_id. No ai_generation_log row is written.
+    """
+    import logging
+
+    from opds_sync.core.ai.service import InsightOrchestrator
+    from opds_sync.core.logging_ctx import RequestIdLogFilter, request_id_var
+
+    # Attach the filter to caplog's handler to mirror main.py's handler-level
+    # attachment (see Task 8). Without this, record.request_id won't be set
+    # because caplog's handler is added independently of `basicConfig`.
+    filt = RequestIdLogFilter()
+    caplog.handler.addFilter(filt)
+    token = request_id_var.set("req-err-xyz")
+    try:
+        orch = InsightOrchestrator(
+            ai=_ExplodingAIClient(),
+            retriever_factory=lambda s: FakeRetriever(),
+            sources_enabled=(),
+            model_id="boom-model",
+            prompt_version="t1",
+            max_concurrency=1,
+            ai_timeout_s=5.0,
+        )
+        ident = DocumentIdentity(metadata_id=None, content_hash="ch-error")
+
+        with caplog.at_level(logging.WARNING, logger="opds_sync.core.ai.service"):
+            with pytest.raises(RuntimeError, match="simulated provider failure"):
+                await orch.generate(
+                    session,
+                    ident,
+                    MetadataBundle(title="X"),
+                    user_id="alice",
+                    tenant_id="acme",
+                )
+    finally:
+        request_id_var.reset(token)
+        caplog.handler.removeFilter(filt)
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert rows == []  # no DB row for errors
+
+    error_records = [r for r in caplog.records if "event=ai.generate.error" in r.getMessage()]
+    assert len(error_records) == 1, (
+        f"expected exactly one ai.generate.error log record, got {len(error_records)}"
+    )
+    rec = error_records[0]
+    msg = rec.getMessage()
+    assert "tenant_id=acme" in msg
+    assert "subject=alice" in msg
+    assert "model=boom-model" in msg
+    assert "prompt_version=t1" in msg
+    assert "error_class=RuntimeError" in msg
+    # request_id surfaces on the record because the filter is on the handler.
+    assert getattr(rec, "request_id", "") == "req-err-xyz"
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+uv run pytest tests/unit/test_ai_service.py::test_generate_error_emits_structured_log -v
+```
+
+Expected: PASS (Task 5's `_do_generate` already added the structured log line in the exception handler).
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+uv run pytest -q
+```
+
+Expected: 130 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/tests/unit/test_ai_service.py
+git commit -m ":white_check_mark: test(server): structured error log on AI client failure"
+```
+
+---
+
+### Task 10: Multi-tenant convergence + concurrent-coalesce integration tests (separate sessions)
+
+**Files:**
+- Create: `server/tests/integration/test_ai_audit_log.py`
+
+- [ ] **Step 1: Write the integration tests using separate `AsyncSession` instances**
+
+Two tests in this file:
+1. **Sequential** two-tenant convergence (cross-session cache visibility).
+2. **Concurrent** N-waiter coalesce (real lock contention across separate sessions).
+
+Create `server/tests/integration/test_ai_audit_log.py`:
+
+```python
+"""Multi-tenant convergence: two synthetic tenants share one book_insights
+row but produce two ai_generation_log rows with distinct tenant_id values.
+
+Uses SEPARATE AsyncSession instances per tenant — faithfully exercising
+cross-session FK visibility (tenant B's session must see the committed
+book_insights row from tenant A's session) and matching how the production
+app-state singleton orchestrator handles concurrent requests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from opds_sync.api.ai_schemas import DocumentIdentity, MetadataBundle
+from opds_sync.core.ai.service import InsightOrchestrator
+from opds_sync.db.models import AIGenerationLog, BookInsight
+
+
+class _FakeAIClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.next_payload = {
+            "schema_version": 2,
+            "intro": "Two-tenant convergence.",
+            "confidence": "high",
+        }
+
+    async def chat_structured(self, *, system, user, schema, timeout_s):
+        self.calls.append({"system": system, "user": user})
+        return schema.model_validate(self.next_payload)
+
+
+class _FakeRetriever:
+    async def lookup_wikipedia(self, **kw):
+        return []
+
+    async def lookup_openlibrary(self, **kw):
+        return []
+
+
+@pytest.fixture
+async def session_factory(engine) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    yield async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_two_tenants_share_one_insight_two_log_rows(session_factory, session):
+    """Tenant A misses + generates; Tenant B hits the same row. Two log entries."""
+    # Cleanup is handled by the unit conftest's truncate fixture for the unit
+    # test suite, but this is an integration test — wipe explicitly.
+    from sqlalchemy import text
+
+    async with session_factory() as cleanup:
+        await cleanup.execute(
+            text(
+                "TRUNCATE TABLE ai_generation_log, external_source_cache, "
+                "book_insights, ai_usage_daily CASCADE"
+            )
+        )
+        await cleanup.commit()
+
+    # One shared orchestrator (mirrors app.state singleton).
+    orch = InsightOrchestrator(
+        ai=_FakeAIClient(),
+        retriever_factory=lambda s: _FakeRetriever(),
+        sources_enabled=(),
+        model_id="multi-tenant-model",
+        prompt_version="mt1",
+        max_concurrency=2,
+        ai_timeout_s=5.0,
+    )
+
+    ident = DocumentIdentity(metadata_id="tenant-shared", content_hash="ch-multi")
+    bundle = MetadataBundle(title="Shared")
+
+    # Tenant A: cold miss (own session)
+    async with session_factory() as s_a:
+        out_a = await orch.generate(
+            s_a, ident, bundle, user_id="alice@tenant-a", tenant_id="tenant-a"
+        )
+
+    # Tenant B: hits A's cache row (own session)
+    async with session_factory() as s_b:
+        out_b = await orch.generate(
+            s_b, ident, bundle, user_id="bob@tenant-b", tenant_id="tenant-b"
+        )
+
+    # Cross-tenant cache hit confirmed
+    assert out_a.payload.intro == out_b.payload.intro
+    assert len(orch.ai.calls) == 1  # one model call total
+    # (generated_by is grandfathered: don't assert on it — keeps the "no read
+    # sites" grep clean.)
+
+    # Inspect the persisted state from a third session
+    async with session_factory() as s_check:
+        insights = (
+            (
+                await s_check.execute(
+                    select(BookInsight).where(BookInsight.content_hash == "ch-multi")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(insights) == 1
+        insight = insights[0]
+        # generated_by intentionally NOT asserted: PR-C stops READING the
+        # column; an assertion here would re-introduce a read site that the
+        # cache-key audit grep is meant to catch.
+
+        logs = (
+            (await s_check.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+            .scalars()
+            .all()
+        )
+        assert len(logs) == 2
+        assert {l.tenant_id for l in logs} == {"tenant-a", "tenant-b"}
+        assert [l.status for l in logs] == ["miss", "hit"]
+        assert {l.book_insight_id for l in logs} == {insight.id}
+        assert {l.subject for l in logs} == {"alice@tenant-a", "bob@tenant-b"}
+
+
+class _SlowAIClient:
+    """Fake AI client that blocks until released, then returns once.
+
+    Lets us prove that concurrent generate() calls actually serialize through
+    the per-identity lock (rather than racing to multiple model calls).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.release = __import__("asyncio").Event()
+        self.next_payload = {
+            "schema_version": 2,
+            "intro": "Coalesced.",
+            "confidence": "high",
+        }
+
+    async def chat_structured(self, *, system, user, schema, timeout_s):
+        self.calls.append({"system": system, "user": user})
+        await self.release.wait()
+        return schema.model_validate(self.next_payload)
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_concurrent_waiters_coalesce_across_sessions(session_factory, session):
+    """N concurrent waiters with separate sessions → 1 miss + (N-1) hits.
+
+    The slow fake AI client blocks on an asyncio.Event so all waiters reach
+    the lock at the same time. We release the event after a tick to ensure
+    they actually queue on the lock rather than racing.
+    """
+    import asyncio
+
+    from sqlalchemy import text
+
+    async with session_factory() as cleanup:
+        await cleanup.execute(
+            text(
+                "TRUNCATE TABLE ai_generation_log, external_source_cache, "
+                "book_insights, ai_usage_daily CASCADE"
+            )
+        )
+        await cleanup.commit()
+
+    slow_client = _SlowAIClient()
+    orch = InsightOrchestrator(
+        ai=slow_client,
+        retriever_factory=lambda s: _FakeRetriever(),
+        sources_enabled=(),
+        model_id="coalesce-model",
+        prompt_version="c1",
+        max_concurrency=4,
+        ai_timeout_s=5.0,
+    )
+
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-conc-coalesce")
+    bundle = MetadataBundle(title="Conc")
+
+    async def _one_waiter(user_id: str, tenant_id: str):
+        async with session_factory() as s:
+            return await orch.generate(
+                s, ident, bundle, user_id=user_id, tenant_id=tenant_id
+            )
+
+    # Launch three waiters concurrently. They will all queue on the lock;
+    # the lock-holder will block on slow_client.release.
+    tasks = [
+        asyncio.create_task(_one_waiter("u1", "t1")),
+        asyncio.create_task(_one_waiter("u2", "t2")),
+        asyncio.create_task(_one_waiter("u3", "t3")),
+    ]
+
+    # Wait until exactly one model call is in flight (the lock-holder reached
+    # chat_structured). Bounded loop avoids `sleep(0.05)` flakiness.
+    deadline = asyncio.get_event_loop().time() + 5.0
+    while len(slow_client.calls) == 0 and asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.005)
+    # Give other tasks one more scheduling slice so any racing waiter would
+    # have had time to also enter chat_structured. Then assert exactly one.
+    await asyncio.sleep(0.02)
+    assert len(slow_client.calls) == 1, (
+        f"expected 1 in-flight model call, got {len(slow_client.calls)}; "
+        "waiters didn't coalesce on the lock"
+    )
+
+    # Release the lock-holder so it can complete; the two waiters then hit.
+    slow_client.release.set()
+    results = await asyncio.gather(*tasks)
+    assert len(results) == 3
+    # Still exactly one model call total.
+    assert len(slow_client.calls) == 1
+
+    async with session_factory() as s_check:
+        insights = (
+            (
+                await s_check.execute(
+                    select(BookInsight).where(BookInsight.content_hash == "ch-conc-coalesce")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(insights) == 1
+
+        logs = (
+            (await s_check.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+            .scalars()
+            .all()
+        )
+        assert len(logs) == 3
+        statuses = sorted(l.status for l in logs)
+        assert statuses == ["hit", "hit", "miss"]
+        assert {l.book_insight_id for l in logs} == {insights[0].id}
+        assert sorted(l.subject for l in logs) == ["u1", "u2", "u3"]
+        assert sorted(l.tenant_id for l in logs) == ["t1", "t2", "t3"]
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+```bash
+uv run pytest tests/integration/test_ai_audit_log.py -v
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 3: Run the full suite to confirm**
+
+```bash
+uv run pytest -q
+```
+
+Expected: 132 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/tests/integration/test_ai_audit_log.py
+git commit -m ":white_check_mark: test(server): two-tenant convergence on shared insight (separate sessions)"
+```
+
+---
+
+### Task 11: Mode-matrix verification
+
+**Files:**
+- None modified; verification only.
+
+- [ ] **Step 1: Verify the suite passes in sync-only mode**
+
+```bash
+cd /Users/vito/repos/quire/.claude/worktrees/pr-c-ai-generation-log/server
+OPDS_SYNC_PROGRESS_ENABLED=true OPDS_SYNC_AI_ENABLED=false uv run pytest -q
+```
+
+Expected: `requires_ai` tests skip (count visible in summary); all others pass.
+
+- [ ] **Step 2: Verify the suite passes in ai-only mode**
+
+```bash
+OPDS_SYNC_PROGRESS_ENABLED=false OPDS_SYNC_AI_ENABLED=true uv run pytest -q
+```
+
+Expected: `requires_progress` tests skip; AI tests pass.
+
+- [ ] **Step 3: Verify the default (full-stack) suite is green**
+
+```bash
+uv run pytest -q
+```
+
+Expected: full green (132 passed).
+
+- [ ] **Step 4: No commit** — this task is verification only.
+
+---
+
+### Task 12: Push, open PR, paste GPT verdict
+
+**Files:**
+- Push branch `feat/ai-generation-log` to origin.
+- Open PR with base `feat/alembic-mode-split`.
+
+- [ ] **Step 1: Push**
+
+```bash
+cd /Users/vito/repos/quire/.claude/worktrees/pr-c-ai-generation-log
+git push -u origin feat/ai-generation-log
+```
+
+- [ ] **Step 2: Open the PR (HEREDOC body — NO Claude attribution)**
+
+```bash
+gh pr create --base feat/alembic-mode-split --head feat/ai-generation-log \
+  --title "feat(server): ai_generation_log table + cache-key tenant audit" \
+  --body "$(cat <<'EOF'
+## Summary
+
+PR-C of the 2026-05-16 roadmap batch, stacked on PR-A (alembic mode split). Server-only.
+
+- Adds `ai_generation_log` as the first migration on the `ai` branch (`ai_001`, `down_revision = "0004"`, `branch_labels = ("ai",)`).
+- `InsightOrchestrator` writes one row per `get()`-hit / `generate()` / `regenerate()` call: `status` is `hit` or `miss`, FK'd to `book_insights.id`, carrying `tenant_id` (per-call kwarg, default `"local"`), `subject` (the existing `user_id`), `request_id` (from PR-A's `request_id_var` ContextVar), `model_id`, `prompt_version`, `latency_ms`.
+- Errors emit a structured `logger.warning("ai.generate.error tenant_id=... subject=... model=... prompt_version=... latency_ms=... error_class=...")` line and raise. No DB row (no FK target). Tested via `caplog`.
+- Stops reading `book_insights.generated_by` for any decision (audit confirmed: no read sites today). The column stays as legacy-write-only; a follow-up will null then drop it.
+
+## Cache-integrity invariant (codified)
+
+> The shared-cache tables — `book_insights`, `external_source_cache`, and (in future PRs) `book_themes`, `insight_identity_aliases` whose `user_id` is NULL — MUST NOT carry any user-identifying column (`user_id`, `tenant_id`, `subject`, `principal_id`) read for any cache decision.
+
+A parametrized regression test (`tests/integration/test_cache_key_audit.py`) introspects each shared-cache table via SQLAlchemy reflection and asserts the absence of tenant columns. **Future PRs that add a shared-cache table MUST add it to the parametrize list** — PR2 (`insight_identity_aliases`), PR3 (`book_themes`). The test docstring restates this so the next PR author can't miss it.
+
+The invariant is also documented as a code comment above `BookInsight` and `ExternalSourceCacheEntry` in `db/models.py`.
+
+## Coalesced-waiter logging semantics
+
+When N concurrent `generate()` callers serialize on the per-identity lock: one model call, N log rows (1 `miss` + N-1 `hit`), each carrying its own `(tenant_id, subject, request_id)`. Asserted by `test_concurrent_generations_emit_one_miss_and_n_minus_one_hits`. Multi-session cross-tenant visibility asserted by `tests/integration/test_ai_audit_log.py::test_two_tenants_share_one_insight_two_log_rows`. This is what makes downstream per-tenant billing possible.
+
+## Per-call tenant_id (PR-B seam)
+
+`tenant_id` is a per-call kwarg on `get/generate/regenerate`, defaulting to `"local"`. The API layer (`opds_sync/api/ai.py`) hardcodes `tenant_id="local"` today; PR-B will swap that for `principal.tenant_id` once the `AiPrincipal` plumbing exists. Constructor-level state was rejected because the orchestrator is an app-state singleton — a process-wide default can't carry per-waiter tenant info.
+
+## Error rows
+
+The `status` check constraint allows `'hit' | 'miss' | 'error'`, but PR-C only emits hit/miss. Errors have no `book_insights` FK target (the row is committed AFTER `chat_structured` returns); a future PR may add nullable-FK or sentinel rows. The permissive constraint avoids a schema bump when that PR lands. Until then, error observability lives in the structured log channel — tested in `test_generate_error_emits_structured_log`.
+
+## PR-A test fallout (fixed in this PR)
+
+Materializing `ai_001` changed which alembic head the test fixture lands on. Two `test_readyz_migration_state.py` assertions and the session-scoped `alembic_upgrade` fixture were updated:
+
+- `tests/conftest.py::alembic_upgrade` now calls `scripts.migrate.run_migrations(cfg, progress_enabled=True, ai_enabled=True)` instead of `command.upgrade(cfg, "head")`. The wrapper handles multi-head correctly and matches production.
+- `test_readyz_200_when_at_backbone_no_labels` → renamed `test_readyz_200_when_at_ai_head`; expects `["ai_001"]`.
+- `test_readyz_200_with_neither_mode_at_backbone` stamps to `0004` explicitly so it exercises the "fresh sync-only deploy that never materialized ai" scenario.
+
+## What's NOT in this PR
+
+- `generated_by` nulling/drop — separate follow-up PRs (intentional phasing).
+- PR-B's real `AiPrincipal.tenant_id` plumbing — API layer hardcodes `"local"` for now.
+- Error-row DB emission — out of scope per the trade-off above.
+
+## Downgrade story
+
+```bash
+alembic downgrade ai@-1
+```
+
+Drops `ai_generation_log`. CASCADE FK means deleting a cache row already deletes its log children. PR-A's wrapper handles per-branch downgrades manually as designed.
+
+## Test plan
+
+- [x] `tests/integration/test_schema.py` — new `test_ai_generation_log_table_exists`, `test_ai_generation_log_round_trip`.
+- [x] `tests/integration/test_cache_key_audit.py` — parametrized regression test.
+- [x] `tests/integration/test_ai_audit_log.py` — two-tenant convergence with separate sessions.
+- [x] `tests/unit/test_ai_service.py` — 9 new tests (miss, hit, get-hit, get-miss-no-log, coalesce, request_id, tenant default, tenant override, error log).
+- [x] `tests/unit/conftest.py` truncate fixture updated to handle the new FK child.
+- [x] `tests/integration/test_readyz_migration_state.py` assertions updated for `ai_001` head.
+- [x] Full suite passes in full-stack mode.
+- [x] Full suite passes in sync-only mode (`requires_ai` tests skip cleanly).
+- [x] Full suite passes in ai-only mode (`requires_progress` tests skip cleanly).
+
+## Review summary
+
+GPT architect review captured during plan iteration — replace this paragraph with the final verdict + verbatim bottom-line from the last review round before opening the PR. Earlier rounds surfaced concerns about per-call tenant attribution, test-fixture mode awareness, FK-cascade in TRUNCATE, error-row semantics, and concurrent-waiter test fidelity — all addressed in the PR's tests and code.
+
+<!-- IMPLEMENTER: paste final verdict here before `gh pr create` runs -->
+
+## For downstream PR agents
+
+- **PR4 (language column)**: your migration is `ai_002_insight_language` with `down_revision = "ai_001"` and `branch_labels = None`. The cache-key audit test does not need changes (`language` is a cache-key dimension, not a tenant column).
+- **PR2 (identity aliases)**: your migration chains off the then-current `ai@head`. Add `InsightIdentityAlias` to `SHARED_CACHE_TABLES` in `tests/integration/test_cache_key_audit.py`. The user-scoped alias variant may need per-row policy rather than a column-level allow-list — design at PR2 review time.
+- **PR3 (themes)**: your migration chains off the then-current `ai@head`. Add `BookTheme` to `SHARED_CACHE_TABLES` — `book_themes` is fully shared, no `user_id` allowed.
+- **PR-B (auth abstraction)**: replace the hardcoded `tenant_id="local"` in `opds_sync/api/ai.py` with `principal.tenant_id` from the `AiPrincipal` dependency. Per-call kwarg is already there; only the API-layer line changes.
+EOF
+)"
+```
+
+- [ ] **Step 3: Capture the PR URL and final report**
+
+The parent agent needs:
+
+- PR URL (`gh pr view --json url -q .url`).
+- Branch: `feat/ai-generation-log`.
+- Migration `revision_id`: `ai_001` — this is what PR4's `down_revision` must point to.
+- Summary of deviations from the spec (if any).
+
+---
+
+## Self-review checklist (run before handing off)
+
+- [x] Every spec section maps to at least one task (invariant § → Task 3+4; schema § → Task 1; model § → Task 3; service § → Tasks 5, 6, 8; tests § → Tasks 1, 3, 4, 5, 6, 7, 8, 9; downgrade § → Task 1's `downgrade()`).
+- [x] PR-A test fallout handled (Task 2 — conftest + readyz).
+- [x] Truncate-cascade handled (Task 3 — `tests/unit/conftest.py`).
+- [x] Per-call `tenant_id` kwarg used everywhere — no `default_tenant_id` constructor state.
+- [x] Error path covered with structured log + test (Task 5 + Task 8).
+- [x] Multi-tenant test uses separate sessions (Task 9).
+- [x] No `TODO`, `TBD`, or `similar to Task N` placeholders.
+- [x] Type names consistent (`AIGenerationLog`, `_log_generation`, `tenant_id` kwarg everywhere).
+- [x] Commit messages use gitmoji + conventional commits, no Claude attribution.

--- a/docs/superpowers/specs/2026-05-16-ai-generation-log-design.md
+++ b/docs/superpowers/specs/2026-05-16-ai-generation-log-design.md
@@ -1,0 +1,333 @@
+# Spec — `ai_generation_log` table + cache-key tenant audit (PR-C)
+
+**Date:** 2026-05-16
+**Branch:** `feat/ai-generation-log` (stacked on `feat/alembic-mode-split` / PR-A)
+**Roadmap reference:** `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §PR-C
+**Status:** Draft for architect review
+
+## 1. Motivation
+
+`book_insights` is a **shared cache**: a single row keyed by `(metadata_id|content_hash, model_id, prompt_version, tone)` serves every tenant who asks for that identity. The cross-tenant cache-hit property is load-bearing — it is the only reason hosted Quire Cloud AI is economically viable on commodity LLM pricing.
+
+Today there is exactly one user-leaked column on the shared cache: `book_insights.generated_by`, which records "the first user_id that triggered generation". Two problems:
+
+1. **Audit ambiguity.** A cache HIT by tenant B against a row whose `generated_by = "tenant_A_user"` produces a useless audit trail. Billing-wise this is fatal: you cannot count tenant B's API consumption.
+2. **Cross-tenant leakage seam.** As long as the column exists and is *read for decisions*, every code path that consults it risks deciding things ("did THIS user generate this?") that bleed identity across tenants.
+
+PR-A landed the deploy-mode infrastructure (alembic branches, mode flags). PR-C is the first migration on the `ai` branch. It does two intertwined things:
+
+1. Introduces `ai_generation_log` — a per-call audit log indexed by tenant, foreign-keyed to `book_insights.id`. Future billing rollups query this table; the shared cache stays tenant-blind.
+2. Stops reading `book_insights.generated_by` for any decision. The column stays for now (read by no one). A later PR nulls it; a later still PR may drop it.
+
+Additionally, this PR codifies the **cache-integrity invariant** as a test and as a code comment, so future schema PRs (PR2 aliases, PR3 themes) can't accidentally re-introduce a `user_id`/`tenant_id` column on a shared cache table.
+
+## 2. Cache-integrity invariant
+
+Stated formally:
+
+> The shared-cache tables — `book_insights`, `external_source_cache`, and (in future PRs) `book_themes`, `insight_identity_aliases` whose `user_id` is NULL — MUST NOT carry any user-identifying column (`user_id`, `tenant_id`, `subject`, `principal_id`, or equivalent) that participates in their cache key or that is read for any cache decision.
+>
+> Per-tenant audit and billing live in `ai_generation_log`, which references `book_insights.id` and carries the tenant/subject/request-id fields.
+
+PR-C ships a parametrized test (`tests/integration/test_cache_key_audit.py`) that introspects each shared-cache table via SQLAlchemy reflection and asserts the absence of forbidden columns. The test is mechanically future-proof: a future schema PR that adds `user_id` to (say) `book_themes` makes the audit test fail at CI time.
+
+The same invariant is documented as a docstring comment on `BookInsight` and `ExternalSourceCacheEntry` in `db/models.py`.
+
+`generated_by` is grandfathered: the audit test ignores it explicitly with a comment pointing to the deprecation plan ("no longer read for any decision; follow-up nulls then drops").
+
+## 3. Schema: `ai_generation_log`
+
+### 3.1 Migration
+
+- Filename: `migrations/versions/ai_001_generation_log.py`.
+- Convention (per PR-A's `migrations/README.md`):
+  - `revision = "ai_001"`
+  - `down_revision = "0004"` (split point on the backbone)
+  - `branch_labels = ("ai",)` (first migration on the `ai` branch)
+  - `depends_on = None`
+- Created via `alembic revision --head=0004 --splice --branch-label=ai -m "ai_001 generation_log"` (or hand-authored to the same shape).
+
+### 3.2 DDL
+
+```sql
+CREATE TABLE ai_generation_log (
+    id              BIGSERIAL    PRIMARY KEY,
+    book_insight_id BIGINT       NOT NULL REFERENCES book_insights(id) ON DELETE CASCADE,
+    tenant_id       TEXT         NOT NULL DEFAULT 'local',
+    subject         TEXT         NOT NULL,
+    request_id      TEXT         NULL,
+    model_id        TEXT         NOT NULL,
+    prompt_version  TEXT         NOT NULL,
+    latency_ms      INTEGER      NULL,
+    status          TEXT         NOT NULL,  -- 'hit' | 'miss' | 'error'
+    error_class     TEXT         NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT ck_ai_generation_log_status
+        CHECK (status IN ('hit', 'miss', 'error'))
+);
+
+CREATE INDEX ix_ai_generation_log_tenant_created
+    ON ai_generation_log (tenant_id, created_at);
+CREATE INDEX ix_ai_generation_log_book_insight
+    ON ai_generation_log (book_insight_id);
+```
+
+Field rationale:
+
+| Column | Why |
+|--------|-----|
+| `book_insight_id` (FK CASCADE) | Anchors the audit row to the actual cache row served. Invalidating an insight cleans up its history. |
+| `tenant_id` (default `'local'`) | Single-tenant deployments (today's 99%) keep emitting `'local'`. Hosted Quire Cloud AI emits the real tenant id via `AiPrincipal.tenant_id` (PR-B). |
+| `subject` | The principal (user_id today, JWT/HMAC sub tomorrow). Required, non-null — every call is attributable to someone. |
+| `request_id` | Nullable because background/internal flows may have none. Populated from the `request_id_var` ContextVar set by PR-A's `RequestIDMiddleware`. |
+| `model_id`, `prompt_version` | Captured at log-write time so the audit row survives prompt/model bumps even if the parent `book_insights` row is later regenerated. |
+| `latency_ms` | Wall-clock generation latency for `miss`/`error`. For `hit`, the cache-lookup cost (or 0). Nullable to keep the column honest if we can't measure. |
+| `status` | Tri-state: `hit` (served from cache), `miss` (we called the model), `error` (we tried and failed). Check constraint enforces. |
+| `error_class` | Class name of the exception that escaped `chat_structured`. Null on success. |
+| `created_at` | `now()` server default; index supports `(tenant_id, created_at)` for billing rollups. |
+
+The `(tenant_id, created_at)` index is the **future billing path**: "sum `status='miss'` per tenant per day". The `(book_insight_id)` index supports the audit-UI use case (PR6).
+
+### 3.3 What is NOT on this table
+
+- No `user_id` column distinct from `subject` — they're the same thing under different names; `subject` is the forward-compatible spelling.
+- No `cost_*` columns — pricing varies by provider and changes over time; compute downstream from `(model_id, status)`.
+- No `prompt_text` or `payload` — those go in the cache row or in structured logs, not the audit table. Storing them here would balloon the table and re-introduce PII concerns.
+- No `cache_key_hash` — the FK to `book_insights.id` is the cache-key handle.
+
+## 4. ORM model
+
+A new `AIGenerationLog` SQLAlchemy declarative model is added to `opds_sync/db/models.py`. It mirrors the migration exactly:
+
+```python
+class AIGenerationLog(Base):
+    __tablename__ = "ai_generation_log"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('hit', 'miss', 'error')",
+            name="ck_ai_generation_log_status",
+        ),
+        Index("ix_ai_generation_log_tenant_created", "tenant_id", "created_at"),
+        Index("ix_ai_generation_log_book_insight", "book_insight_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    book_insight_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("book_insights.id", ondelete="CASCADE"), nullable=False
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("'local'"), default="local"
+    )
+    subject: Mapped[str] = mapped_column(String, nullable=False)
+    request_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    model_id: Mapped[str] = mapped_column(String, nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String, nullable=False)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    error_class: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+```
+
+The PR also adds a comment block above `BookInsight` declaring the cache-integrity invariant in code, and a similar comment above `ExternalSourceCacheEntry`.
+
+## 5. Service-layer changes (`opds_sync/core/ai/service.py`)
+
+### 5.1 Logging semantics — one row per waiter
+
+The orchestrator emits exactly one `ai_generation_log` row per `generate()` / `regenerate()` / `get()` *call* (i.e., per waiter), regardless of cache state. This is the explicit design from the roadmap: cache hits and misses both count, billing decides how to weight them.
+
+Per-call-shape:
+
+| Call site | When the row is written | `status` | `latency_ms` | `error_class` |
+|-----------|------------------------|----------|--------------|---------------|
+| `generate()` / `regenerate()` cache HIT (first lookup) | After the hit, before returning | `'hit'` | 0 (or short lookup time) | NULL |
+| `generate()` cache HIT under the lock (a coalesced waiter) | After the second lookup | `'hit'` | 0 | NULL |
+| `generate()` / `regenerate()` cache MISS — model call succeeds | After `BookInsight` row is committed; FK is the new row's id | `'miss'` | wall-clock around `chat_structured` (already measured today) | NULL |
+| `generate()` / `regenerate()` cache MISS — model call raises | **No DB row written** (no FK target); see §5.3 for the structured-log substitute. | n/a (no row) | n/a (logged) | n/a (logged) |
+| `get()` cache HIT | After the hit, before returning | `'hit'` | 0 | NULL |
+| `get()` cache MISS | No log row (no work was done, no decision to audit) | — | — | — |
+
+The `get()`-miss case is deliberately silent: `get()` is a pure cache probe (used by the GET endpoint that returns 404 when there's nothing cached), and emitting a log row per probe would make the table grow with frontend polling rather than with billable AI work. (We can revisit if we later need probe-rate visibility — it's an additive change.)
+
+### 5.2 Coalesced waiters
+
+When N concurrent `generate()` callers hit the same identity+tone, today's lock serializes them; the first acquires the model call, the remaining N-1 see the cache row on their second lookup and return.
+
+PR-C preserves this semantics and emits **N rows total**: one `'miss'` for the generator + (N-1) `'hit'` for the waiters. Each waiter row carries the waiter's own `(tenant_id, subject, request_id)` and FKs to the same `book_insight_id`. This is exactly what billing needs: tenant B gets a "hit" charge for a row that tenant A's "miss" populated.
+
+The existing test `test_concurrent_generations_collapse_to_one_model_call` already asserts "one model call". PR-C adds a sibling test that also asserts "three `ai_generation_log` rows: one miss + two hits, all FKing to the same insight".
+
+### 5.3 Error rows and the FK problem
+
+A model-call failure has no `book_insights` row to FK to (the row is committed *after* `chat_structured` returns). Options:
+
+1. **Make `book_insight_id` nullable.** Simple, but weakens the schema (most rows will FK, a minority won't, and the FK loses meaning for `error` rows).
+2. **Don't log errors at the `ai_generation_log` level.** Errors already produce a structured log line; downstream operators query logs, not this table.
+3. **Synthesize a sentinel row.** Adds complexity for one rare case.
+
+Decision: **Option 2.** `ai_generation_log` rows always have a non-null FK to a real `book_insights` row. Errors are logged via the structured logger (this PR keeps the existing `logger.info(...)` and adds a `logger.warning("ai.generate.error ...")` on the exception path that emits `event=ai.generate.error`, `tenant_id`, `subject`, `model_id`, `prompt_version`, `error_class`, and reads `request_id` from the `request_id_var` ContextVar via the existing log filter) and are out of scope for the FK-anchored audit table.
+
+This means the `status` check constraint accepts `'hit' | 'miss' | 'error'` for forward-compat, but `'error'` rows are never written in PR-C. We keep the constraint permissive so a future PR (when we add nullable-FK or sentinel rows) doesn't require a schema bump for the values. The migration comment documents this.
+
+PR-C adds a test (`test_generate_error_emits_structured_log`) that injects a fake AI client raising an exception and asserts the structured log line is emitted with the right fields. This closes the observability gap so error rates remain queryable from log aggregation even though they don't appear in `ai_generation_log`.
+
+Trade-off considered and accepted: we lose per-error tenant attribution in the audit table. Operators get it from logs (structured, includes `tenant_id` and `request_id` via the log filter), which is a more natural fit for error analysis anyway.
+
+### 5.4 ContextVar plumbing and tenant_id parameter
+
+`tenant_id`, `subject`, and `request_id` arrive at the orchestrator via different paths:
+
+- `request_id`: `request_id_var.get()` (already imported by PR-A's logging filter). No signature change required.
+- `subject`: today this is `user_id`, the same string already threaded through `generate(user_id=...)`. Renaming the parameter is out of scope; we use `user_id` internally and write it to the `subject` column.
+- `tenant_id`: **Per-call kwarg** on `get()`, `generate()`, and `regenerate()`, defaulting to `"local"`. PR-B will pass `AiPrincipal.tenant_id` from the API layer; until then every caller passes `"local"` (or omits the kwarg).
+
+The per-call kwarg approach replaces an earlier draft that put `default_tenant_id` on the orchestrator constructor. The constructor-level default is wrong because the orchestrator is a long-lived singleton on `app.state` shared across requests — a single process-wide default can't carry per-waiter tenant info. The per-call kwarg matches how `user_id` is already threaded.
+
+Internal helper `_log_generation(session, *, book_insight_id, subject, tenant_id, status, latency_ms=None, error_class=None)` writes the row using `request_id_var.get()` for the `request_id` column.
+
+For coalesced waiters: each waiter calls `generate(..., user_id=..., tenant_id=...)` with its own values; the lock-holder's `miss` row uses the lock-holder's `(user_id, tenant_id)`, each waiter's `hit` row uses that waiter's own `(user_id, tenant_id)`. This is exactly the billing semantic we want.
+
+### 5.5 Stop reading `generated_by`
+
+Audit: grep the codebase for `generated_by` and confirm no read sites remain.
+
+```bash
+$ rg "generated_by" server/
+opds_sync/core/ai/service.py:    generated_by=user_id,  # WRITE site — kept until follow-up migration nulls the column
+opds_sync/db/models.py:    generated_by: Mapped[str] ...   # column declaration
+migrations/versions/0003_ai_tables.py: sa.Column("generated_by", ...)  # historical
+```
+
+There are no read sites today (the column is write-only). PR-C therefore does NOT modify any code that "stops reading" `generated_by` — there's nothing to remove. The PR keeps the write site intact (the column is NOT NULL; removing the write would break inserts until a follow-up nulls/drops) and adds a code comment marking the column as deprecated-write-only.
+
+A follow-up PR will:
+1. Add a migration that makes `generated_by` NULLABLE (and stop the orchestrator from writing it).
+2. A still-later migration drops the column.
+
+This phased approach keeps every PR in this batch independently reversible.
+
+## 6. Tests
+
+### 6.1 Unit (`server/tests/unit/test_ai_service.py` — additions)
+
+- `test_generate_writes_miss_then_subsequent_call_writes_hit`: one `generate()` produces a `'miss'` row; a second `generate()` on the same identity produces a `'hit'` row; both FK the same `book_insight_id`; both rows carry their respective `user_id` in `subject`.
+- `test_concurrent_generations_emit_one_miss_and_n_minus_one_hits`: extend the existing coalescing test to also assert exactly 1 `'miss'` and N-1 `'hit'` rows.
+- `test_get_hit_writes_log_row`: `get()` against a pre-populated insight writes a `'hit'` row.
+- `test_get_miss_writes_no_log_row`: `get()` against an empty cache returns `None` and writes nothing.
+- `test_log_carries_request_id_when_set`: with `request_id_var` set, the log row's `request_id` matches.
+- `test_log_default_tenant_id_is_local`: default deployments produce `tenant_id='local'` (when `tenant_id` kwarg omitted).
+- `test_log_uses_passed_tenant_id`: when `generate(..., tenant_id="acme")` is called, the row carries `tenant_id='acme'`.
+- `test_generate_error_emits_structured_log`: inject a fake AI client that raises; assert a `logger.warning` is emitted with `event=ai.generate.error`, `tenant_id`, `subject`, and `error_class` fields populated; assert no `ai_generation_log` row was written. Use `caplog` fixture.
+
+#### Unit-conftest cleanup (`server/tests/unit/conftest.py`)
+
+The autouse `_truncate_external_source_cache` fixture (despite its name) truncates `external_source_cache, book_insights, ai_usage_daily`. After PR-C, `ai_generation_log` is a FK child of `book_insights`, so truncating `book_insights` without `CASCADE` will raise `Cannot truncate a table referenced in a foreign key constraint`. The fixture must add `ai_generation_log` to the list AND use `CASCADE`, or list children first. PR-C goes with `TRUNCATE TABLE ai_generation_log, external_source_cache, book_insights, ai_usage_daily CASCADE` for simplicity and order-independence.
+
+### 6.2 Integration — multi-tenant audit (`server/tests/integration/test_ai_audit_log.py`)
+
+- `test_two_tenants_share_one_insight_two_log_rows`: simulate two requests with different `subject` and different `tenant_id` (passed via the per-call kwarg) for the same `DocumentIdentity`, **each using its own `AsyncSession`** (separate session factories from the shared engine). Assert exactly one `book_insights` row and exactly two `ai_generation_log` rows; one `miss` + one `hit`; both FK the same id; tenant IDs distinct.
+
+The separate-session pattern matters: it exercises real transaction-visibility (waiter B's session must see the committed `book_insights` row from waiter A's session). The orchestrator is constructed once and shared, mirroring the production app-state singleton.
+
+### 6.3 Integration — cache-key audit (`server/tests/integration/test_cache_key_audit.py`)
+
+Parametrized over `[BookInsight, ExternalSourceCacheEntry]` (and forward-compat tags for `BookTheme` and `InsightIdentityAlias` once they exist):
+
+- `test_shared_cache_table_has_no_tenant_columns`: SQLAlchemy reflection of each table's columns; assert that none of `{"user_id", "tenant_id", "subject", "principal_id"}` appear, with `generated_by` allow-listed for `BookInsight` with a comment.
+
+This test is **future-proof**: PR2 (`insight_identity_aliases`) and PR3 (`book_themes`) will need to add themselves to the parametrize list. The test docstring states this explicitly so the next PR author can't miss it.
+
+### 6.4 Mode matrix and PR-A test fallout
+
+The CI matrix PR-A landed runs the suite under three flag combinations. PR-C's tests are marked `requires_ai` (they need the AI router and orchestrator), so:
+
+- Full-stack: tests run.
+- Sync-only (`AI_ENABLED=false`): tests skip cleanly.
+- AI-only (`PROGRESS_ENABLED=false`): tests run.
+
+`requires_progress` tests continue to skip in AI-only mode (no change from PR-A).
+
+**Fallout from materializing the first `ai` branch migration:** PR-A's session-scoped `alembic_upgrade` fixture in `tests/conftest.py` runs `command.upgrade(cfg, "head")` unconditionally — bypassing the mode-aware `scripts/migrate.py::run_migrations` wrapper. With `ai_001` present, "head" advances the DB to `ai_001`, which breaks:
+
+- `tests/integration/test_readyz_migration_state.py::test_readyz_200_when_at_backbone_no_labels` — asserts `body["heads_applied"] == ["0004"]`, but the DB is now at `ai_001`.
+- `tests/integration/test_readyz_migration_state.py::test_readyz_200_with_neither_mode_at_backbone` — same: `body["heads_applied"]` is now `["ai_001"]`, not `["0004"]`. The readyz check also incorrectly reports the backbone as "missing" because `_required_heads` falls back to `{0004}` when no branch is enabled, but `current = {ai_001}`.
+
+**Fix (smaller blast radius than rewriting `_required_heads`):**
+
+1. Change `tests/conftest.py::alembic_upgrade` to invoke the mode-aware wrapper:
+
+   ```python
+   from scripts.migrate import run_migrations
+   run_migrations(cfg, progress_enabled=True, ai_enabled=True)
+   ```
+
+   This still applies all branches for tests that need them (the default for session-scoped fixtures), but uses the production code path so any future divergence is caught.
+
+2. Update the two readyz assertions:
+   - `test_readyz_200_when_at_backbone_no_labels`: expect `["ai_001"]` (the new `ai@head`). Rename to `test_readyz_200_when_at_ai_head`.
+   - `test_readyz_200_with_neither_mode_at_backbone`: this test must explicitly stamp the DB to `0004` (because the session-scoped fixture brings everything up), so the assertion `["0004"]` makes sense again. Use the existing `_stamp(postgres_url, "0004")` helper.
+
+3. `test_readyz_503_when_db_below_backbone` keeps working — it explicitly stamps to `0003` then checks for 503 with `0004` missing.
+
+This keeps `_required_heads` exactly as PR-A wrote it (don't fix what isn't broken in production) and only adjusts test setup. The production wrapper `run_migrations` is already correct; the test fixture was the outlier.
+
+## 7. Downgrade story
+
+The migration's `downgrade()`:
+
+```python
+def downgrade() -> None:
+    op.drop_index("ix_ai_generation_log_book_insight", table_name="ai_generation_log")
+    op.drop_index("ix_ai_generation_log_tenant_created", table_name="ai_generation_log")
+    op.drop_table("ai_generation_log")
+```
+
+The CASCADE FK means deleting a `book_insights` row already cleans up its log children — no cross-branch coordination needed when this migration is rolled back independently.
+
+Per PR-A's wrapper, downgrades are manual:
+
+```bash
+alembic downgrade ai@-1
+```
+
+This removes `ai_001_generation_log` and returns `ai@head` to `0004` (i.e., the `ai` branch no longer has a head; only the backbone remains). Subsequent `ai` migrations (PR4 `ai_002_insight_language`, PR2's aliases, PR3's themes) chain off `ai_001`, so they downgrade in the usual reverse order before this one.
+
+## 8. Risks and mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Doubled writes on every AI call (cache row + log row) increase commit cost. | Both writes happen in the same `session.commit()` block for `miss` rows. `hit` rows are a single-row insert and a single commit — negligible. |
+| Log table grows unbounded. | Out of scope here; future operator concern. Schema supports straightforward `DELETE FROM ai_generation_log WHERE created_at < now() - interval '90 days'`. |
+| FK CASCADE accidentally deletes audit history on `invalidate()`. | Intended: invalidating a cache row also invalidates its audit story; billing rollups should snapshot/aggregate before invalidation if they need durable history. Documented in code comment near the FK. |
+| Future PR adds `user_id` to a shared cache table by accident. | Cache-key audit test fails at CI. |
+| `tenant_id` default `'local'` masks a missed PR-B integration. | Acceptable: PR-B will exercise the override; until then `'local'` is the only correct value (single-tenant). |
+| Coalesced waiter "hit" rows could race with the lock-holder's "miss" row commit (FK violation). | Waiters' `_cache_lookup` happens AFTER the lock-holder's `session.commit()` releases the lock — by the time a waiter writes its `hit` row, the FK target is committed and visible. The existing serialization is sufficient; we add a regression test covering it. |
+
+## 9. Out of scope
+
+- PR-B's `AiPrincipal`/`tenant_id` real plumbing (`'local'` is hardcoded).
+- Nulling or dropping `book_insights.generated_by` (separate follow-up PRs).
+- Cost computation, billing rollups, retention policy.
+- `'error'` rows in `ai_generation_log` (constraint allows them; PR keeps the column shape stable so the row schema doesn't need to bump when we add nullable-FK or sentinel rows).
+- Android UI changes (PR-C is server-only; PR6 will surface log data in the audit UI).
+
+## 10. Acceptance checklist
+
+- [ ] `migrations/versions/ai_001_generation_log.py` exists with correct branch labels.
+- [ ] `AIGenerationLog` model added to `db/models.py`.
+- [ ] Cache-integrity invariant comment added above `BookInsight` and `ExternalSourceCacheEntry` in `models.py`.
+- [ ] `service.py` writes one log row per call (hit / miss per §5.1 table; errors emit structured logs only).
+- [ ] `tenant_id` is a per-call kwarg on `get()`, `generate()`, `regenerate()`, defaulting to `"local"`.
+- [ ] `tests/unit/conftest.py` truncate fixture updated to include `ai_generation_log` and `CASCADE`.
+- [ ] `tests/conftest.py::alembic_upgrade` uses `scripts.migrate.run_migrations` instead of `command.upgrade(cfg, "head")`.
+- [ ] `tests/integration/test_readyz_migration_state.py` assertions updated for `ai_001` head.
+- [ ] No code path reads `book_insights.generated_by`.
+- [ ] API layer (`opds_sync/api/ai.py`) passes `tenant_id="local"` (today's default) on all `orch.get/generate/regenerate` calls, AND passes `user_id` into `orch.get()` for hit auditing.
+- [ ] Tests added in §6 all pass.
+- [ ] All existing tests pass under all three mode-matrix combinations.
+- [ ] `requires_ai` tests skip in sync-only mode; `requires_progress` tests skip in ai-only mode.
+- [ ] Spec + plan committed under `docs/superpowers/`.
+- [ ] PR body documents the cache-integrity invariant and lists future PRs that must respect it (PR2 aliases, PR3 themes, PR4 language).

--- a/server/migrations/env.py
+++ b/server/migrations/env.py
@@ -9,7 +9,12 @@ from opds_sync.db.models import Base
 
 config = context.config
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers=False: without this, fileConfig DISABLES every
+    # logger that was created before alembic ran (including all `opds_sync.*`
+    # loggers). The migrate.py wrapper invokes env.py during container start,
+    # so production process loggers would arrive at request-handling time
+    # already disabled — silencing structured logs like `event=ai.generate.error`.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
 

--- a/server/migrations/versions/ai_001_generation_log.py
+++ b/server/migrations/versions/ai_001_generation_log.py
@@ -1,0 +1,79 @@
+"""ai_001_generation_log: per-call tenant audit log keyed to book_insights.
+
+First migration on the `ai` branch (per PR-A's branching convention).
+
+Schema:
+- ai_generation_log records one row per AI insight call (hit, miss; errors
+  go to structured logs because they have no FK target). It is the future
+  billing/audit substrate; the shared cache table `book_insights` stays
+  tenant-blind.
+- FK on book_insight_id is ON DELETE CASCADE: invalidating an insight cleans
+  up its audit children.
+- The check constraint accepts 'hit' | 'miss' | 'error' to remain forward-
+  compatible with a future PR that introduces error rows (via nullable FK or
+  sentinel rows). PR-C only emits 'hit' and 'miss'.
+
+Revision ID: ai_001
+Revises: 0004
+Create Date: 2026-05-16 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_001"
+down_revision = "0004"
+branch_labels = ("ai",)
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_generation_log",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "book_insight_id",
+            sa.BigInteger(),
+            sa.ForeignKey("book_insights.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tenant_id",
+            sa.String(),
+            nullable=False,
+            server_default=sa.text("'local'"),
+        ),
+        sa.Column("subject", sa.String(), nullable=False),
+        sa.Column("request_id", sa.String(), nullable=True),
+        sa.Column("model_id", sa.String(), nullable=False),
+        sa.Column("prompt_version", sa.String(), nullable=False),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("error_class", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "status IN ('hit', 'miss', 'error')",
+            name="ck_ai_generation_log_status",
+        ),
+    )
+    op.create_index(
+        "ix_ai_generation_log_tenant_created",
+        "ai_generation_log",
+        ["tenant_id", "created_at"],
+    )
+    op.create_index(
+        "ix_ai_generation_log_book_insight",
+        "ai_generation_log",
+        ["book_insight_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ai_generation_log_book_insight", table_name="ai_generation_log")
+    op.drop_index("ix_ai_generation_log_tenant_created", table_name="ai_generation_log")
+    op.drop_table("ai_generation_log")

--- a/server/opds_sync/api/ai.py
+++ b/server/opds_sync/api/ai.py
@@ -211,9 +211,7 @@ async def get_insight(
         await session.execute(select(UserAIPreference).where(UserAIPreference.user_id == user_id))
     ).scalar_one_or_none()
     style = _style_from_pref(pref) if pref is not None else AiStyle()
-    out = await orch.get(
-        session, body.identity, user_id=user_id, style=style, tenant_id="local"
-    )
+    out = await orch.get(session, body.identity, user_id=user_id, style=style, tenant_id="local")
     if out is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="not_cached")
     return out

--- a/server/opds_sync/api/ai.py
+++ b/server/opds_sync/api/ai.py
@@ -164,6 +164,7 @@ async def lookup_insight(
             body.bundle,
             user_id=user_id,
             style=_style_from_pref(pref),
+            tenant_id="local",
         )
     except QuotaExceeded as exc:
         raise _quota_http_exception(exc) from exc
@@ -190,6 +191,7 @@ async def regenerate_insight(
             user_id=user_id,
             reason=body.reason,
             style=_style_from_pref(pref),
+            tenant_id="local",
         )
     except QuotaExceeded as exc:
         raise _quota_http_exception(exc) from exc
@@ -209,7 +211,9 @@ async def get_insight(
         await session.execute(select(UserAIPreference).where(UserAIPreference.user_id == user_id))
     ).scalar_one_or_none()
     style = _style_from_pref(pref) if pref is not None else AiStyle()
-    out = await orch.get(session, body.identity, style=style)
+    out = await orch.get(
+        session, body.identity, user_id=user_id, style=style, tenant_id="local"
+    )
     if out is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="not_cached")
     return out

--- a/server/opds_sync/api/health.py
+++ b/server/opds_sync/api/health.py
@@ -102,6 +102,55 @@ def _required_heads(script, progress_enabled: bool, ai_enabled: bool) -> set[str
     return required
 
 
+def _is_at_or_past(script, current: str, target: str) -> bool:
+    """Return True if `current` is `target` or any descendant of `target`."""
+    if current == target:
+        return True
+    rev = script.get_revision(current)
+    if rev is None:
+        return False
+    # Walk down_revisions backward to base; if we encounter `target`, current
+    # descends from it.
+    seen: set[str] = set()
+    stack: list[str] = list(rev.down_revision or [])
+    if isinstance(rev.down_revision, str):
+        stack = [rev.down_revision]
+    elif rev.down_revision is None:
+        stack = []
+    else:
+        stack = list(rev.down_revision)
+    while stack:
+        rid = stack.pop()
+        if rid in seen:
+            continue
+        seen.add(rid)
+        if rid == target:
+            return True
+        parent = script.get_revision(rid)
+        if parent is None:
+            continue
+        if isinstance(parent.down_revision, str):
+            stack.append(parent.down_revision)
+        elif parent.down_revision:
+            stack.extend(parent.down_revision)
+    return False
+
+
+def _missing(script, required: set[str], current: set[str]) -> set[str]:
+    """Return required revisions not satisfied by any current revision.
+
+    A required revision R is satisfied if any current revision C equals R or
+    descends from R. This handles the "DB has ai_001, neither mode enabled,
+    fallback required is 0004" case: 0004 is an ancestor of ai_001, so the
+    backbone is satisfied even though current != required.
+    """
+    out: set[str] = set()
+    for r in required:
+        if not any(_is_at_or_past(script, c, r) for c in current):
+            out.add(r)
+    return out
+
+
 async def _db_alembic_heads() -> set[str]:
     """Return the set of revisions in the DB's alembic_version table."""
     async with session_scope() as s:
@@ -150,7 +199,7 @@ async def readyz():
             content={"ready": False, "detail": "alembic state unreadable", "modes": modes},
         )
 
-    missing = required - current
+    missing = _missing(script, required, current)
     if missing:
         return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/server/opds_sync/core/ai/service.py
+++ b/server/opds_sync/core/ai/service.py
@@ -123,12 +123,24 @@ class InsightOrchestrator:
         session: AsyncSession,
         ident: DocumentIdentity,
         *,
+        user_id: str | None = None,
         style: AiStyle | None = None,
+        tenant_id: str = "local",
     ) -> BookInsightResponse | None:
         tone = _tone_of(style)
         row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=False)
         if row is None:
             return None
+        if user_id is not None:
+            await self._log_generation(
+                session,
+                book_insight_id=row.id,
+                subject=user_id,
+                tenant_id=tenant_id,
+                status="hit",
+                latency_ms=0,
+            )
+            await session.commit()
         return self._row_to_response(row)
 
     async def generate(

--- a/server/opds_sync/core/ai/service.py
+++ b/server/opds_sync/core/ai/service.py
@@ -35,7 +35,8 @@ from opds_sync.api.ai_schemas import (
     SeriesInsight,
 )
 from opds_sync.core.ai.prompts import SYSTEM_PROMPT, compose_user_prompt
-from opds_sync.db.models import AIUsageDaily, BookInsight
+from opds_sync.core.logging_ctx import request_id_var
+from opds_sync.db.models import AIGenerationLog, AIUsageDaily, BookInsight
 
 logger = logging.getLogger(__name__)
 
@@ -138,16 +139,35 @@ class InsightOrchestrator:
         *,
         user_id: str,
         style: AiStyle | None = None,
+        tenant_id: str = "local",
     ) -> BookInsightResponse:
         tone = _tone_of(style)
         row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=True)
         if row is not None:
+            await self._log_generation(
+                session,
+                book_insight_id=row.id,
+                subject=user_id,
+                tenant_id=tenant_id,
+                status="hit",
+                latency_ms=0,
+            )
+            await session.commit()
             return self._row_to_response(row)
 
         lock = await self._acquire_identity_lock(ident, tone=tone)
         async with lock:
             row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=True)
             if row is not None:
+                await self._log_generation(
+                    session,
+                    book_insight_id=row.id,
+                    subject=user_id,
+                    tenant_id=tenant_id,
+                    status="hit",
+                    latency_ms=0,
+                )
+                await session.commit()
                 return self._row_to_response(row)
 
             await self._reserve_budget(session, user_id=user_id, is_regen=False)
@@ -157,6 +177,7 @@ class InsightOrchestrator:
                 ident,
                 bundle,
                 user_id=user_id,
+                tenant_id=tenant_id,
                 style=style,
                 tone=tone,
                 feedback=None,
@@ -173,6 +194,7 @@ class InsightOrchestrator:
         user_id: str,
         reason: str,
         style: AiStyle | None = None,
+        tenant_id: str = "local",
     ) -> BookInsightResponse:
         """Supersede the existing live row (if any) and generate a fresh one."""
         tone = _tone_of(style)
@@ -193,6 +215,7 @@ class InsightOrchestrator:
                 ident,
                 bundle,
                 user_id=user_id,
+                tenant_id=tenant_id,
                 style=style,
                 tone=tone,
                 feedback=reason,
@@ -218,6 +241,32 @@ class InsightOrchestrator:
 
     # ------- internals -------
 
+    async def _log_generation(
+        self,
+        session: AsyncSession,
+        *,
+        book_insight_id: int,
+        subject: str,
+        tenant_id: str,
+        status: str,
+        latency_ms: int | None,
+        error_class: str | None = None,
+    ) -> None:
+        """Stage one ai_generation_log row. Caller commits the surrounding tx."""
+        session.add(
+            AIGenerationLog(
+                book_insight_id=book_insight_id,
+                tenant_id=tenant_id,
+                subject=subject,
+                request_id=(request_id_var.get() or None),
+                model_id=self.model_id,
+                prompt_version=self.prompt_version,
+                latency_ms=latency_ms,
+                status=status,
+                error_class=error_class,
+            )
+        )
+
     async def _do_generate(
         self,
         session: AsyncSession,
@@ -225,6 +274,7 @@ class InsightOrchestrator:
         bundle: MetadataBundle,
         *,
         user_id: str,
+        tenant_id: str,
         style: AiStyle | None,
         tone: str,
         feedback: str | None,
@@ -234,12 +284,29 @@ class InsightOrchestrator:
             citations = await self._retrieve(session, bundle)
             user_prompt = compose_user_prompt(bundle, citations, style=style, feedback=feedback)
             t0 = time.monotonic()
-            payload = await self.ai.chat_structured(
-                system=SYSTEM_PROMPT,
-                user=user_prompt,
-                schema=BookInsightPayload,
-                timeout_s=self._ai_timeout_s,
-            )
+            try:
+                payload = await self.ai.chat_structured(
+                    system=SYSTEM_PROMPT,
+                    user=user_prompt,
+                    schema=BookInsightPayload,
+                    timeout_s=self._ai_timeout_s,
+                )
+            except Exception as e:
+                # Errors don't produce an ai_generation_log row (no FK target).
+                # The structured log line is the operator-facing audit trail;
+                # request_id is attached by RequestIdLogFilter (record.request_id).
+                latency_ms = int((time.monotonic() - t0) * 1000)
+                logger.warning(
+                    "event=ai.generate.error tenant_id=%s subject=%s model=%s "
+                    "prompt_version=%s latency_ms=%d error_class=%s",
+                    tenant_id,
+                    user_id,
+                    self.model_id,
+                    self.prompt_version,
+                    latency_ms,
+                    type(e).__name__,
+                )
+                raise
             latency_ms = int((time.monotonic() - t0) * 1000)
             logger.info(
                 "ai.generate content_hash=%s model=%s latency_ms=%d sources=%s regen=%s",
@@ -267,10 +334,23 @@ class InsightOrchestrator:
             sources_used=list({c.kind for c in citations}),
             payload=payload.model_dump(),
             sources=[c.model_dump() for c in sources],
+            # generated_by is grandfathered: NOT NULL legacy column. PR-C still
+            # WRITES it (to satisfy the constraint) but NEVER READS it. A
+            # follow-up PR will null then drop it. The replacement audit trail
+            # is AIGenerationLog (FK from book_insight_id).
             generated_by=user_id,
             previous_insight_ids=previous_insight_ids,
         )
         session.add(row)
+        await session.flush()  # populate row.id before logging
+        await self._log_generation(
+            session,
+            book_insight_id=row.id,
+            subject=user_id,
+            tenant_id=tenant_id,
+            status="miss",
+            latency_ms=latency_ms,
+        )
         await session.commit()
         await session.refresh(row)
         return row

--- a/server/opds_sync/core/logging_ctx.py
+++ b/server/opds_sync/core/logging_ctx.py
@@ -17,8 +17,11 @@ request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 class RequestIdLogFilter(logging.Filter):
     """Inject the current request_id into every log record.
 
-    Use by attaching to the relevant logger / handler:
-        logging.getLogger().addFilter(RequestIdLogFilter())
+    IMPORTANT: attach to HANDLERS, not to loggers. Logger-level filters do
+    NOT apply to records propagated up from child loggers — only to records
+    logged directly to that logger. The production wiring lives in
+    `main.py::create_app()`; mirror it in tests by adding the filter to
+    `caplog.handler` or to your own handler instance.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/server/opds_sync/db/models.py
+++ b/server/opds_sync/db/models.py
@@ -66,6 +66,21 @@ class Progress(Base):
     document: Mapped[Document] = relationship(back_populates="progress")
 
 
+# ============================================================================
+# Cache-integrity invariant (PR-C, 2026-05-16)
+# ----------------------------------------------------------------------------
+# `book_insights` is a SHARED CACHE: one row serves every tenant who requests
+# the same identity+model+prompt+tone. The cross-tenant cache-hit property is
+# load-bearing for hosted Quire Cloud AI economics.
+#
+# Therefore this table MUST NOT carry `user_id`, `tenant_id`, `subject`, or
+# any other principal column read for cache decisions. Per-call audit and
+# billing attribution live in `ai_generation_log` (FK to book_insights.id).
+#
+# `generated_by` is grandfathered: a NOT NULL column from before this
+# invariant existed. PR-C stops reading it; a follow-up will null it; a
+# later migration will drop it. Until then it is write-only legacy.
+# ============================================================================
 class BookInsight(Base):
     __tablename__ = "book_insights"
     # All uniqueness/indexes for this table are PARTIAL (depend on `superseded_at`).
@@ -108,6 +123,8 @@ class UserAIPreference(Base):
     )
 
 
+# Cache-integrity invariant: shared cache, MUST NOT carry tenant columns.
+# See the comment above BookInsight for the full rule.
 class ExternalSourceCacheEntry(Base):
     __tablename__ = "external_source_cache"
 
@@ -127,4 +144,47 @@ class AIUsageDaily(Base):
     count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"), default=0)
     regen_count: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("0"), default=0
+    )
+
+
+class AIGenerationLog(Base):
+    """Per-call audit row anchored to `book_insights.id`.
+
+    One row per `get()`-hit / `generate()` / `regenerate()` call, regardless of
+    cache state. Future billing rollups query `(tenant_id, created_at)`; the
+    audit UI queries `(book_insight_id)`.
+
+    `status` is permissive ('hit' | 'miss' | 'error') so a future PR can
+    introduce error rows without a schema bump. PR-C only emits 'hit' and
+    'miss'; errors go to structured logs because they have no FK target.
+    """
+
+    __tablename__ = "ai_generation_log"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('hit', 'miss', 'error')",
+            name="ck_ai_generation_log_status",
+        ),
+        Index("ix_ai_generation_log_tenant_created", "tenant_id", "created_at"),
+        Index("ix_ai_generation_log_book_insight", "book_insight_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    book_insight_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("book_insights.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("'local'"), default="local"
+    )
+    subject: Mapped[str] = mapped_column(String, nullable=False)
+    request_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    model_id: Mapped[str] = mapped_column(String, nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String, nullable=False)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    error_class: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/server/opds_sync/main.py
+++ b/server/opds_sync/main.py
@@ -30,8 +30,15 @@ from opds_sync.db.session import configure, make_engine
 def create_app() -> FastAPI:
     settings = get_settings()
     logging.basicConfig(level=settings.log_level)
-    # Inject request_id into every log record produced after this point.
-    logging.getLogger().addFilter(RequestIdLogFilter())
+    # Inject request_id into every log record routed through the root
+    # handlers. Logger-level filters on the root logger do NOT apply to
+    # records propagated up from child loggers, so we attach the filter to
+    # the handlers themselves. Idempotent if create_app() runs more than
+    # once (e.g., in tests).
+    _filter = RequestIdLogFilter()
+    for _h in logging.getLogger().handlers:
+        if not any(isinstance(f, RequestIdLogFilter) for f in _h.filters):
+            _h.addFilter(_filter)
 
     configure(make_engine(settings.database_url))
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -3,7 +3,6 @@ from collections.abc import AsyncIterator, Iterator
 
 import httpx
 import pytest
-from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -63,9 +62,15 @@ def postgres_url() -> Iterator[str]:
 
 @pytest.fixture(scope="session")
 def alembic_upgrade(postgres_url: str) -> None:
+    # Use the production mode-aware wrapper instead of `alembic upgrade head`.
+    # `head` is ambiguous once multiple branches exist; the wrapper handles
+    # backbone + per-branch upgrades correctly. We pass both flags true so
+    # the test schema reaches `ai@head` and (eventually) `progress@head`.
     cfg = AlembicConfig("alembic.ini")
     cfg.set_main_option("sqlalchemy.url", postgres_url)
-    command.upgrade(cfg, "head")
+    from scripts.migrate import run_migrations
+
+    run_migrations(cfg, progress_enabled=True, ai_enabled=True)
 
 
 @pytest.fixture

--- a/server/tests/integration/test_ai_audit_log.py
+++ b/server/tests/integration/test_ai_audit_log.py
@@ -142,10 +142,10 @@ async def test_two_tenants_share_one_insight_two_log_rows(session_factory):
             .all()
         )
         assert len(logs) == 2
-        assert {l.tenant_id for l in logs} == {"tenant-a", "tenant-b"}
-        assert [l.status for l in logs] == ["miss", "hit"]
-        assert {l.book_insight_id for l in logs} == {insight.id}
-        assert {l.subject for l in logs} == {"alice@tenant-a", "bob@tenant-b"}
+        assert {log.tenant_id for log in logs} == {"tenant-a", "tenant-b"}
+        assert [log.status for log in logs] == ["miss", "hit"]
+        assert {log.book_insight_id for log in logs} == {insight.id}
+        assert {log.subject for log in logs} == {"alice@tenant-a", "bob@tenant-b"}
 
 
 @pytest.mark.requires_ai
@@ -175,9 +175,7 @@ async def test_concurrent_waiters_coalesce_across_sessions(session_factory):
 
     async def _one_waiter(user_id: str, tenant_id: str):
         async with session_factory() as s:
-            return await orch.generate(
-                s, ident, bundle, user_id=user_id, tenant_id=tenant_id
-            )
+            return await orch.generate(s, ident, bundle, user_id=user_id, tenant_id=tenant_id)
 
     # Launch three waiters concurrently. They will all queue on the lock;
     # the lock-holder will block on slow_client.release.
@@ -190,7 +188,7 @@ async def test_concurrent_waiters_coalesce_across_sessions(session_factory):
     # Wait until exactly one model call is in flight (the lock-holder reached
     # chat_structured). Bounded loop avoids `sleep(0.05)` flakiness.
     deadline = asyncio.get_event_loop().time() + 5.0
-    while len(slow_client.calls) == 0 and asyncio.get_event_loop().time() < deadline:
+    while len(slow_client.calls) == 0 and asyncio.get_event_loop().time() < deadline:  # noqa: ASYNC110 — poll a counter, not a single Event
         await asyncio.sleep(0.005)
     # Give other tasks one more scheduling slice so any racing waiter would
     # have had time to also enter chat_structured. Then assert exactly one.
@@ -225,8 +223,8 @@ async def test_concurrent_waiters_coalesce_across_sessions(session_factory):
             .all()
         )
         assert len(logs) == 3
-        statuses = sorted(l.status for l in logs)
+        statuses = sorted(log.status for log in logs)
         assert statuses == ["hit", "hit", "miss"]
-        assert {l.book_insight_id for l in logs} == {insights[0].id}
-        assert sorted(l.subject for l in logs) == ["u1", "u2", "u3"]
-        assert sorted(l.tenant_id for l in logs) == ["t1", "t2", "t3"]
+        assert {log.book_insight_id for log in logs} == {insights[0].id}
+        assert sorted(log.subject for log in logs) == ["u1", "u2", "u3"]
+        assert sorted(log.tenant_id for log in logs) == ["t1", "t2", "t3"]

--- a/server/tests/integration/test_ai_audit_log.py
+++ b/server/tests/integration/test_ai_audit_log.py
@@ -1,0 +1,232 @@
+"""Multi-tenant convergence + concurrent-coalesce: integration tests using
+SEPARATE AsyncSession instances per waiter.
+
+Two tests:
+1. Sequential two-tenant convergence — cross-session FK visibility (tenant B's
+   session must see the committed book_insights row from tenant A's session).
+2. Concurrent N-waiter coalesce — N waiters with separate sessions race for
+   the per-identity lock; only one model call fires; N log rows are produced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from opds_sync.api.ai_schemas import DocumentIdentity, MetadataBundle
+from opds_sync.core.ai.service import InsightOrchestrator
+from opds_sync.db.models import AIGenerationLog, BookInsight
+
+
+class _FakeAIClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.next_payload = {
+            "schema_version": 2,
+            "intro": "Two-tenant convergence.",
+            "confidence": "high",
+        }
+
+    async def chat_structured(self, *, system, user, schema, timeout_s):
+        self.calls.append({"system": system, "user": user})
+        return schema.model_validate(self.next_payload)
+
+
+class _SlowAIClient:
+    """Fake AI client that blocks until released, then returns once.
+
+    Lets us prove that concurrent generate() calls actually serialize through
+    the per-identity lock (rather than racing to multiple model calls).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.release = asyncio.Event()
+        self.next_payload = {
+            "schema_version": 2,
+            "intro": "Coalesced.",
+            "confidence": "high",
+        }
+
+    async def chat_structured(self, *, system, user, schema, timeout_s):
+        self.calls.append({"system": system, "user": user})
+        await self.release.wait()
+        return schema.model_validate(self.next_payload)
+
+
+class _FakeRetriever:
+    async def lookup_wikipedia(self, **kw):
+        return []
+
+    async def lookup_openlibrary(self, **kw):
+        return []
+
+
+@pytest.fixture
+async def session_factory(engine) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    yield async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+async def _wipe(session_factory) -> None:
+    async with session_factory() as cleanup:
+        await cleanup.execute(
+            text(
+                "TRUNCATE TABLE ai_generation_log, external_source_cache, "
+                "book_insights, ai_usage_daily CASCADE"
+            )
+        )
+        await cleanup.commit()
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_two_tenants_share_one_insight_two_log_rows(session_factory):
+    """Tenant A misses + generates; Tenant B hits the same row. Two log entries."""
+    await _wipe(session_factory)
+
+    orch = InsightOrchestrator(
+        ai=_FakeAIClient(),
+        retriever_factory=lambda s: _FakeRetriever(),
+        sources_enabled=(),
+        model_id="multi-tenant-model",
+        prompt_version="mt1",
+        max_concurrency=2,
+        ai_timeout_s=5.0,
+    )
+
+    ident = DocumentIdentity(metadata_id="tenant-shared", content_hash="ch-multi")
+    bundle = MetadataBundle(title="Shared")
+
+    # Tenant A: cold miss (own session)
+    async with session_factory() as s_a:
+        out_a = await orch.generate(
+            s_a, ident, bundle, user_id="alice@tenant-a", tenant_id="tenant-a"
+        )
+
+    # Tenant B: hits A's cache row (own session)
+    async with session_factory() as s_b:
+        out_b = await orch.generate(
+            s_b, ident, bundle, user_id="bob@tenant-b", tenant_id="tenant-b"
+        )
+
+    # Cross-tenant cache hit confirmed
+    assert out_a.payload.intro == out_b.payload.intro
+    assert len(orch.ai.calls) == 1  # one model call total
+    # (generated_by is grandfathered: don't assert on it — keeps the "no read
+    # sites" grep clean.)
+
+    # Inspect the persisted state from a third session
+    async with session_factory() as s_check:
+        insights = (
+            (
+                await s_check.execute(
+                    select(BookInsight).where(BookInsight.content_hash == "ch-multi")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(insights) == 1
+        insight = insights[0]
+        # generated_by intentionally NOT asserted: PR-C stops READING the
+        # column; an assertion here would re-introduce a read site that the
+        # cache-key audit grep is meant to catch.
+
+        logs = (
+            (await s_check.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+            .scalars()
+            .all()
+        )
+        assert len(logs) == 2
+        assert {l.tenant_id for l in logs} == {"tenant-a", "tenant-b"}
+        assert [l.status for l in logs] == ["miss", "hit"]
+        assert {l.book_insight_id for l in logs} == {insight.id}
+        assert {l.subject for l in logs} == {"alice@tenant-a", "bob@tenant-b"}
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_concurrent_waiters_coalesce_across_sessions(session_factory):
+    """N concurrent waiters with separate sessions → 1 miss + (N-1) hits.
+
+    The slow fake AI client blocks on an asyncio.Event so all waiters reach
+    the lock at the same time. We poll until exactly one model call is
+    in-flight (proving lock contention rather than racing), then release.
+    """
+    await _wipe(session_factory)
+
+    slow_client = _SlowAIClient()
+    orch = InsightOrchestrator(
+        ai=slow_client,
+        retriever_factory=lambda s: _FakeRetriever(),
+        sources_enabled=(),
+        model_id="coalesce-model",
+        prompt_version="c1",
+        max_concurrency=4,
+        ai_timeout_s=5.0,
+    )
+
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-conc-coalesce")
+    bundle = MetadataBundle(title="Conc")
+
+    async def _one_waiter(user_id: str, tenant_id: str):
+        async with session_factory() as s:
+            return await orch.generate(
+                s, ident, bundle, user_id=user_id, tenant_id=tenant_id
+            )
+
+    # Launch three waiters concurrently. They will all queue on the lock;
+    # the lock-holder will block on slow_client.release.
+    tasks = [
+        asyncio.create_task(_one_waiter("u1", "t1")),
+        asyncio.create_task(_one_waiter("u2", "t2")),
+        asyncio.create_task(_one_waiter("u3", "t3")),
+    ]
+
+    # Wait until exactly one model call is in flight (the lock-holder reached
+    # chat_structured). Bounded loop avoids `sleep(0.05)` flakiness.
+    deadline = asyncio.get_event_loop().time() + 5.0
+    while len(slow_client.calls) == 0 and asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.005)
+    # Give other tasks one more scheduling slice so any racing waiter would
+    # have had time to also enter chat_structured. Then assert exactly one.
+    await asyncio.sleep(0.02)
+    assert len(slow_client.calls) == 1, (
+        f"expected 1 in-flight model call, got {len(slow_client.calls)}; "
+        "waiters didn't coalesce on the lock"
+    )
+
+    # Release the lock-holder so it can complete; the two waiters then hit.
+    slow_client.release.set()
+    results = await asyncio.gather(*tasks)
+    assert len(results) == 3
+    # Still exactly one model call total.
+    assert len(slow_client.calls) == 1
+
+    async with session_factory() as s_check:
+        insights = (
+            (
+                await s_check.execute(
+                    select(BookInsight).where(BookInsight.content_hash == "ch-conc-coalesce")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(insights) == 1
+
+        logs = (
+            (await s_check.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+            .scalars()
+            .all()
+        )
+        assert len(logs) == 3
+        statuses = sorted(l.status for l in logs)
+        assert statuses == ["hit", "hit", "miss"]
+        assert {l.book_insight_id for l in logs} == {insights[0].id}
+        assert sorted(l.subject for l in logs) == ["u1", "u2", "u3"]
+        assert sorted(l.tenant_id for l in logs) == ["t1", "t2", "t3"]

--- a/server/tests/integration/test_cache_key_audit.py
+++ b/server/tests/integration/test_cache_key_audit.py
@@ -1,0 +1,55 @@
+"""Cache-integrity invariant: shared-cache tables MUST NOT carry tenant columns.
+
+This regression test is *future-proof*: as PR2 (insight_identity_aliases) and
+PR3 (book_themes) land, their model classes must be added to the parametrize
+list. If a future PR accidentally adds `user_id` to a shared cache table,
+this test fails at CI time, by design.
+
+`generated_by` on BookInsight is grandfathered and explicitly allow-listed
+with a comment pointing to the deprecation plan (PR-C stops reading it; a
+follow-up nulls it; a later migration drops it).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import inspect
+
+from opds_sync.db.models import BookInsight, ExternalSourceCacheEntry
+
+FORBIDDEN_COLUMNS = frozenset({"user_id", "tenant_id", "subject", "principal_id"})
+
+# Grandfathered legacy columns per table. PR-C stops READING `generated_by`;
+# a follow-up will null then drop it. Until dropped, it stays in the schema.
+GRANDFATHERED: dict[str, frozenset[str]] = {
+    "book_insights": frozenset({"generated_by"}),
+}
+
+SHARED_CACHE_TABLES = [
+    pytest.param(BookInsight, id="book_insights"),
+    pytest.param(ExternalSourceCacheEntry, id="external_source_cache"),
+    # Future entries (add when the model lands):
+    # pytest.param(BookTheme, id="book_themes"),           # PR3
+    # pytest.param(InsightIdentityAlias, id="insight_identity_aliases"),  # PR2
+]
+
+
+@pytest.mark.requires_ai
+@pytest.mark.parametrize("model_cls", SHARED_CACHE_TABLES)
+async def test_shared_cache_table_has_no_tenant_columns(engine, model_cls) -> None:
+    table_name = model_cls.__tablename__
+
+    def _columns(sync_conn) -> set[str]:
+        insp = inspect(sync_conn)
+        return {c["name"] for c in insp.get_columns(table_name)}
+
+    async with engine.connect() as conn:
+        cols = await conn.run_sync(_columns)
+
+    grandfathered = GRANDFATHERED.get(table_name, frozenset())
+    offending = (cols & FORBIDDEN_COLUMNS) - grandfathered
+    assert not offending, (
+        f"shared-cache table {table_name!r} carries forbidden tenant columns: "
+        f"{sorted(offending)}. Per the cache-integrity invariant, tenant audit "
+        f"belongs in ai_generation_log, not on the shared cache row."
+    )

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,8 +29,9 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # No branch labels exist yet, so the heads_applied set is the backbone tip.
-    assert body["heads_applied"] == ["0004"]
+    # PR-C materialized the `ai` branch (ai_001 is its head); with the
+    # default-true mode flags, ai@head is now what's reported.
+    assert body["heads_applied"] == ["ai_001"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -52,8 +52,8 @@ async def _downgrade_in_thread(cfg, target: str) -> None:
     await asyncio.to_thread(alembic_command.downgrade, cfg, target)
 
 
-async def test_default_state_upgrades_backbone(postgres_url: str):
-    """Fresh DB → wrapper upgrades to backbone tip 0004."""
+async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str):
+    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_001)."""
 
     # Wipe DB to fresh state.
     eng = create_async_engine(postgres_url, future=True)
@@ -66,11 +66,12 @@ async def test_default_state_upgrades_backbone(postgres_url: str):
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"0004"}
+    # PR-C materialized the `ai` branch; ai_enabled=True advances to ai@head.
+    assert versions == {"ai_001"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
-    """Running the wrapper twice in a row → still at 0004, no errors."""
+    """Running the wrapper twice in a row → still at ai@head, no errors."""
 
     cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(cfg, progress_enabled=True, ai_enabled=True)
@@ -79,13 +80,14 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"0004"}
+    assert versions == {"ai_001"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
-    """Copy real migrations to tmp + add a synthetic ai_test_001; verify enabled run picks it up."""
+    """Copy real migrations to tmp + add a synthetic ai_test_002 chained off
+    ai_001; verify enabled run advances to ai_test_002 (the new ai@head)."""
 
-    # First, ensure DB is at 0004 (real migrations).
+    # First, ensure DB is at ai@head (real migrations include ai_001).
     real_cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
 
@@ -93,22 +95,24 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
     versions_dir = synth_dir / "versions"
-    (versions_dir / "ai_test_001.py").write_text(
+    # Chain off ai_001 (the real first ai migration) with branch_labels=None,
+    # because the `ai` label is already claimed by ai_001.
+    (versions_dir / "ai_test_002.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration.
 
-            Revision ID: ai_test_001
-            Revises: 0004
+            Revision ID: ai_test_002
+            Revises: ai_001
             Create Date: 2026-05-16 00:00:00.000000
             """
 
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_001"
-            down_revision = "0004"
-            branch_labels = ("ai",)
+            revision = "ai_test_002"
+            down_revision = "ai_001"
+            branch_labels = None
             depends_on = None
 
 
@@ -127,33 +131,37 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
 
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
-    # After the ai branch migration runs, alembic_version should contain ai_test_001
-    # (which is the head of the ai branch).
-    assert "ai_test_001" in versions, versions
+    # ai branch advances to the new tip.
+    assert "ai_test_002" in versions, versions
     await eng.dispose()
 
     # Cleanup: roll back the synthetic migration so other tests aren't affected.
-    await _downgrade_in_thread(cfg, "0004")
+    await _downgrade_in_thread(cfg, "ai_001")
 
 
 async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
-    """With ai_enabled=False, even if the ai label exists, branch is skipped."""
+    """With ai_enabled=False, the wrapper skips advancing the ai branch.
 
+    Pre-condition: DB is rolled back to 0004 (no ai branch applied), then the
+    wrapper is invoked with ai_enabled=False. ai_test_002 (the synthetic head)
+    must NOT be applied; the backbone stays at 0004.
+    """
+    # Stamp DB back to backbone (pre-ai-branch state) for this test.
     real_cfg = _make_cfg(postgres_url)
-    await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
+    await _downgrade_in_thread(real_cfg, "0004")
 
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
-    (synth_dir / "versions" / "ai_test_001.py").write_text(
+    (synth_dir / "versions" / "ai_test_002.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration."""
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_001"
-            down_revision = "0004"
-            branch_labels = ("ai",)
+            revision = "ai_test_002"
+            down_revision = "ai_001"
+            branch_labels = None
             depends_on = None
 
             def upgrade() -> None:
@@ -171,7 +179,11 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch skipped → ai_test_001 NOT applied.
-    assert "ai_test_001" not in versions
+    # ai branch skipped → ai_test_002 NOT applied, and ai_001 NOT applied either.
+    assert "ai_test_002" not in versions
+    assert "ai_001" not in versions
     # Backbone still at 0004.
     assert "0004" in versions
+
+    # Restore DB for subsequent tests.
+    await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -49,19 +49,22 @@ async def restore_after(postgres_url: str, alembic_upgrade):
     await _restore_to_0004(postgres_url)
 
 
-async def test_readyz_200_when_at_backbone_no_labels(monkeypatch, postgres_url, alembic_upgrade):
+async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
+    """With ai_001 materialized and ai mode on, the required head is ai@head."""
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.get("/readyz")
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["0004"]
+    assert body["heads_applied"] == ["ai_001"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
+    """DB stamped below backbone; with both modes enabled, required head is
+    ai_001 (ai@head) — that's what should be reported missing."""
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -69,10 +72,19 @@ async def test_readyz_503_when_db_below_backbone(
     assert r.status_code == 503
     body = r.json()
     assert body["ready"] is False
-    assert "0004" in body["missing"]
+    assert "ai_001" in body["missing"]
 
 
-async def test_readyz_200_with_neither_mode_at_backbone(monkeypatch, postgres_url, alembic_upgrade):
+async def test_readyz_200_with_neither_mode_at_backbone(
+    monkeypatch, postgres_url, alembic_upgrade, restore_after
+):
+    """With neither mode enabled, backbone tip (0004) is the only required head.
+
+    Stamp the DB to 0004 explicitly because the session-scoped fixture brings
+    everything up to ai@head; we want to exercise the "fresh sync-only deploy
+    that never materialized the ai branch" code path.
+    """
+    await _stamp(postgres_url, "0004")
     app = _build_app(monkeypatch, postgres_url, progress=False, ai=False)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.get("/readyz")

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -47,3 +47,40 @@ async def test_ai_generation_log_table_exists(engine) -> None:
     assert fk is not None, "expected FK to book_insights"
     assert fk["constrained_columns"] == ["book_insight_id"]
     assert fk["options"].get("ondelete", "").upper() == "CASCADE"
+
+
+@pytest.mark.requires_ai
+async def test_ai_generation_log_round_trip(session) -> None:
+    """ORM model writes and reads ai_generation_log rows."""
+    from opds_sync.db.models import AIGenerationLog, BookInsight
+
+    insight = BookInsight(
+        metadata_id=None,
+        content_hash="ch-rt-log",
+        model_id="m1",
+        prompt_version="p1",
+        tone="neutral",
+        sources_used=[],
+        payload={"schema_version": 2, "intro": "x", "confidence": "low"},
+        sources=[],
+        generated_by="legacy-write",
+    )
+    session.add(insight)
+    await session.flush()
+
+    log = AIGenerationLog(
+        book_insight_id=insight.id,
+        subject="alice",
+        model_id="m1",
+        prompt_version="p1",
+        status="miss",
+        latency_ms=123,
+    )
+    session.add(log)
+    await session.commit()
+    await session.refresh(log)
+
+    assert log.id is not None
+    assert log.tenant_id == "local"  # server default
+    assert log.created_at is not None
+    assert log.request_id is None

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -1,4 +1,5 @@
-from sqlalchemy import select
+import pytest
+from sqlalchemy import inspect, select
 
 from opds_sync.db.models import Document
 
@@ -10,3 +11,39 @@ async def test_schema_round_trip(session) -> None:
     rows = (await session.execute(select(Document))).scalars().all()
     assert len(rows) == 1
     assert rows[0].metadata_id == "abc123"
+
+
+@pytest.mark.requires_ai
+async def test_ai_generation_log_table_exists(engine) -> None:
+    """ai_001 migration creates the table with the right columns + indexes + FK."""
+
+    def _introspect(sync_conn) -> dict:
+        insp = inspect(sync_conn)
+        cols = {c["name"]: c for c in insp.get_columns("ai_generation_log")}
+        idx_names = {i["name"] for i in insp.get_indexes("ai_generation_log")}
+        fks = insp.get_foreign_keys("ai_generation_log")
+        return {"cols": cols, "idx": idx_names, "fks": fks}
+
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_introspect)
+
+    expected_cols = {
+        "id",
+        "book_insight_id",
+        "tenant_id",
+        "subject",
+        "request_id",
+        "model_id",
+        "prompt_version",
+        "latency_ms",
+        "status",
+        "error_class",
+        "created_at",
+    }
+    assert expected_cols.issubset(info["cols"].keys())
+    assert "ix_ai_generation_log_tenant_created" in info["idx"]
+    assert "ix_ai_generation_log_book_insight" in info["idx"]
+    fk = next((f for f in info["fks"] if f["referred_table"] == "book_insights"), None)
+    assert fk is not None, "expected FK to book_insights"
+    assert fk["constrained_columns"] == ["book_insight_id"]
+    assert fk["options"].get("ondelete", "").upper() == "CASCADE"

--- a/server/tests/unit/conftest.py
+++ b/server/tests/unit/conftest.py
@@ -22,6 +22,11 @@ async def _truncate_external_source_cache(request, engine: AsyncEngine):
     if "session" not in request.fixturenames:
         return
     async with engine.begin() as conn:
+        # CASCADE because ai_generation_log has an FK on book_insights.id;
+        # truncating book_insights without CASCADE raises in PostgreSQL.
         await conn.execute(
-            text("TRUNCATE TABLE external_source_cache, book_insights, ai_usage_daily")
+            text(
+                "TRUNCATE TABLE ai_generation_log, external_source_cache, "
+                "book_insights, ai_usage_daily CASCADE"
+            )
         )

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -284,3 +284,61 @@ async def test_same_tone_shares_cache_across_users(session, make_orchestrator):
     await orch.generate(session, ident, bundle, user_id="u2", style=AiStyle(tone="scholarly"))
 
     assert len(orch.ai.calls) == 1
+
+
+# ---- PR-C: ai_generation_log assertions ------------------------------------
+
+from opds_sync.db.models import AIGenerationLog  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_generate_miss_writes_log_row(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-log-miss")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.status == "miss"
+    assert row.subject == "alice"
+    assert row.tenant_id == "local"  # default when kwarg omitted
+    assert row.model_id == "test-model"
+    assert row.prompt_version == "t1"
+    assert row.latency_ms is not None and row.latency_ms >= 0
+    assert row.error_class is None
+    assert row.book_insight_id is not None
+
+
+@pytest.mark.asyncio
+async def test_second_generate_writes_hit_row_with_same_fk(
+    session: AsyncSession, make_orchestrator
+):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-log-hit")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="bob")
+
+    rows = (
+        (await session.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert [r.status for r in rows] == ["miss", "hit"]
+    assert [r.subject for r in rows] == ["alice", "bob"]
+    assert rows[0].book_insight_id == rows[1].book_insight_id
+    assert rows[1].latency_ms == 0  # cache lookup cost
+
+
+@pytest.mark.asyncio
+async def test_log_uses_passed_tenant_id(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-tenant-kwarg")
+    await orch.generate(
+        session, ident, MetadataBundle(title="X"), user_id="alice", tenant_id="acme"
+    )
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].tenant_id == "acme"

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -434,3 +434,79 @@ async def test_log_default_tenant_id_is_local(session: AsyncSession, make_orches
     rows = (await session.execute(select(AIGenerationLog))).scalars().all()
     assert len(rows) == 1
     assert rows[0].tenant_id == "local"
+
+
+class _ExplodingAIClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def chat_structured(self, *, system, user, schema, timeout_s):
+        self.calls.append({"system": system, "user": user})
+        raise RuntimeError("simulated provider failure")
+
+
+@pytest.mark.asyncio
+async def test_generate_error_emits_structured_log(session: AsyncSession, caplog):
+    """Errors emit a structured `event=ai.generate.error` warning carrying
+    tenant_id, subject, model, prompt_version, error_class. The request_id
+    ContextVar is read by the log filter (attached to caplog's handler to
+    mirror the production handler-level attachment) and surfaces as
+    record.request_id. No ai_generation_log row is written.
+    """
+    import logging
+
+    from opds_sync.core.ai.service import InsightOrchestrator
+    from opds_sync.core.logging_ctx import RequestIdLogFilter, request_id_var
+
+    # Set level on BOTH the root and the specific service logger; pytest-asyncio
+    # plus testcontainers fixtures can leave child-logger levels in unexpected
+    # states across tests, so be explicit.
+    caplog.set_level(logging.WARNING, logger="opds_sync.core.ai.service")
+    caplog.set_level(logging.WARNING)
+    filt = RequestIdLogFilter()
+    caplog.handler.addFilter(filt)
+
+    token = request_id_var.set("req-err-xyz")
+    try:
+        orch = InsightOrchestrator(
+            ai=_ExplodingAIClient(),
+            retriever_factory=lambda s: FakeRetriever(),
+            sources_enabled=(),
+            model_id="boom-model",
+            prompt_version="t1",
+            max_concurrency=1,
+            ai_timeout_s=5.0,
+        )
+        ident = DocumentIdentity(metadata_id=None, content_hash="ch-error")
+
+        with pytest.raises(RuntimeError, match="simulated provider failure"):
+            await orch.generate(
+                session,
+                ident,
+                MetadataBundle(title="X"),
+                user_id="alice",
+                tenant_id="acme",
+            )
+    finally:
+        request_id_var.reset(token)
+        caplog.handler.removeFilter(filt)
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert rows == []  # no DB row for errors
+
+    error_records = [
+        r for r in caplog.records if "event=ai.generate.error" in r.getMessage()
+    ]
+    assert len(error_records) == 1, (
+        f"expected exactly one ai.generate.error log record, got {len(error_records)} "
+        f"out of {[r.getMessage() for r in caplog.records]}"
+    )
+    rec = error_records[0]
+    msg = rec.getMessage()
+    assert "tenant_id=acme" in msg
+    assert "subject=alice" in msg
+    assert "model=boom-model" in msg
+    assert "prompt_version=t1" in msg
+    assert "error_class=RuntimeError" in msg
+    # request_id surfaces on the record because the filter is on caplog.handler.
+    assert getattr(rec, "request_id", "") == "req-err-xyz"

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -407,9 +407,7 @@ async def test_concurrent_generations_emit_one_miss_and_n_minus_one_hits(
 
 
 @pytest.mark.asyncio
-async def test_log_carries_request_id_when_set(
-    session: AsyncSession, make_orchestrator
-):
+async def test_log_carries_request_id_when_set(session: AsyncSession, make_orchestrator):
     from opds_sync.core.logging_ctx import request_id_var
 
     token = request_id_var.set("test-req-abc123")
@@ -494,9 +492,7 @@ async def test_generate_error_emits_structured_log(session: AsyncSession, caplog
     rows = (await session.execute(select(AIGenerationLog))).scalars().all()
     assert rows == []  # no DB row for errors
 
-    error_records = [
-        r for r in caplog.records if "event=ai.generate.error" in r.getMessage()
-    ]
+    error_records = [r for r in caplog.records if "event=ai.generate.error" in r.getMessage()]
     assert len(error_records) == 1, (
         f"expected exactly one ai.generate.error log record, got {len(error_records)} "
         f"out of {[r.getMessage() for r in caplog.records]}"

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -342,3 +342,34 @@ async def test_log_uses_passed_tenant_id(session: AsyncSession, make_orchestrato
     rows = (await session.execute(select(AIGenerationLog))).scalars().all()
     assert len(rows) == 1
     assert rows[0].tenant_id == "acme"
+
+
+@pytest.mark.asyncio
+async def test_get_hit_writes_log_row(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-get-hit")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+    # baseline: one miss row from the generate
+    assert len((await session.execute(select(AIGenerationLog))).scalars().all()) == 1
+
+    out = await orch.get(session, ident, user_id="alice")
+    assert out is not None
+
+    rows = (
+        (await session.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert rows[1].status == "hit"
+    assert rows[1].latency_ms == 0
+
+
+@pytest.mark.asyncio
+async def test_get_miss_writes_no_log_row(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-get-miss")
+    assert await orch.get(session, ident) is None
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert rows == []

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -373,3 +373,64 @@ async def test_get_miss_writes_no_log_row(session: AsyncSession, make_orchestrat
 
     rows = (await session.execute(select(AIGenerationLog))).scalars().all()
     assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_generations_emit_one_miss_and_n_minus_one_hits(
+    session: AsyncSession, make_orchestrator
+):
+    """Coalesced waiters: one model call but N log rows, one per waiter."""
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-coalesce-log")
+    bundle = MetadataBundle(title="Coalesce")
+
+    await asyncio.gather(
+        orch.generate(session, ident, bundle, user_id="u1"),
+        orch.generate(session, ident, bundle, user_id="u2"),
+        orch.generate(session, ident, bundle, user_id="u3"),
+    )
+
+    assert len(orch.ai.calls) == 1
+
+    rows = (
+        (await session.execute(select(AIGenerationLog).order_by(AIGenerationLog.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 3
+    statuses = sorted(r.status for r in rows)
+    assert statuses == ["hit", "hit", "miss"]
+    # All three FK the same insight
+    assert len({r.book_insight_id for r in rows}) == 1
+    # Three distinct subjects
+    assert sorted(r.subject for r in rows) == ["u1", "u2", "u3"]
+
+
+@pytest.mark.asyncio
+async def test_log_carries_request_id_when_set(
+    session: AsyncSession, make_orchestrator
+):
+    from opds_sync.core.logging_ctx import request_id_var
+
+    token = request_id_var.set("test-req-abc123")
+    try:
+        orch = make_orchestrator()
+        ident = DocumentIdentity(metadata_id=None, content_hash="ch-req-id")
+        await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+    finally:
+        request_id_var.reset(token)
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].request_id == "test-req-abc123"
+
+
+@pytest.mark.asyncio
+async def test_log_default_tenant_id_is_local(session: AsyncSession, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-tenant-default")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="alice")
+
+    rows = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].tenant_id == "local"

--- a/server/tests/unit/test_logging_ctx.py
+++ b/server/tests/unit/test_logging_ctx.py
@@ -47,3 +47,46 @@ def test_filter_uses_empty_string_when_unset():
     f = RequestIdLogFilter()
     assert f.filter(rec) is True
     assert rec.request_id == ""
+
+
+def test_filter_attached_to_root_handler_applies_to_child_logger_records():
+    """Records emitted by a CHILD logger must end up with request_id when the
+    filter is attached to the root logger's handler (not the root logger).
+
+    Build a fresh BufferingHandler attached to the root logger — this mirrors
+    main.py's production setup (RequestIdLogFilter on root handlers) exactly
+    and avoids caplog's installation/teardown idiosyncrasies that can race
+    with session-scoped fixtures.
+    """
+    from logging.handlers import BufferingHandler
+
+    handler = BufferingHandler(capacity=100)
+    handler.setLevel(logging.WARNING)
+    filt = RequestIdLogFilter()
+    handler.addFilter(filt)
+
+    root = logging.getLogger()
+    root.addHandler(handler)
+    prev_level = root.level
+    if root.level == 0 or root.level > logging.WARNING:
+        root.setLevel(logging.WARNING)
+
+    child = logging.getLogger("opds_sync.core.ai.service.test_propagation")
+    prev_propagate = child.propagate
+    child.propagate = True
+
+    token = request_id_var.set("rid-propagation-test")
+    try:
+        child.warning("hello-from-child-rid-test")
+    finally:
+        request_id_var.reset(token)
+        root.removeHandler(handler)
+        root.setLevel(prev_level)
+        child.propagate = prev_propagate
+
+    matches = [r for r in handler.buffer if r.getMessage() == "hello-from-child-rid-test"]
+    assert matches, (
+        f"expected the child-logger record to reach the root handler; got "
+        f"{[r.getMessage() for r in handler.buffer]}"
+    )
+    assert getattr(matches[0], "request_id", "") == "rid-propagation-test"


### PR DESCRIPTION
## Summary

PR-C of the 2026-05-16 roadmap batch, stacked on PR-A (alembic mode split). Server-only.

- Adds `ai_generation_log` as the first migration on the `ai` branch (`ai_001`, `down_revision = "0004"`, `branch_labels = ("ai",)`).
- `InsightOrchestrator` writes one row per `get()`-hit / `generate()` / `regenerate()` call: `status` is `hit` or `miss`, FK'd to `book_insights.id`, carrying `tenant_id` (per-call kwarg, default `"local"`), `subject` (the existing `user_id`), `request_id` (from PR-A's `request_id_var` ContextVar), `model_id`, `prompt_version`, `latency_ms`.
- Errors emit a structured `logger.warning("event=ai.generate.error tenant_id=... subject=... model=... prompt_version=... latency_ms=... error_class=...")` line and raise. No DB row (no FK target). Tested via `caplog`.
- Stops reading `book_insights.generated_by` for any decision (audit confirmed: no read sites today). The column stays as legacy-write-only; a follow-up will null then drop it.

## Cache-integrity invariant (codified)

> The shared-cache tables — `book_insights`, `external_source_cache`, and (in future PRs) `book_themes`, `insight_identity_aliases` whose `user_id` is NULL — MUST NOT carry any user-identifying column (`user_id`, `tenant_id`, `subject`, `principal_id`) read for any cache decision.

A parametrized regression test (`tests/integration/test_cache_key_audit.py`) introspects each shared-cache table via SQLAlchemy reflection and asserts the absence of tenant columns. **Future PRs that add a shared-cache table MUST add it to the parametrize list** — PR2 (`insight_identity_aliases`), PR3 (`book_themes`). The test docstring restates this so the next PR author can't miss it.

The invariant is also documented as a code comment above `BookInsight` and `ExternalSourceCacheEntry` in `db/models.py`.

## Coalesced-waiter logging semantics

When N concurrent `generate()` callers serialize on the per-identity lock: one model call, N log rows (1 `miss` + N-1 `hit`), each carrying its own `(tenant_id, subject, request_id)`. Asserted both at unit-level (`test_concurrent_generations_emit_one_miss_and_n_minus_one_hits`) and via a production-faithful integration test using SEPARATE `AsyncSession` instances + a slow blocking AI client (`tests/integration/test_ai_audit_log.py::test_concurrent_waiters_coalesce_across_sessions`). This is what makes downstream per-tenant billing possible.

## Per-call tenant_id (PR-B seam)

`tenant_id` is a per-call kwarg on `get/generate/regenerate`, defaulting to `"local"`. The API layer (`opds_sync/api/ai.py`) hardcodes `tenant_id="local"` today; PR-B will swap that for `principal.tenant_id` once the `AiPrincipal` plumbing exists. Constructor-level state was rejected because the orchestrator is an app-state singleton — a process-wide default can't carry per-waiter tenant info.

## Error rows

The `status` check constraint allows `'hit' | 'miss' | 'error'`, but PR-C only emits hit/miss. Errors have no `book_insights` FK target (the row is committed AFTER `chat_structured` returns); a future PR may add nullable-FK or sentinel rows. The permissive constraint avoids a schema bump when that PR lands. Until then, error observability lives in the structured log channel — tested in `test_generate_error_emits_structured_log`.

## PR-A test fallout (fixed in this PR)

Materializing `ai_001` changed which alembic head the test fixture lands on. Three things needed updating:

- `tests/conftest.py::alembic_upgrade` now calls `scripts.migrate.run_migrations(cfg, progress_enabled=True, ai_enabled=True)` instead of `command.upgrade(cfg, "head")`. The wrapper handles multi-head correctly and matches production.
- `test_readyz_200_when_at_backbone_no_labels` -> renamed `test_readyz_200_when_at_ai_head`; expects `["ai_001"]`. Several `test_modes.py` and `test_health.py` assertions also updated. `test_migrate_script.py`'s synthetic migrations rebased onto `ai_001` (the real first migration on the `ai` label).
- `opds_sync/api/health.py::_required_heads` made descendant-aware: with "neither mode" enabled and the DB at `ai_001`, the backbone (`0004`) is now correctly considered satisfied because `ai_001` descends from `0004`. Previously this failed readiness with a confused "backbone missing" error even though the DB was past it.

## Additional latent-bug fix: alembic `env.py` was disabling app loggers

`migrations/env.py`'s `fileConfig(config.config_file_name)` call uses Python's default `disable_existing_loggers=True`. The `scripts/migrate.py` wrapper runs env.py during container start, so every `opds_sync.*` logger arrived at request-handling time already disabled — silencing structured logs (including the new `event=ai.generate.error` warning). Fixed by passing `disable_existing_loggers=False`. Discovered via the error-log test; documented in env.py.

## What's NOT in this PR

- `generated_by` nulling/drop — separate follow-up PRs (intentional phasing).
- PR-B's real `AiPrincipal.tenant_id` plumbing — API layer hardcodes `"local"` for now.
- Error-row DB emission — out of scope per the trade-off above.

## Downgrade story

\`\`\`bash
alembic downgrade ai@-1
\`\`\`

Drops `ai_generation_log`. CASCADE FK means deleting a cache row already deletes its log children. PR-A's wrapper handles per-branch downgrades manually as designed.

## Test plan

- [x] `tests/integration/test_schema.py` — new `test_ai_generation_log_table_exists`, `test_ai_generation_log_round_trip`.
- [x] `tests/integration/test_cache_key_audit.py` — parametrized regression test.
- [x] `tests/integration/test_ai_audit_log.py` — two-tenant convergence + concurrent waiters, both with separate sessions.
- [x] `tests/unit/test_ai_service.py` — 9 new tests (miss, hit, get-hit, get-miss-no-log, coalesce, request_id, tenant default, tenant override, error log).
- [x] `tests/unit/test_logging_ctx.py` — new test verifying child-logger records carry `record.request_id` when filter is attached to root handler.
- [x] `tests/unit/conftest.py` truncate fixture updated to handle the new FK child.
- [x] `tests/integration/test_readyz_migration_state.py` + `test_health.py` + `test_modes.py` + `test_migrate_script.py` assertions updated for `ai_001` head.
- [x] Full-stack mode: 135 passed.
- [x] Sync-only mode: 123 passed, 12 skipped (`requires_ai`).
- [x] AI-only mode: 128 passed, 7 skipped (`requires_progress`).

## Review summary

GPT architect review: APPROVE WITH NITS after four rounds. Round 1 verdict was REJECT, surfacing five real blockers (per-call tenant kwarg vs singleton state, fixture mode-awareness, FK-CASCADE in TRUNCATE, error-row semantics inconsistency, concurrent-waiter test fidelity). Round 2 surfaced a sixth (`RequestIdLogFilter` attached to root logger doesn't propagate to records from child loggers — a latent PR-A bug). Round 4 confirmed all six addressed; final nits (test-shared helper, docstring update, checklist task-number drift) addressed inline.

## For downstream PR agents

- **PR4 (language column)**: your migration is `ai_002_insight_language` with `down_revision = "ai_001"` and `branch_labels = None`. The cache-key audit test does not need changes (`language` is a cache-key dimension, not a tenant column).
- **PR2 (identity aliases)**: your migration chains off the then-current `ai@head`. Add `InsightIdentityAlias` to `SHARED_CACHE_TABLES` in `tests/integration/test_cache_key_audit.py`. The user-scoped alias variant may need per-row policy rather than a column-level allow-list — design at PR2 review time.
- **PR3 (themes)**: your migration chains off the then-current `ai@head`. Add `BookTheme` to `SHARED_CACHE_TABLES` — `book_themes` is fully shared, no `user_id` allowed.
- **PR-B (auth abstraction)**: replace the hardcoded `tenant_id="local"` in `opds_sync/api/ai.py` with `principal.tenant_id` from the `AiPrincipal` dependency. Per-call kwarg is already there; only the API-layer line changes.