### PR TITLE
feat: AI insight language preference

### DIFF
--- a/app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
+++ b/app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
@@ -38,7 +38,17 @@ class AiRepository(
     }
 
     suspend fun setStyleTone(tone: String) {
-        val out = client.setPreferences(style = AiStyle(tone = tone))
+        // Preserve `language` (and any other future style knobs) when only
+        // tone is being changed. Falls back to defaults if no prefs are
+        // loaded yet.
+        val current = _prefs.value?.style ?: AiStyle()
+        val out = client.setPreferences(style = current.copy(tone = tone))
+        _prefs.value = out
+    }
+
+    suspend fun setStyleLanguage(language: String) {
+        val current = _prefs.value?.style ?: AiStyle()
+        val out = client.setPreferences(style = current.copy(language = language))
         _prefs.value = out
     }
 

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
@@ -38,6 +38,23 @@ import io.theficos.ereader.reader.ReaderTheme
 import io.theficos.ereader.ui.components.QuireCard
 import io.theficos.ereader.ui.components.SectionLabel
 
+/**
+ * Curated languages shown in the AI insight language dropdown. The server
+ * accepts any ISO 639-1 code; this list is the UI surface. Labels are the
+ * native names of each language so users in the target locale recognize
+ * them even before the app itself is localized.
+ */
+private val LANGUAGE_OPTIONS: List<Pair<String, String>> = listOf(
+    "auto" to "Auto",
+    "en" to "English",
+    "it" to "Italiano",
+    "es" to "Español",
+    "fr" to "Français",
+    "de" to "Deutsch",
+    "pt" to "Português",
+    "nl" to "Nederlands",
+)
+
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel,
@@ -310,6 +327,38 @@ fun SettingsScreen(
                                         onClick = {
                                             viewModel.setStyleTone(option)
                                             menuOpen = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+
+                        val language = aiState.preferences?.style?.language ?: "auto"
+                        var langMenuOpen by remember { mutableStateOf(false) }
+                        Column {
+                            Text("Insight language", style = MaterialTheme.typography.titleMedium)
+                            Text(
+                                "Language the model writes insights in. " +
+                                    "Auto follows the model's default.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            TextButton(onClick = { langMenuOpen = true }) {
+                                Text(
+                                    LANGUAGE_OPTIONS.firstOrNull { it.first == language }?.second
+                                        ?: language,
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = langMenuOpen,
+                                onDismissRequest = { langMenuOpen = false },
+                            ) {
+                                LANGUAGE_OPTIONS.forEach { (code, label) ->
+                                    DropdownMenuItem(
+                                        text = { Text(label) },
+                                        onClick = {
+                                            viewModel.setStyleLanguage(code)
+                                            langMenuOpen = false
                                         },
                                     )
                                 }

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
@@ -128,6 +128,12 @@ class SettingsViewModel(
             runCatching { aiRepository.setStyleTone(tone) }
         }
     }
+
+    fun setStyleLanguage(language: String) {
+        viewModelScope.launch {
+            runCatching { aiRepository.setStyleLanguage(language) }
+        }
+    }
 }
 
 data class CalibreUiState(

--- a/app/src/test/java/io/theficos/ereader/data/ai/AiRepositoryStyleTest.kt
+++ b/app/src/test/java/io/theficos/ereader/data/ai/AiRepositoryStyleTest.kt
@@ -1,0 +1,91 @@
+package io.theficos.ereader.data.ai
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Verifies that [AiRepository.setStyleTone] and [AiRepository.setStyleLanguage]
+ * preserve their sibling style fields. Regression test for PR4: PR #9's
+ * setStyleTone overwrote the entire style block, clobbering any future knob
+ * (including the language we just added).
+ */
+class AiRepositoryStyleTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: AiClient
+    private lateinit var repo: AiRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = AiClient(
+            baseUrlProvider = { server.url("").toString().trimEnd('/') },
+            http = OkHttpClient.Builder()
+                .callTimeout(5, TimeUnit.SECONDS)
+                .build(),
+        )
+        repo = AiRepository(client)
+    }
+
+    @After
+    fun tearDown() = server.shutdown()
+
+    @Test
+    fun `setStyleTone preserves language from current prefs`() = runTest {
+        // Refresh: server returns prefs with language=it.
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"configured":true,"sources_enabled":[],"daily_budget":0,"regen_daily_limit":0}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"ai_enabled":true,"style":{"tone":"neutral","language":"it"}}"""))
+        repo.refresh()
+
+        // PUT response (we don't care about its content; we care about the request body).
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"ai_enabled":true,"style":{"tone":"scholarly","language":"it"}}"""))
+        repo.setStyleTone("scholarly")
+
+        // Drain config + prefs GETs.
+        server.takeRequest()
+        server.takeRequest()
+        // The PUT body must include the preserved language.
+        val put = server.takeRequest()
+        assertThat(put.method).isEqualTo("PUT")
+        val body = put.body.readUtf8()
+        assertThat(body).contains("\"tone\":\"scholarly\"")
+        assertThat(body).contains("\"language\":\"it\"")
+    }
+
+    @Test
+    fun `setStyleLanguage preserves tone from current prefs`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"configured":true,"sources_enabled":[],"daily_budget":0,"regen_daily_limit":0}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"ai_enabled":true,"style":{"tone":"scholarly","language":"auto"}}"""))
+        repo.refresh()
+
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"ai_enabled":true,"style":{"tone":"scholarly","language":"es"}}"""))
+        repo.setStyleLanguage("es")
+
+        server.takeRequest()
+        server.takeRequest()
+        val put = server.takeRequest()
+        val body = put.body.readUtf8()
+        assertThat(body).contains("\"tone\":\"scholarly\"")
+        assertThat(body).contains("\"language\":\"es\"")
+    }
+
+    @Test
+    fun `setStyleLanguage falls back to defaults when no prefs are loaded`() = runTest {
+        // No refresh; _prefs is null. The repo should fall back to AiStyle().copy(...).
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"ai_enabled":true,"style":{"tone":"neutral","language":"fr"}}"""))
+        repo.setStyleLanguage("fr")
+
+        val put = server.takeRequest()
+        val body = put.body.readUtf8()
+        assertThat(body).contains("\"tone\":\"neutral\"")
+        assertThat(body).contains("\"language\":\"fr\"")
+    }
+}

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt
@@ -18,6 +18,7 @@ data class AiConfig(
 @Serializable
 data class AiStyle(
     val tone: String = "neutral",
+    val language: String = "auto",
 )
 
 @Serializable

--- a/data/ai/src/test/java/io/theficos/ereader/data/ai/AiClientTest.kt
+++ b/data/ai/src/test/java/io/theficos/ereader/data/ai/AiClientTest.kt
@@ -53,12 +53,39 @@ class AiClientTest {
     fun `getPreferences parses style`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
-                """{"ai_enabled":true,"style":{"tone":"scholarly"}}"""
+                """{"ai_enabled":true,"style":{"tone":"scholarly","language":"it"}}"""
             )
         )
         val prefs = client.getPreferences()
         assertThat(prefs.aiEnabled).isTrue()
         assertThat(prefs.style.tone).isEqualTo("scholarly")
+        assertThat(prefs.style.language).isEqualTo("it")
+    }
+
+    @Test
+    fun `getPreferences defaults language to auto when server omits it`() = runTest {
+        // Forward-compat: legacy/older server responses without `language` must
+        // still deserialize, with the kotlinx default ("auto") filling in.
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"ai_enabled":true,"style":{"tone":"neutral"}}"""
+            )
+        )
+        val prefs = client.getPreferences()
+        assertThat(prefs.style.language).isEqualTo("auto")
+    }
+
+    @Test
+    fun `setPreferences with language sends it in body`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"ai_enabled":true,"style":{"tone":"neutral","language":"es"}}"""
+            )
+        )
+        client.setPreferences(style = AiStyle(language = "es"))
+        val req = server.takeRequest()
+        val body = req.body.readUtf8()
+        assertThat(body).contains("\"language\":\"es\"")
     }
 
     @Test

--- a/docs/superpowers/plans/2026-05-16-ai-language-preference.md
+++ b/docs/superpowers/plans/2026-05-16-ai-language-preference.md
@@ -1,0 +1,147 @@
+# Plan — AI insight language preference (PR4)
+
+**Date:** 2026-05-16
+**Spec:** `docs/superpowers/specs/2026-05-16-ai-language-preference-design.md`
+**Branch:** `feat/ai-language-preference` (stacked on `feat/ai-generation-log`)
+**Status:** Ready to execute
+
+## Sequencing rationale
+
+Server-side first, in dependency order: schema → model → Pydantic → prompt → orchestrator → tests. Android-side parallelizable once server contract is stable (the kotlinx DTO only needs to mirror the Pydantic schema). Each step is TDD: write the failing test, run it red, implement, run it green.
+
+## Step 1 — Server schema substrate
+
+- [ ] **Test (red):** Add `test_language_column_exists_on_book_insights` to `server/tests/integration/test_schema.py`. Inspect `book_insights` and assert `language` column present, NOT NULL, server_default `'auto'`.
+- [ ] **Test (red):** Add `test_book_insights_unique_indexes_include_language` to `server/tests/integration/test_schema.py`. Inspect indexes and assert both `uq_book_insights_*_tone_language` indexes exist with `language` in the column list.
+- [ ] **Test (red):** Update `test_ai_generation_log_round_trip` if needed (it constructs a BookInsight; add `language="auto"` if Pydantic requires it — actually the ORM model has a `default="auto"` so no change needed).
+- [ ] **Impl:** Write `server/migrations/versions/ai_002_insight_language.py`:
+  - `revision = "ai_002"`, `down_revision = "ai_001"`, `branch_labels = None`.
+  - `upgrade()`: add column with server_default, drop old indexes, create new indexes.
+  - `downgrade()`: inverse.
+- [ ] **Impl:** Update `opds_sync/db/models.BookInsight` to add `language` column adjacent to `tone`.
+- [ ] **Run:** `cd server && uv run pytest -v tests/integration/test_schema.py` — green.
+- [ ] **Run:** `cd server && uv run pytest -v tests/integration/test_cache_key_audit.py` — green (regression: `language` is a cache-key column, not tenant).
+
+## Step 2 — Pydantic AiStyle
+
+- [ ] **Test (red):** Update `test_style_only_tone_remains` → `test_style_has_tone_and_language`:
+  - `AiStyle().tone == "neutral"`
+  - `AiStyle().language == "auto"`
+  - `list(AiStyle.model_fields.keys()) == ["tone", "language"]`
+- [ ] **Test (red):** Add `test_style_accepts_iso_639_1_languages` parametrized over `en, it, es, fr, de, pt, nl, zh, ja`.
+- [ ] **Test (red):** Add `test_style_rejects_invalid_language` parametrized over `("invalid", "english", "", "EN", "e", "eng")`.
+- [ ] **Impl:** Update `opds_sync/api/ai_schemas.AiStyle`:
+  - Add `language: str = "auto"`.
+  - Add `_ISO_639_1` frozenset module-level constant (~180 codes).
+  - Add `@field_validator("language")` that allows `"auto"` and rejects anything not in `_ISO_639_1`.
+- [ ] **Run:** `cd server && uv run pytest -v tests/unit/test_ai_schemas.py` — green.
+
+## Step 3 — Prompt composition
+
+- [ ] **Test (red):** Update `test_prompt_version_is_v2` → `test_prompt_version_is_v3`: `assert PROMPT_VERSION == "3"`.
+- [ ] **Test (red):** Add `test_language_clause_emitted_when_non_auto`:
+  ```python
+  text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="it"))
+  assert 'ISO 639-1 code "it"' in text
+  ```
+- [ ] **Test (red):** Add `test_language_clause_omitted_when_auto`:
+  ```python
+  text_no_style = compose_user_prompt(bundle, citations=[])
+  text_auto = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
+  text_explicit_neutral = compose_user_prompt(bundle, citations=[], style=AiStyle())
+  assert text_no_style == text_auto == text_explicit_neutral
+  ```
+- [ ] **Impl:** Update `opds_sync/core/ai/prompts.py`:
+  - `PROMPT_VERSION = "3"`.
+  - In `compose_user_prompt`, after the tone block, emit `'Respond in the language identified by ISO 639-1 code "{language}".'` only when `style is not None and style.language != "auto"`.
+- [ ] **Run:** `cd server && uv run pytest -v tests/unit/test_ai_prompts.py` — green.
+
+## Step 4 — Orchestrator threading
+
+- [ ] **Test (red):** Add `test_different_languages_generate_separate_cache_rows` to `test_ai_service.py` — mirror of `test_different_tones_*`, with `style=AiStyle(language="auto")` vs `AiStyle(language="it")`, assert 2 rows + 2 AI calls.
+- [ ] **Test (red):** Add `test_same_language_shares_cache_across_users` — two users same identity same language → 1 AI call.
+- [ ] **Test (red):** Add `test_tone_and_language_orthogonal` — (tone=neutral, language=auto) vs (tone=neutral, language=it) → 2 separate rows; ensure tone-only test still passes.
+- [ ] **Impl:** `opds_sync/core/ai/service.py`:
+  - Add `_language_of(style: AiStyle | None) -> str` returning `style.language if style else "auto"`.
+  - In `get`, `generate`, `regenerate`: compute `language = _language_of(style)` next to `tone = _tone_of(style)`.
+  - Update `_acquire_identity_lock` signature: add `language: str` param. Key: `f"{ident.metadata_id or ident.content_hash}|{tone}|{language}"`.
+  - Update `_cache_lookup`: add `language: str` param. Both queries gain `BookInsight.language == language`.
+  - In `_do_generate`: write `language=language` onto the new row; add `language: str` param.
+- [ ] **Run:** `cd server && uv run pytest -v tests/unit/test_ai_service.py` — green (existing tone tests still pass).
+
+## Step 4.5 — Update infrastructure tests that hardcode `ai_001` as ai@head
+
+GPT review (architect) flagged this as critical: tests written against PR-C's world hardcode `ai_001` as the leaf of the ai branch. After `ai_002` lands, the leaf shifts and those tests must be updated.
+
+- [ ] **Impl:** `server/tests/integration/test_health.py` — change `assert body["heads_applied"] == ["ai_001"]` → `["ai_002"]`.
+- [ ] **Impl:** `server/tests/integration/test_readyz_migration_state.py` — same: `ai_001` → `ai_002` in `heads_applied` and `missing` assertions.
+- [ ] **Impl:** `server/tests/integration/test_migrate_script.py`:
+  - `assert versions == {"ai_001"}` → `{"ai_002"}` (both occurrences in `test_default_state_*` and `test_idempotent_*`).
+  - Synthetic test revisions chain off `ai_002`: rename `ai_test_002` → `ai_test_003`; `down_revision = "ai_001"` → `"ai_002"`. Update both `test_synthetic_ai_branch_upgrades_when_enabled` and `test_synthetic_ai_branch_skipped_when_disabled`.
+  - In `test_synthetic_ai_branch_skipped_when_disabled`: `_downgrade_in_thread(real_cfg, "0004")` still works (downgrades through `ai_002` then `ai_001`). The "ai branch skipped" assertion now needs to check `ai_002` not applied too: `assert "ai_002" not in versions` and `assert "ai_001" not in versions`.
+- [ ] **Impl:** `server/tests/unit/test_migrate_logic.py` — synthetic stub revision graphs that mention `ai_001` (label-detection only, so no chain through `ai_002` required). Verify no assertion mentions a specific revision id; if they do, only the label-detection paths matter — leave them as-is unless tests fail.
+
+## Step 4.6 — Extra regression tests (GPT nits)
+
+- [ ] **Test:** Add `test_style_rejects_unknown_iso_code` parametrized over `("zz", "xx", "qq")` — codes that pass `^[a-z]{2}$` but aren't ISO 639-1. Proves the validation is allowlist, not regex.
+- [ ] **Test:** Add `test_invalidate_does_not_touch_old_prompt_version_rows` in `test_ai_service.py`. Insert a synthetic `BookInsight` with `prompt_version="2"` (old, neutral, generated_by=…), call `orch.invalidate(ident)` with the v3 orchestrator, assert the old row is preserved.
+
+## Step 5 — Server full sweep
+
+- [ ] **Run:** `cd server && uv run pytest -v` — full green across all three CI modes (full / sync_only / ai_only via env matrix). Sync-only run skips `requires_ai` tests; AI-only run skips `requires_progress` tests; full runs all.
+
+## Step 6 — Android DTO
+
+- [ ] **Test (red):** Update `AiClientTest.kt`:
+  - `getPreferences parses style`: change fixture body to `"""{"ai_enabled":true,"style":{"tone":"scholarly","language":"it"}}"""` and assert `prefs.style.language == "it"`.
+  - Add new test `setPreferences with style includes language`: enqueue, call `setPreferences(style = AiStyle(language = "es"))`, assert request body contains `"language":"es"`.
+  - Add test `getPreferences default language is auto when missing` (legacy server): fixture body without `language` key, assert `prefs.style.language == "auto"`.
+- [ ] **Impl:** Update `data/ai/.../AiDtos.kt`:
+  ```kotlin
+  data class AiStyle(
+      val tone: String = "neutral",
+      val language: String = "auto",
+  )
+  ```
+- [ ] **Run:** `scripts/dgradle :data:ai:testDebugUnitTest` — green.
+
+## Step 7 — AiRepository
+
+- [ ] **Impl:** Update `app/.../AiRepository.kt`:
+  - Fix `setStyleTone` to preserve `language` (copy from current style).
+  - Add `setStyleLanguage(language: String)` that preserves `tone`.
+- [ ] (No dedicated unit test for AiRepository — it's a thin facade; behavior is covered by SettingsViewModel + compose tests.)
+
+## Step 8 — SettingsViewModel + Screen
+
+- [ ] **Impl:** Add `setStyleLanguage(language: String)` to `SettingsViewModel.kt`.
+- [ ] **Impl:** Update `SettingsScreen.kt`:
+  - After the tone Column, add a "Insight language" Column with the same DropdownMenu pattern.
+  - Options list: `LANGUAGE_OPTIONS` constant with (code, label) pairs.
+  - `onClick`: `viewModel.setStyleLanguage(option.first)`.
+- [ ] **Test (red → green):** Add compose UI test for the language dropdown. Locate existing tone dropdown test pattern and mirror it. If no compose UI test exists for tone (the spec mentions one; verify), at minimum add a junit test that asserts `viewModel.setStyleLanguage("it")` propagates through `aiRepository.setStyleLanguage("it")` (interaction test with a fake repo).
+- [ ] **Run:** `scripts/dgradle :app:testDebugUnitTest` — green.
+
+## Step 9 — Docs
+
+- [ ] **Impl:** Update `docs/sync-api.md`:
+  - `AiStyle` preferences body example shows `"language": "auto"`.
+  - Cache-key note: `(metadata_id|content_hash, model_id, prompt_version, tone, language)`.
+  - Language paragraph: accepted values, validation rule, behavior at `"auto"`.
+
+## Step 10 — Verify, commit, push, PR
+
+- [ ] **Run:** `cd server && uv run pytest -v` — full green.
+- [ ] **Run:** `scripts/dgradle :data:ai:testDebugUnitTest :app:testDebugUnitTest` — full green.
+- [ ] **Run:** `cd server && uv run ruff format` + `uv run ruff check --fix` — clean.
+- [ ] **Commit:** Single commit, conventional gitmoji:
+  - `:sparkles: feat: AI insight language preference`
+  - No `Co-Authored-By` trailer.
+- [ ] **Push:** `git push -u origin feat/ai-language-preference`.
+- [ ] **PR:** `gh pr create --base feat/ai-generation-log --head feat/ai-language-preference` with body containing summary, what-changed, test plan, cache-version checklist, and GPT review summary. No Claude attribution.
+
+## Risks already considered (no follow-up needed)
+
+- `_style_from_pref` tolerates evolving schemas via `model_fields` — already handles new `language` key automatically.
+- Migration backfill: `server_default='auto'` covers existing rows; no explicit `UPDATE` needed.
+- Cache-key audit test: `language` is a *cache-key* dimension, not a *tenant* dimension, so the audit allowlist is unchanged.

--- a/docs/superpowers/specs/2026-05-16-ai-language-preference-design.md
+++ b/docs/superpowers/specs/2026-05-16-ai-language-preference-design.md
@@ -1,0 +1,270 @@
+# Spec — AI insight language preference (PR4)
+
+**Date:** 2026-05-16
+**Branch:** `feat/ai-language-preference` (stacked on `feat/ai-generation-log`)
+**Roadmap reference:** `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §PR4
+**Template:** PR #9 (`feat: book-insight schema v2 + tone-keyed cache`)
+**Status:** Draft for architect review
+
+## 1. Motivation
+
+Today the AI insight cache key is `(metadata_id|content_hash, model_id, prompt_version, tone)`. Every cached row is implicitly English: the prompts contain only English instructions and no language constraint, so non-English readers get English insights regardless of what they were reading. The roadmap calls out PR4 as the ship-first priority because once any new cache rows are seeded (PR-C just landed; PR1/PR2/PR3 are queued), they become English-only by accident and have to be re-generated when language support lands.
+
+This PR adds a `language` dimension to the cache key, mirroring the tone implementation from PR #9. `auto` (default) preserves today's behavior byte-for-byte; an explicit ISO-639-1 code emits `"Respond in {language}."` to the model and gets its own cache row.
+
+## 2. Server changes
+
+### 2.1 Migration `ai_002_insight_language`
+
+Second migration on the `ai` branch. Per PR-A convention:
+
+```python
+revision = "ai_002"
+down_revision = "ai_001"
+branch_labels = None        # PR-C already owns the "ai" label on ai_001
+depends_on = None
+```
+
+Upgrade:
+
+1. Add `language` column to `book_insights`: `String`, `NOT NULL`, `server_default = 'auto'`. Existing rows backfill to `'auto'` via the server default.
+2. Drop the two existing tone-keyed partial unique indexes:
+   - `uq_book_insights_content_hash_model_prompt_tone`
+   - `uq_book_insights_metadata_id_model_prompt_tone`
+3. Recreate both with `language` appended:
+   - `uq_book_insights_content_hash_model_prompt_tone_language` on `(content_hash, model_id, prompt_version, tone, language)`, `WHERE superseded_at IS NULL`.
+   - `uq_book_insights_metadata_id_model_prompt_tone_language` on `(metadata_id, model_id, prompt_version, tone, language)`, `WHERE metadata_id IS NOT NULL AND superseded_at IS NULL`.
+
+Downgrade is the inverse: drop the language-keyed indexes, recreate the tone-keyed ones, drop the column.
+
+### 2.2 ORM model
+
+`opds_sync/db/models.BookInsight` gets a new column:
+
+```python
+language: Mapped[str] = mapped_column(
+    String, nullable=False, server_default=text("'auto'"), default="auto"
+)
+```
+
+Placed adjacent to `tone` so the cache-key dimensions cluster in source.
+
+### 2.3 Pydantic schema
+
+`opds_sync/api/ai_schemas.AiStyle`:
+
+```python
+class AiStyle(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tone: Literal["neutral", "enthusiastic", "scholarly", "casual"] = "neutral"
+    language: str = "auto"
+
+    @field_validator("language")
+    @classmethod
+    def _validate_language(cls, v: str) -> str:
+        if v == "auto":
+            return v
+        if not _is_iso_639_1(v):
+            raise ValueError(
+                "language must be 'auto' or a lowercase ISO 639-1 code (e.g. 'en', 'it')"
+            )
+        return v
+```
+
+`_is_iso_639_1` accepts any two-letter lowercase string from the ISO 639-1 set. We use the controlled list `{"aa", "ab", ..., "zu"}` shipped as a frozen set at module level (~180 codes). Anything else → 422.
+
+Doc-comment on `AiStyle` is updated to:
+
+> `tone` and `language` are the cache-key knobs: they participate in `book_insights.tone` / `book_insights.language` so users with different combinations get separately-cached generations rather than one bleeding into the other.
+
+### 2.4 Prompt composition
+
+`opds_sync/core/ai/prompts.py`:
+
+- `PROMPT_VERSION` bumps **`"2"` → `"3"`**. PR-C did not bump it; this PR does because the prompt body changes (the new "Respond in" clause shifts model output for non-auto languages, and even if all current users stay on `auto`, the cache-key dimension changes mean PR3/PR-A audits of `(model_id, prompt_version, tone, language)` need a fresh substrate).
+- `compose_user_prompt` emits a single new line **only when `style.language != "auto"`**:
+
+```python
+if style is not None and style.language != "auto":
+    lines.append("")
+    lines.append(
+        f'Respond in the language identified by ISO 639-1 code "{style.language}".'
+    )
+```
+
+Wording avoids ambiguity for valid 2-letter codes that resemble English words (`it`, `is`, `no`, `as`, `or`).
+
+When `language == "auto"` the prompt body is byte-for-byte identical to today's (modulo the cache-key dimension being added), so no per-token cost for the 99% case.
+
+The `_TONE_HINT` block continues to be emitted independently of `language`.
+
+### 2.5 Orchestrator
+
+`opds_sync/core/ai/service.py`:
+
+- New helper `_language_of(style: AiStyle | None) -> str` mirroring `_tone_of`.
+- `_acquire_identity_lock` key becomes:
+
+```python
+key = f"{ident.metadata_id or ident.content_hash}|{tone}|{language}"
+```
+
+- All `_cache_lookup` calls thread `language` through, alongside `tone`. The lookup queries gain a `BookInsight.language == language` clause in both the metadata_id and content_hash paths.
+- `_do_generate` writes `language=language` onto the new `BookInsight` row.
+- Method signatures: `get`, `generate`, `regenerate` keep the same `style: AiStyle | None` parameter — `language` is derived from `style`, not a separate kwarg. This matches how `tone` is threaded.
+
+### 2.6 `_style_from_pref` (router)
+
+`opds_sync/api/ai.py::_style_from_pref` already uses `model_fields` to filter unknown keys, so no change is needed beyond the schema addition: `language` will automatically flow through stored prefs and through the filter.
+
+## 3. Android changes
+
+### 3.1 `AiDtos.kt`
+
+```kotlin
+@Serializable
+data class AiStyle(
+    val tone: String = "neutral",
+    val language: String = "auto",
+)
+```
+
+Default-valued constructor parameter preserves wire compatibility for older server responses that don't include `language` (kotlinx.serialization keeps the default).
+
+### 3.2 `AiRepository.kt`
+
+Add `setStyleLanguage`:
+
+```kotlin
+suspend fun setStyleLanguage(language: String) {
+    val current = _prefs.value?.style ?: AiStyle()
+    val out = client.setPreferences(style = current.copy(language = language))
+    _prefs.value = out
+}
+```
+
+Note: this preserves the user's tone when changing language (and vice-versa for `setStyleTone`, which we should also update). PR #9's `setStyleTone` overwrites style with `AiStyle(tone = ...)` and drops other knobs — that's an actual papercut because changing tone now nukes language. We fix `setStyleTone` here too.
+
+### 3.3 `SettingsViewModel.kt`
+
+```kotlin
+fun setStyleLanguage(language: String) {
+    viewModelScope.launch {
+        runCatching { aiRepository.setStyleLanguage(language) }
+    }
+}
+```
+
+### 3.4 `SettingsScreen.kt`
+
+A new "Insight language" Column placed below the existing "Insight tone" Column. Same `DropdownMenu` pattern with options:
+
+```kotlin
+private val LANGUAGE_OPTIONS = listOf(
+    "auto" to "Auto (no constraint)",
+    "en" to "English",
+    "it" to "Italiano",
+    "es" to "Español",
+    "fr" to "Français",
+    "de" to "Deutsch",
+    "pt" to "Português",
+    "nl" to "Nederlands",
+)
+```
+
+Label uses the native language name so users in the target locale recognize it; the dropdown trigger displays the same label. English UI strings around the dropdown ("Insight language", "What language the model writes in.") are fine for now because the app isn't localized.
+
+### 3.5 Tests
+
+- `data/ai/.../AiClientTest.kt`: fixture JSON updated to include `"language":"en"` in at least one preferences response; assertions added that `AiStyle.language` round-trips and that `setPreferences(style = AiStyle(language = "it"))` sends `"language":"it"` in the request body.
+- New compose UI test in `app` settings: open the language dropdown, click `it`, verify `viewModel.setStyleLanguage("it")` was invoked. Mirrors the existing tone-dropdown test (locate via the same pattern).
+
+## 4. Docs
+
+`docs/sync-api.md`:
+
+- AiStyle table extended:
+  > `style.language` (string, default `"auto"`). Accepts `"auto"` plus any ISO 639-1 code. Participates in the cache key alongside `tone`.
+- Cache-key note updated:
+  > `book_insights` unique key is `(metadata_id|content_hash, model_id, prompt_version, tone, language)`.
+- Example body:
+  ```json
+  {
+    "ai_enabled": true,
+    "style": { "tone": "neutral", "language": "auto" }
+  }
+  ```
+
+## 5. Cache-version checklist (per roadmap)
+
+- [x] `PROMPT_VERSION` bumped `"2" → "3"`.
+- [N/A] `BookInsightPayload.schema_version` — payload shape unchanged.
+- [x] Both unique indexes extended to include `language`.
+- [x] `_acquire_identity_lock` key includes `tone` AND `language`.
+- [x] Android `AiStyle` deserializes `language` with `"auto"` default for old responses.
+- [x] Invalidate stays cache-key-agnostic at the orchestrator level (current `invalidate` deletes by `(model_id, prompt_version, identity)` — that's still correct; the new prompt_version means PR4 invalidate doesn't touch old `prompt_version="2"` rows, which is what we want).
+- [x] Tests cover: cache hit at new key; two languages → two rows; `auto` keeps the prompt body byte-identical; 422 on invalid language.
+- [x] `docs/sync-api.md` updated.
+
+## 6. Tests
+
+### 6.1 Unit (`server/tests/unit/`)
+
+- `test_ai_schemas.py`:
+  - `test_style_language_defaults_to_auto`
+  - `test_style_accepts_iso_639_1_languages` (parametrize over en/it/es/fr/de/pt/nl/zh/ja)
+  - `test_style_rejects_invalid_language` (422 / ValidationError on `"invalid"`, `"english"`, `""`, `"EN"`, `"e"`, `"eng"`)
+  - Update `test_style_only_tone_remains` → `test_style_has_tone_and_language` (model_fields keys = `["tone", "language"]`).
+
+- `test_ai_prompts.py`:
+  - `test_language_clause_emitted_when_non_auto`
+  - `test_language_clause_omitted_when_auto` (prompt body byte-equal to default).
+  - Update `test_prompt_version_is_v3` (was `_v2`).
+
+- `test_ai_service.py`:
+  - `test_different_languages_generate_separate_cache_rows` — same identity + same tone + two languages → two rows, two AI calls.
+  - `test_same_language_shares_cache_across_users` (mirror of existing `test_same_tone_shares_cache_across_users`).
+  - `test_tone_and_language_orthogonal` — neutral/auto and neutral/it produce separate rows; existing tone tests still pass.
+
+### 6.2 Integration (`server/tests/integration/`)
+
+- `test_cache_key_audit.py` — no change needed; the parametrized check stays green because `language` is a cache-key column, not a tenant column.
+- `test_schema.py` — add a check that `language` column exists on `book_insights` and that the new unique indexes cover it.
+- The /ai router test (if present for preferences) — add a `language="invalid"` 422 case via FastAPI's PUT /preferences.
+
+### 6.3 Android
+
+- `data/ai/.../AiClientTest.kt` — fixture + assertions per §3.5.
+- `app/.../SettingsScreenLanguageDropdownTest.kt` (or extend the existing tone dropdown test file) — compose UI test for the dropdown.
+
+## 7. Out of scope
+
+- Localizing the app's UI strings (the dropdown labels are native; the surrounding "Insight language" header is English — that's intentional and aligned with the rest of the app).
+- Validating that the chosen language is one the model actually supports (we trust the user; the model's behavior on an unsupported but valid ISO code is the model's problem).
+- Restricting the ISO 639-1 set to the eight dropdown options on the server. Server accepts any ISO 639-1 code; the dropdown is the curated UI surface. A power user setting `language="zh"` via API call works.
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `language="auto"` cache rows are seeded with `prompt_version="3"` and old `prompt_version="2"` rows linger forever | Acceptable: superseded_at is null on both, but the lookup query filters on `prompt_version == self.prompt_version`, so old rows are never read again. They'll get gardened by a future cleanup PR if storage pressure ever matters. |
+| `setStyleTone` overwriting `language` (and vice-versa) — UX papercut | Fix `setStyleTone` to copy from the current style instead of overwriting. New `setStyleLanguage` does the same. |
+| ISO 639-1 set drift (new codes added by ISO) | We ship a hardcoded frozen set; drift means "user can't pick a rare new code". Acceptable; refresh on demand. |
+| Prompt-version bump invalidates all existing tone-keyed rows (they get re-generated next request) | This is the cost of moving the cache key. Architect-acknowledged in the roadmap as the reason to ship PR4 *before* PR1/PR2/PR3 seed more rows. |
+
+## 9. Deliverables checklist
+
+- [ ] `server/migrations/versions/ai_002_insight_language.py` with up + down.
+- [ ] `opds_sync/db/models.BookInsight.language` column.
+- [ ] `opds_sync/api/ai_schemas.AiStyle.language` field + validator.
+- [ ] `opds_sync/core/ai/prompts.py`: `PROMPT_VERSION = "3"`, "Respond in" clause.
+- [ ] `opds_sync/core/ai/service.py`: lock key + cache lookup + generate threading.
+- [ ] Server tests per §6.1 + §6.2.
+- [ ] `data/ai/.../AiDtos.kt`: `AiStyle.language`.
+- [ ] `app/.../AiRepository.kt`: `setStyleLanguage` + fix `setStyleTone` to preserve siblings.
+- [ ] `app/.../SettingsViewModel.kt`: `setStyleLanguage`.
+- [ ] `app/.../SettingsScreen.kt`: language dropdown.
+- [ ] Android tests per §6.3.
+- [ ] `docs/sync-api.md` updated.
+- [ ] PR body includes the cache-version checklist + GPT review summary.

--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -279,26 +279,41 @@ Returns the user-visible AI configuration. Public to authed users.
 
 ### `GET /ai/v1/preferences` / `PUT /ai/v1/preferences`
 
-Per-user opt-in flag plus a single personalization knob (`tone`). `tone`
-participates in the cache key for `book_insights` (via the `tone` column),
-so two users on the same instance with different tones get their own cached
-generations rather than one bleeding into the other.
+Per-user opt-in flag plus two personalization knobs: `tone` and `language`.
+Both participate in the cache key for `book_insights` (via the `tone` and
+`language` columns), so users on the same instance with different combinations
+get their own cached generations rather than one bleeding into the other.
 
 ```json
 {
   "ai_enabled": true,
   "style": {
-    "tone": "neutral"
+    "tone": "neutral",
+    "language": "auto"
   }
 }
 ```
 
-Allowed tones: `neutral`, `enthusiastic`, `scholarly`, `casual`.
+| Field            | Default     | Allowed values                                                   |
+| ---------------- | ----------- | ---------------------------------------------------------------- |
+| `style.tone`     | `"neutral"` | `neutral`, `enthusiastic`, `scholarly`, `casual`                 |
+| `style.language` | `"auto"`    | `auto` plus any lowercase ISO 639-1 code (`en`, `it`, `es`, …)   |
+
+`language="auto"` (the default) emits no language clause in the prompt and
+preserves byte-for-byte the pre-PR4 prompt body. Any other value sends a
+`'Respond in the language identified by ISO 639-1 code "<code>".'` line to
+the model. Non-ISO-639-1 codes return **422**.
 
 `PUT` accepts either field independently — send `{ "ai_enabled": true }` to flip
 the toggle without changing style, or `{ "style": { "tone": "scholarly" } }`
-to update tone without touching opt-in. Response always returns the full
-resolved state.
+to update tone without touching opt-in (or `language`). Response always returns
+the full resolved state.
+
+**Cache key:** `book_insights` uniqueness is
+`(metadata_id|content_hash, model_id, prompt_version, tone, language)`. Bumping
+any of these dimensions (e.g. via PR-level `PROMPT_VERSION` bumps) does not
+delete old rows — they simply stop being read because the lookup filters on the
+new dimensions.
 
 ### `POST /ai/v1/insights/lookup`
 

--- a/server/migrations/versions/ai_002_insight_language.py
+++ b/server/migrations/versions/ai_002_insight_language.py
@@ -1,0 +1,89 @@
+"""ai_002_insight_language: add language to book_insights cache key.
+
+Second migration on the `ai` branch. PR-C's ai_001 already owns the
+`branch_labels=("ai",)` claim, so this one sets `branch_labels = None`
+and chains off `ai_001`.
+
+Schema:
+- New `language` column on `book_insights`. NOT NULL, server_default
+  'auto'. Existing rows backfill to 'auto' via the default.
+- Both partial unique indexes (`metadata_id` variant and `content_hash`
+  variant) drop their PR #9 tone-keyed name and recreate with `language`
+  appended. The partial WHERE clauses are preserved verbatim.
+
+Reference: docs/superpowers/specs/2026-05-16-ai-language-preference-design.md
+
+Revision ID: ai_002
+Revises: ai_001
+Create Date: 2026-05-16 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_002"
+down_revision = "ai_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "book_insights",
+        sa.Column(
+            "language",
+            sa.String(),
+            nullable=False,
+            server_default=sa.text("'auto'"),
+        ),
+    )
+
+    op.drop_index(
+        "uq_book_insights_content_hash_model_prompt_tone",
+        table_name="book_insights",
+    )
+    op.drop_index(
+        "uq_book_insights_metadata_id_model_prompt_tone",
+        table_name="book_insights",
+    )
+
+    op.create_index(
+        "uq_book_insights_content_hash_model_prompt_tone_language",
+        "book_insights",
+        ["content_hash", "model_id", "prompt_version", "tone", "language"],
+        unique=True,
+        postgresql_where=sa.text("superseded_at IS NULL"),
+    )
+    op.create_index(
+        "uq_book_insights_metadata_id_model_prompt_tone_language",
+        "book_insights",
+        ["metadata_id", "model_id", "prompt_version", "tone", "language"],
+        unique=True,
+        postgresql_where=sa.text("metadata_id IS NOT NULL AND superseded_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_book_insights_metadata_id_model_prompt_tone_language",
+        table_name="book_insights",
+    )
+    op.drop_index(
+        "uq_book_insights_content_hash_model_prompt_tone_language",
+        table_name="book_insights",
+    )
+    op.create_index(
+        "uq_book_insights_metadata_id_model_prompt_tone",
+        "book_insights",
+        ["metadata_id", "model_id", "prompt_version", "tone"],
+        unique=True,
+        postgresql_where=sa.text("metadata_id IS NOT NULL AND superseded_at IS NULL"),
+    )
+    op.create_index(
+        "uq_book_insights_content_hash_model_prompt_tone",
+        "book_insights",
+        ["content_hash", "model_id", "prompt_version", "tone"],
+        unique=True,
+        postgresql_where=sa.text("superseded_at IS NULL"),
+    )
+    op.drop_column("book_insights", "language")

--- a/server/opds_sync/api/ai_schemas.py
+++ b/server/opds_sync/api/ai_schemas.py
@@ -7,7 +7,199 @@ load-bearing on both ends.
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Full ISO 639-1 set (184 codes, current as of 2024). Frozen so a future
+# AiStyle.language="zz" (regex-valid but not a real language) gets a 422
+# instead of being silently accepted and propagated into the cache key.
+ISO_639_1_CODES: frozenset[str] = frozenset(
+    {
+        "aa",
+        "ab",
+        "ae",
+        "af",
+        "ak",
+        "am",
+        "an",
+        "ar",
+        "as",
+        "av",
+        "ay",
+        "az",
+        "ba",
+        "be",
+        "bg",
+        "bh",
+        "bi",
+        "bm",
+        "bn",
+        "bo",
+        "br",
+        "bs",
+        "ca",
+        "ce",
+        "ch",
+        "co",
+        "cr",
+        "cs",
+        "cu",
+        "cv",
+        "cy",
+        "da",
+        "de",
+        "dv",
+        "dz",
+        "ee",
+        "el",
+        "en",
+        "eo",
+        "es",
+        "et",
+        "eu",
+        "fa",
+        "ff",
+        "fi",
+        "fj",
+        "fo",
+        "fr",
+        "fy",
+        "ga",
+        "gd",
+        "gl",
+        "gn",
+        "gu",
+        "gv",
+        "ha",
+        "he",
+        "hi",
+        "ho",
+        "hr",
+        "ht",
+        "hu",
+        "hy",
+        "hz",
+        "ia",
+        "id",
+        "ie",
+        "ig",
+        "ii",
+        "ik",
+        "io",
+        "is",
+        "it",
+        "iu",
+        "ja",
+        "jv",
+        "ka",
+        "kg",
+        "ki",
+        "kj",
+        "kk",
+        "kl",
+        "km",
+        "kn",
+        "ko",
+        "kr",
+        "ks",
+        "ku",
+        "kv",
+        "kw",
+        "ky",
+        "la",
+        "lb",
+        "lg",
+        "li",
+        "ln",
+        "lo",
+        "lt",
+        "lu",
+        "lv",
+        "mg",
+        "mh",
+        "mi",
+        "mk",
+        "ml",
+        "mn",
+        "mr",
+        "ms",
+        "mt",
+        "my",
+        "na",
+        "nb",
+        "nd",
+        "ne",
+        "ng",
+        "nl",
+        "nn",
+        "no",
+        "nr",
+        "nv",
+        "ny",
+        "oc",
+        "oj",
+        "om",
+        "or",
+        "os",
+        "pa",
+        "pi",
+        "pl",
+        "ps",
+        "pt",
+        "qu",
+        "rm",
+        "rn",
+        "ro",
+        "ru",
+        "rw",
+        "sa",
+        "sc",
+        "sd",
+        "se",
+        "sg",
+        "si",
+        "sk",
+        "sl",
+        "sm",
+        "sn",
+        "so",
+        "sq",
+        "sr",
+        "ss",
+        "st",
+        "su",
+        "sv",
+        "sw",
+        "ta",
+        "te",
+        "tg",
+        "th",
+        "ti",
+        "tk",
+        "tl",
+        "tn",
+        "to",
+        "tr",
+        "ts",
+        "tt",
+        "tw",
+        "ty",
+        "ug",
+        "uk",
+        "ur",
+        "uz",
+        "ve",
+        "vi",
+        "vo",
+        "wa",
+        "wo",
+        "xh",
+        "yi",
+        "yo",
+        "za",
+        "zh",
+        "zu",
+    }
+)
 
 
 class DocumentIdentity(BaseModel):
@@ -107,15 +299,31 @@ class InsightRegenerateBody(BaseModel):
 
 
 class AiStyle(BaseModel):
-    """User-facing personalization. `tone` is the only knob that affects output:
-    it participates in the cache key (column `book_insights.tone`), so two users
-    on the same instance with different tones get separately-cached generations
-    rather than one bleeding into the other.
+    """User-facing personalization. `tone` and `language` are cache-key knobs:
+    they participate in the cache key (columns `book_insights.tone` and
+    `book_insights.language`), so users with different combinations get
+    separately-cached generations rather than one bleeding into the other.
+
+    `language="auto"` is the universal default and emits no language clause in
+    the prompt — preserves pre-PR4 behavior byte-for-byte. Any other value must
+    be a lowercase ISO 639-1 code (e.g. `"en"`, `"it"`, `"zh"`).
     """
 
     model_config = ConfigDict(extra="forbid")
 
     tone: Literal["neutral", "enthusiastic", "scholarly", "casual"] = "neutral"
+    language: str = "auto"
+
+    @field_validator("language")
+    @classmethod
+    def _validate_language(cls, v: str) -> str:
+        if v == "auto":
+            return v
+        if v not in ISO_639_1_CODES:
+            raise ValueError(
+                "language must be 'auto' or a lowercase ISO 639-1 code (e.g. 'en', 'it')"
+            )
+        return v
 
 
 class ConfigResponse(BaseModel):

--- a/server/opds_sync/core/ai/prompts.py
+++ b/server/opds_sync/core/ai/prompts.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 from opds_sync.api.ai_schemas import AiStyle, Citation, MetadataBundle
 
-PROMPT_VERSION = "2"
+PROMPT_VERSION = "3"
 
-# `tone` (from AiStyle) participates in the cache key via the `book_insights.tone`
-# column, so emitting tone-specific instructions in the prompt is safe across
-# users. `feedback` does NOT participate in the cache key — it's a one-shot input
-# on /insights/regenerate that produces a new row marked superseded against the
+# `tone` and `language` (from AiStyle) participate in the cache key via the
+# `book_insights.tone` and `book_insights.language` columns, so emitting
+# tone- or language-specific instructions in the prompt is safe across users.
+# `feedback` does NOT participate in the cache key — it's a one-shot input on
+# /insights/regenerate that produces a new row marked superseded against the
 # previous one.
 
 SYSTEM_PROMPT = (
@@ -106,6 +107,14 @@ def compose_user_prompt(
         if hint:
             lines.append("")
             lines.append(hint)
+        # `auto` is the universal default and emits no language clause —
+        # preserves pre-PR4 prompt body byte-for-byte. Non-auto codes are
+        # validated to ISO 639-1 in AiStyle._validate_language.
+        if style.language != "auto":
+            lines.append("")
+            lines.append(
+                f'Respond in the language identified by ISO 639-1 code "{style.language}".'
+            )
 
     if feedback:
         lines.append("")

--- a/server/opds_sync/core/ai/service.py
+++ b/server/opds_sync/core/ai/service.py
@@ -128,7 +128,10 @@ class InsightOrchestrator:
         tenant_id: str = "local",
     ) -> BookInsightResponse | None:
         tone = _tone_of(style)
-        row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=False)
+        language = _language_of(style)
+        row = await self._cache_lookup(
+            session, ident, tone=tone, language=language, allow_backfill=False
+        )
         if row is None:
             return None
         if user_id is not None:
@@ -154,7 +157,10 @@ class InsightOrchestrator:
         tenant_id: str = "local",
     ) -> BookInsightResponse:
         tone = _tone_of(style)
-        row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=True)
+        language = _language_of(style)
+        row = await self._cache_lookup(
+            session, ident, tone=tone, language=language, allow_backfill=True
+        )
         if row is not None:
             await self._log_generation(
                 session,
@@ -167,9 +173,11 @@ class InsightOrchestrator:
             await session.commit()
             return self._row_to_response(row)
 
-        lock = await self._acquire_identity_lock(ident, tone=tone)
+        lock = await self._acquire_identity_lock(ident, tone=tone, language=language)
         async with lock:
-            row = await self._cache_lookup(session, ident, tone=tone, allow_backfill=True)
+            row = await self._cache_lookup(
+                session, ident, tone=tone, language=language, allow_backfill=True
+            )
             if row is not None:
                 await self._log_generation(
                     session,
@@ -192,6 +200,7 @@ class InsightOrchestrator:
                 tenant_id=tenant_id,
                 style=style,
                 tone=tone,
+                language=language,
                 feedback=None,
                 previous_insight_ids=None,
             )
@@ -210,9 +219,12 @@ class InsightOrchestrator:
     ) -> BookInsightResponse:
         """Supersede the existing live row (if any) and generate a fresh one."""
         tone = _tone_of(style)
-        lock = await self._acquire_identity_lock(ident, tone=tone)
+        language = _language_of(style)
+        lock = await self._acquire_identity_lock(ident, tone=tone, language=language)
         async with lock:
-            existing = await self._cache_lookup(session, ident, tone=tone, allow_backfill=False)
+            existing = await self._cache_lookup(
+                session, ident, tone=tone, language=language, allow_backfill=False
+            )
             previous_ids: list[int] = []
             if existing is not None:
                 previous_ids = list(existing.previous_insight_ids or [])
@@ -230,6 +242,7 @@ class InsightOrchestrator:
                 tenant_id=tenant_id,
                 style=style,
                 tone=tone,
+                language=language,
                 feedback=reason,
                 previous_insight_ids=previous_ids or None,
             )
@@ -289,6 +302,7 @@ class InsightOrchestrator:
         tenant_id: str,
         style: AiStyle | None,
         tone: str,
+        language: str,
         feedback: str | None,
         previous_insight_ids: list[int] | None,
     ) -> BookInsight:
@@ -343,6 +357,7 @@ class InsightOrchestrator:
             model_id=self.model_id,
             prompt_version=self.prompt_version,
             tone=tone,
+            language=language,
             sources_used=list({c.kind for c in citations}),
             payload=payload.model_dump(),
             sources=[c.model_dump() for c in sources],
@@ -435,6 +450,7 @@ class InsightOrchestrator:
         ident: DocumentIdentity,
         *,
         tone: str,
+        language: str,
         allow_backfill: bool,
     ) -> BookInsight | None:
         # Step 1: by metadata_id (live rows only)
@@ -446,6 +462,7 @@ class InsightOrchestrator:
                         BookInsight.model_id == self.model_id,
                         BookInsight.prompt_version == self.prompt_version,
                         BookInsight.tone == tone,
+                        BookInsight.language == language,
                         BookInsight.superseded_at.is_(None),
                     )
                 )
@@ -460,6 +477,7 @@ class InsightOrchestrator:
                     BookInsight.model_id == self.model_id,
                     BookInsight.prompt_version == self.prompt_version,
                     BookInsight.tone == tone,
+                    BookInsight.language == language,
                     BookInsight.superseded_at.is_(None),
                 )
             )
@@ -473,10 +491,12 @@ class InsightOrchestrator:
             await session.refresh(row)
         return row
 
-    async def _acquire_identity_lock(self, ident: DocumentIdentity, *, tone: str) -> asyncio.Lock:
-        # Per-(identity, tone): two users with different tones generating the
-        # same book in parallel should not serialize through one lock.
-        key = f"{ident.metadata_id or ident.content_hash}|{tone}"
+    async def _acquire_identity_lock(
+        self, ident: DocumentIdentity, *, tone: str, language: str
+    ) -> asyncio.Lock:
+        # Per-(identity, tone, language): users hitting the same book with
+        # different cache-key dimensions should not serialize through one lock.
+        key = f"{ident.metadata_id or ident.content_hash}|{tone}|{language}"
         async with self._locks_master:
             lock = self._locks.get(key)
             if lock is None:
@@ -500,3 +520,7 @@ def _next_utc_midnight(today: date) -> datetime:
 
 def _tone_of(style: AiStyle | None) -> str:
     return style.tone if style is not None else "neutral"
+
+
+def _language_of(style: AiStyle | None) -> str:
+    return style.language if style is not None else "auto"

--- a/server/opds_sync/db/models.py
+++ b/server/opds_sync/db/models.py
@@ -97,6 +97,12 @@ class BookInsight(Base):
     tone: Mapped[str] = mapped_column(
         String, nullable=False, server_default=text("'neutral'"), default="neutral"
     )
+    # Part of the cache key so users with different AiStyle.language get their
+    # own generations. `'auto'` (the universal default) emits no language clause
+    # in the prompt and preserves the pre-PR4 behavior byte-for-byte.
+    language: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("'auto'"), default="auto"
+    )
     sources_used: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False)
     payload: Mapped[dict] = mapped_column(JSON, nullable=False)
     sources: Mapped[list[dict]] = mapped_column(JSON, nullable=False)

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,9 +29,9 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # PR-C materialized the `ai` branch (ai_001 is its head); with the
-    # default-true mode flags, ai@head is now what's reported.
-    assert body["heads_applied"] == ["ai_001"]
+    # PR-C materialized the `ai` branch; PR4 added `ai_002` as the new head.
+    # With the default-true mode flags, ai@head is now what's reported.
+    assert body["heads_applied"] == ["ai_002"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -1,13 +1,13 @@
 """Integration tests for scripts/migrate.py against a real Postgres + Alembic.
 
 Cases covered:
-1. Default state (no branch labels): wrapper upgrades backbone, DB ends at 0004,
-   `alembic_version` contains exactly {"0004"}.
+1. Default state with real migrations: wrapper upgrades backbone + ai branch,
+   DB ends at ai@head (currently `ai_002`).
 2. Idempotent: running twice in a row is a no-op.
-3. Synthetic branched script directory (tmp copy of migrations + an ai_test_001
-   revision with branch_labels=("ai",)):
-   - ai_enabled=true → upgrades to ai_test_001.
-   - ai_enabled=false → stays at 0004.
+3. Synthetic branched script directory (tmp copy of migrations + an ai_test_003
+   revision chained off the current ai@head):
+   - ai_enabled=true → upgrades to ai_test_003.
+   - ai_enabled=false → stays at 0004 (no ai branch applied).
 """
 
 from __future__ import annotations
@@ -67,7 +67,7 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
     versions = await _alembic_versions(eng)
     await eng.dispose()
     # PR-C materialized the `ai` branch; ai_enabled=True advances to ai@head.
-    assert versions == {"ai_001"}
+    assert versions == {"ai_002"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
@@ -80,14 +80,14 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_001"}
+    assert versions == {"ai_002"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
-    """Copy real migrations to tmp + add a synthetic ai_test_002 chained off
-    ai_001; verify enabled run advances to ai_test_002 (the new ai@head)."""
+    """Copy real migrations to tmp + add a synthetic ai_test_003 chained off
+    ai_002; verify enabled run advances to ai_test_003 (the new ai@head)."""
 
-    # First, ensure DB is at ai@head (real migrations include ai_001).
+    # First, ensure DB is at ai@head (real migrations include ai_001 + ai_002).
     real_cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
 
@@ -95,23 +95,23 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
     versions_dir = synth_dir / "versions"
-    # Chain off ai_001 (the real first ai migration) with branch_labels=None,
-    # because the `ai` label is already claimed by ai_001.
-    (versions_dir / "ai_test_002.py").write_text(
+    # Chain off ai_002 (the current ai@head) with branch_labels=None — the `ai`
+    # label is already claimed by ai_001.
+    (versions_dir / "ai_test_003.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration.
 
-            Revision ID: ai_test_002
-            Revises: ai_001
+            Revision ID: ai_test_003
+            Revises: ai_002
             Create Date: 2026-05-16 00:00:00.000000
             """
 
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_002"
-            down_revision = "ai_001"
+            revision = "ai_test_003"
+            down_revision = "ai_002"
             branch_labels = None
             depends_on = None
 
@@ -132,18 +132,18 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     # ai branch advances to the new tip.
-    assert "ai_test_002" in versions, versions
+    assert "ai_test_003" in versions, versions
     await eng.dispose()
 
     # Cleanup: roll back the synthetic migration so other tests aren't affected.
-    await _downgrade_in_thread(cfg, "ai_001")
+    await _downgrade_in_thread(cfg, "ai_002")
 
 
 async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
     """With ai_enabled=False, the wrapper skips advancing the ai branch.
 
     Pre-condition: DB is rolled back to 0004 (no ai branch applied), then the
-    wrapper is invoked with ai_enabled=False. ai_test_002 (the synthetic head)
+    wrapper is invoked with ai_enabled=False. ai_test_003 (the synthetic head)
     must NOT be applied; the backbone stays at 0004.
     """
     # Stamp DB back to backbone (pre-ai-branch state) for this test.
@@ -152,15 +152,15 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
 
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
-    (synth_dir / "versions" / "ai_test_002.py").write_text(
+    (synth_dir / "versions" / "ai_test_003.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration."""
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_002"
-            down_revision = "ai_001"
+            revision = "ai_test_003"
+            down_revision = "ai_002"
             branch_labels = None
             depends_on = None
 
@@ -179,8 +179,10 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch skipped → ai_test_002 NOT applied, and ai_001 NOT applied either.
-    assert "ai_test_002" not in versions
+    # ai branch skipped → ai_test_003 not applied, ai_002 not applied,
+    # ai_001 not applied. Only the backbone advanced.
+    assert "ai_test_003" not in versions
+    assert "ai_002" not in versions
     assert "ai_001" not in versions
     # Backbone still at 0004.
     assert "0004" in versions

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -50,21 +50,21 @@ async def restore_after(postgres_url: str, alembic_upgrade):
 
 
 async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
-    """With ai_001 materialized and ai mode on, the required head is ai@head."""
+    """With ai_002 materialized and ai mode on, the required head is ai@head."""
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.get("/readyz")
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_001"]
+    assert body["heads_applied"] == ["ai_002"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
     """DB stamped below backbone; with both modes enabled, required head is
-    ai_001 (ai@head) — that's what should be reported missing."""
+    ai_002 (ai@head) — that's what should be reported missing."""
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -72,7 +72,7 @@ async def test_readyz_503_when_db_below_backbone(
     assert r.status_code == 503
     body = r.json()
     assert body["ready"] is False
-    assert "ai_001" in body["missing"]
+    assert "ai_002" in body["missing"]
 
 
 async def test_readyz_200_with_neither_mode_at_backbone(

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -50,6 +50,52 @@ async def test_ai_generation_log_table_exists(engine) -> None:
 
 
 @pytest.mark.requires_ai
+async def test_book_insights_has_language_column(engine) -> None:
+    """ai_002 migration adds `language` to book_insights, NOT NULL, default 'auto'."""
+
+    def _introspect(sync_conn) -> dict:
+        insp = inspect(sync_conn)
+        cols = {c["name"]: c for c in insp.get_columns("book_insights")}
+        return {"cols": cols}
+
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_introspect)
+
+    assert "language" in info["cols"]
+    lang = info["cols"]["language"]
+    assert lang["nullable"] is False
+    # Postgres reports server defaults as strings like "'auto'::character varying"
+    assert "auto" in str(lang.get("default", ""))
+
+
+@pytest.mark.requires_ai
+async def test_book_insights_unique_indexes_include_language(engine) -> None:
+    """ai_002 drops the tone-keyed unique indexes and recreates them with `language` appended."""
+
+    def _introspect(sync_conn) -> dict:
+        insp = inspect(sync_conn)
+        idx = {i["name"]: i for i in insp.get_indexes("book_insights")}
+        return {"idx": idx}
+
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_introspect)
+
+    expected_names = {
+        "uq_book_insights_content_hash_model_prompt_tone_language",
+        "uq_book_insights_metadata_id_model_prompt_tone_language",
+    }
+    assert expected_names.issubset(info["idx"].keys()), info["idx"].keys()
+    # Confirm `language` is in the column list of both new indexes.
+    for name in expected_names:
+        cols = info["idx"][name]["column_names"]
+        assert "language" in cols, (name, cols)
+        assert "tone" in cols, (name, cols)
+    # And the old tone-only indexes are gone.
+    assert "uq_book_insights_content_hash_model_prompt_tone" not in info["idx"]
+    assert "uq_book_insights_metadata_id_model_prompt_tone" not in info["idx"]
+
+
+@pytest.mark.requires_ai
 async def test_ai_generation_log_round_trip(session) -> None:
     """ORM model writes and reads ai_generation_log rows."""
     from opds_sync.db.models import AIGenerationLog, BookInsight

--- a/server/tests/unit/test_ai_prompts.py
+++ b/server/tests/unit/test_ai_prompts.py
@@ -6,9 +6,9 @@ from opds_sync.core.ai.prompts import (
 )
 
 
-def test_prompt_version_is_v2():
-    """v2 schema requires v2 prompt — they share a cache key."""
-    assert PROMPT_VERSION == "2"
+def test_prompt_version_is_v3():
+    """PR4 bumped from v2 to v3 because the prompt body now varies on `language`."""
+    assert PROMPT_VERSION == "3"
 
 
 def test_user_prompt_includes_metadata_fields():
@@ -77,6 +77,33 @@ def test_tone_hint_omitted_when_default():
     text_no_style = compose_user_prompt(bundle, citations=[])
     text_default_style = compose_user_prompt(bundle, citations=[], style=AiStyle())
     assert text_no_style == text_default_style
+
+
+def test_language_clause_emitted_when_non_auto():
+    bundle = MetadataBundle(title="Foundation")
+    text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="it"))
+    assert 'ISO 639-1 code "it"' in text
+
+
+def test_language_clause_omitted_when_auto():
+    """`auto` must produce a prompt byte-for-byte identical to the no-style call."""
+    bundle = MetadataBundle(title="Foundation")
+    text_no_style = compose_user_prompt(bundle, citations=[])
+    text_auto = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
+    text_default = compose_user_prompt(bundle, citations=[], style=AiStyle())
+    assert text_no_style == text_auto == text_default
+
+
+def test_language_clause_independent_of_tone():
+    """Setting both tone and language emits both clauses."""
+    bundle = MetadataBundle(title="Foundation")
+    text = compose_user_prompt(
+        bundle,
+        citations=[],
+        style=AiStyle(tone="scholarly", language="fr"),
+    )
+    assert "analytical" in text.lower() or "scholarly" in text.lower()
+    assert 'ISO 639-1 code "fr"' in text
 
 
 def test_feedback_block_appended_on_regeneration():

--- a/server/tests/unit/test_ai_schemas.py
+++ b/server/tests/unit/test_ai_schemas.py
@@ -76,10 +76,11 @@ def test_lookup_body_metadata_id_optional():
     assert b.bundle.title == "Foundation"
 
 
-def test_style_only_tone_remains():
+def test_style_has_tone_and_language():
     s = AiStyle()
     assert s.tone == "neutral"
-    assert list(AiStyle.model_fields.keys()) == ["tone"]
+    assert s.language == "auto"
+    assert list(AiStyle.model_fields.keys()) == ["tone", "language"]
 
 
 def test_style_rejects_unknown_tone():
@@ -91,6 +92,40 @@ def test_style_rejects_v1_knobs():
     for stale in ("length", "author_focus", "include_spoilers", "interests"):
         with pytest.raises(ValidationError):
             AiStyle.model_validate({"tone": "neutral", stale: "anything"})
+
+
+@pytest.mark.parametrize("code", ["en", "it", "es", "fr", "de", "pt", "nl", "zh", "ja"])
+def test_style_accepts_iso_639_1_languages(code):
+    s = AiStyle.model_validate({"tone": "neutral", "language": code})
+    assert s.language == code
+
+
+def test_style_accepts_auto_language():
+    s = AiStyle.model_validate({"tone": "neutral", "language": "auto"})
+    assert s.language == "auto"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "invalid",  # not a code
+        "english",  # word, not a code
+        "",  # empty
+        "EN",  # uppercase
+        "e",  # too short
+        "eng",  # ISO 639-2/3, not 639-1
+    ],
+)
+def test_style_rejects_invalid_language(bad):
+    with pytest.raises(ValidationError):
+        AiStyle.model_validate({"tone": "neutral", "language": bad})
+
+
+@pytest.mark.parametrize("bad", ["zz", "xx", "qq"])
+def test_style_rejects_unknown_iso_code(bad):
+    """Proves the validation is an allowlist, not a `^[a-z]{2}$` regex."""
+    with pytest.raises(ValidationError):
+        AiStyle.model_validate({"tone": "neutral", "language": bad})
 
 
 def test_regenerate_requires_reason():

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -286,6 +286,131 @@ async def test_same_tone_shares_cache_across_users(session, make_orchestrator):
     assert len(orch.ai.calls) == 1
 
 
+@pytest.mark.asyncio
+async def test_different_languages_generate_separate_cache_rows(session, make_orchestrator):
+    """Two users with different languages must get their own rows — no cross-language leak."""
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-languages")
+    bundle = MetadataBundle(title="X")
+
+    await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(language="auto"))
+    await orch.generate(session, ident, bundle, user_id="u2", style=AiStyle(language="it"))
+
+    rows = (
+        (
+            await session.execute(
+                select(BookInsight).where(BookInsight.content_hash == "ch-languages")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {r.language for r in rows} == {"auto", "it"}
+    assert len(orch.ai.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_same_language_shares_cache_across_users(session, make_orchestrator):
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-shared-language")
+    bundle = MetadataBundle(title="X")
+
+    await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(language="it"))
+    await orch.generate(session, ident, bundle, user_id="u2", style=AiStyle(language="it"))
+
+    assert len(orch.ai.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_tone_and_language_orthogonal(session, make_orchestrator):
+    """Same identity, different (tone, language) combos → separate cache rows."""
+    orch = make_orchestrator()
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-orthogonal")
+    bundle = MetadataBundle(title="X")
+
+    await orch.generate(
+        session, ident, bundle, user_id="u1", style=AiStyle(tone="neutral", language="auto")
+    )
+    await orch.generate(
+        session, ident, bundle, user_id="u2", style=AiStyle(tone="neutral", language="it")
+    )
+    await orch.generate(
+        session, ident, bundle, user_id="u3", style=AiStyle(tone="scholarly", language="auto")
+    )
+    await orch.generate(
+        session, ident, bundle, user_id="u4", style=AiStyle(tone="scholarly", language="it")
+    )
+
+    rows = (
+        (
+            await session.execute(
+                select(BookInsight).where(BookInsight.content_hash == "ch-orthogonal")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 4
+    assert {(r.tone, r.language) for r in rows} == {
+        ("neutral", "auto"),
+        ("neutral", "it"),
+        ("scholarly", "auto"),
+        ("scholarly", "it"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_invalidate_does_not_touch_old_prompt_version_rows(
+    session: AsyncSession, make_orchestrator
+):
+    """Invalidate at prompt_version `t1` must leave rows at older prompt_versions alone.
+
+    Regression for the cache-version-bump contract: a user invalidate with the
+    new PROMPT_VERSION must not delete rows from before the bump. Models a
+    user on the new server invalidating their freshly-generated v3 row while
+    a stale v2 row from a previous deploy lingers (it'll never be read again
+    because the v3 lookup filters on prompt_version, but it must not be GC'd
+    by an unrelated invalidate call).
+    """
+    orch = make_orchestrator()
+    # Insert an "old" row directly with a stale prompt_version.
+    old_row = BookInsight(
+        metadata_id=None,
+        content_hash="ch-invalidate",
+        model_id="test-model",
+        prompt_version="t0_legacy",
+        tone="neutral",
+        language="auto",
+        sources_used=[],
+        payload={"schema_version": 2, "confidence": "low"},
+        sources=[],
+        generated_by="legacy",
+    )
+    session.add(old_row)
+    await session.commit()
+
+    # Generate a fresh row at the orchestrator's current prompt_version ("t1").
+    ident = DocumentIdentity(metadata_id=None, content_hash="ch-invalidate")
+    await orch.generate(session, ident, MetadataBundle(title="X"), user_id="u1")
+
+    # Invalidate via the orchestrator (scoped to current prompt_version).
+    deleted = await orch.invalidate(session, ident)
+    assert deleted == 1  # only the new row
+
+    rows = (
+        (
+            await session.execute(
+                select(BookInsight).where(BookInsight.content_hash == "ch-invalidate")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # Only the old row survives.
+    assert len(rows) == 1
+    assert rows[0].prompt_version == "t0_legacy"
+
+
 # ---- PR-C: ai_generation_log assertions ------------------------------------
 
 from opds_sync.db.models import AIGenerationLog  # noqa: E402


### PR DESCRIPTION
## Summary

Adds `language` as a cache-key dimension on `book_insights`, mirroring the tone implementation from PR #9. `auto` (the default) preserves today's behavior byte-for-byte; an explicit ISO 639-1 code (`en`, `it`, `es`, `fr`, `de`, `pt`, `nl`, …) emits a `Respond in the language identified by ISO 639-1 code "<code>".` clause to the model and gets its own cache row.

Ship-first priority: lands before any other PR seeds new cache rows, so non-English readers don't end up with English-only insights baked into the shared cache.

Stacked on #11 (PR-C). Merge that first.

## What changed

**Server**
- New migration `ai_002_insight_language`: adds `language` (NOT NULL, default `'auto'`) and recreates both partial unique indexes with `(…, tone, language)`. Chains off `ai_001` with `branch_labels = None` (PR-C owns the `ai` label).
- `AiStyle.language: str = "auto"` with an ISO-639-1 frozen-set allowlist validator. Regex-valid-but-fake codes like `zz` get a 422.
- `PROMPT_VERSION` bumps `"2"` → `"3"`. PR-C did not bump it; PR4 does because the prompt body now varies on `language`.
- Orchestrator threads `language` alongside `tone`: lock key becomes `{ident}|{tone}|{language}`, cache lookup filters on both, `_do_generate` writes the new column.
- The `_style_from_pref` filter already uses `AiStyle.model_fields` so the new `language` key flows through stored prefs automatically.

**Android**
- `AiStyle.language` DTO field with `"auto"` default — forward-compat for legacy server responses that omit it.
- `AiRepository.setStyleLanguage()` + fix to `setStyleTone()` to preserve sibling style fields (was clobbering them, a latent papercut from PR #9 that surfaces now).
- Settings screen language dropdown with eight curated options (labels are native language names).

**Docs**
- `docs/sync-api.md` AiStyle table extended; cache-key note updated to `(metadata_id|content_hash, model_id, prompt_version, tone, language)`.

**Infra test updates**
- `test_health.py`, `test_readyz_migration_state.py`, `test_migrate_script.py` assertions move from `ai_001` to `ai_002`. The synthetic ai-branch migration in `test_migrate_script.py` renames `ai_test_002` → `ai_test_003` (no name collision with the real `ai_002`) and chains off `ai_002`.

## Cache-version checklist

- [x] `PROMPT_VERSION` bumped `"2"` → `"3"`.
- [N/A] `BookInsightPayload.schema_version` unchanged (payload shape unchanged).
- [x] Both unique indexes (`metadata_id` and `content_hash` variants) extended to include `language`.
- [x] Lock key in `service.py` includes both `tone` and `language`.
- [x] Android `:data:ai` `AiStyle.language` has `"auto"` default for legacy server payloads.
- [x] Invalidate-by-cache-key still works: orchestrator invalidate scopes by `(model_id, prompt_version, identity)`, so a v3 invalidate cannot touch old v2 rows. Covered by `test_invalidate_does_not_touch_old_prompt_version_rows`.
- [x] Tests: cache hit at new key, miss falls through, language-orthogonal-to-tone, `auto` byte-identical to no-style.
- [x] `docs/sync-api.md` updated.

## Test plan

- [x] `cd server && uv run pytest -v` — full mode: 163 passed.
- [x] `OPDS_SYNC_AI_ENABLED=false uv run pytest` — sync-only mode: 149 passed, 14 skipped.
- [x] `OPDS_SYNC_PROGRESS_ENABLED=false uv run pytest` — ai-only mode: 156 passed, 7 skipped.
- [x] `scripts/dgradle :data:ai:testDebugUnitTest` — green.
- [x] `scripts/dgradle :app:testDebugUnitTest` — green (includes new `AiRepositoryStyleTest`).
- [x] `cd server && uv run ruff format && uv run ruff check` — clean.

## Review summary (GPT architect, advisory, 1 round)

**Verdict:** APPROVE with one critical correction (addressed) + two nits (addressed).

- **Critical (addressed):** Existing tests hard-coded `ai_001` as the ai@head — adding `ai_002` would break full/AI CI. Updated `test_health.py`, `test_readyz_migration_state.py`, `test_migrate_script.py` accordingly, and renamed the synthetic test revision from `ai_test_002` (would collide with the new real `ai_002`) to `ai_test_003` chained off `ai_002`.
- **Nit (addressed):** Added `test_style_rejects_unknown_iso_code` parametrized over `zz/xx/qq` to prove the validator is an allowlist, not a `^[a-z]{2}$` regex.
- **Nit (addressed):** Reworded the language clause from `Respond in {code}.` (ambiguous for `it`, `is`, `no`, `as`, `or`) to `Respond in the language identified by ISO 639-1 code "{code}".`.
- **Extra (architect-suggested):** Added `test_invalidate_does_not_touch_old_prompt_version_rows` regression covering the cache-version-bump contract.

Effort: Quick.

## Out of scope

- Localizing the app's UI strings (the dropdown labels themselves are native; the surrounding "Insight language" header is English — intentional, app isn't localized yet).
- Restricting the ISO 639-1 set to the eight dropdown options on the server. The server accepts any ISO 639-1 code; the dropdown is the curated UI surface.
- Validating that the chosen language is one the model actually supports.