### PR TITLE
feat(server): AI auth abstraction (seam)

### DIFF
--- a/docs/superpowers/plans/2026-05-16-ai-auth-abstraction.md
+++ b/docs/superpowers/plans/2026-05-16-ai-auth-abstraction.md
@@ -1,0 +1,207 @@
+# Plan — AI auth abstraction (PR-B)
+
+**Spec:** `docs/superpowers/specs/2026-05-16-ai-auth-abstraction-design.md`
+**Approach:** TDD throughout. The unit/integration seams are clean (auth
+dependency, settings, principal dataclass), so failing tests come first;
+implementation follows.
+
+Each task is a checkbox. Verification commands inline. Run `cd server` once
+per shell and use `uv run` for python invocations.
+
+## Phase 0 — Baseline
+
+- [ ] **0.1 Confirm green baseline.** `cd server && uv run pytest -v` passes
+      on a fresh checkout of `feat/ai-auth-abstraction`. Capture test count for
+      "no regression" claim.
+
+## Phase 1 — Settings
+
+- [ ] **1.1 RED: `tests/unit/test_settings.py::test_ai_auth_mode_defaults_to_basic`.**
+      Assert `Settings().ai_auth_mode == "basic"` and `Settings().ai_token_secrets is None`.
+- [ ] **1.2 RED: `tests/unit/test_settings.py::test_ai_token_secrets_parses_json`.**
+      Set env `OPDS_SYNC_AI_TOKEN_SECRETS='{"k1":"a"}'`; assert
+      `Settings().ai_token_secrets == {"k1": "a"}`.
+- [ ] **1.3 GREEN: edit `opds_sync/config.py`.** Add `ai_auth_mode`,
+      `ai_token_secrets`, `ai_token_issuer`, `ai_token_audience` as documented in
+      spec §4. Ensure `Literal["basic","token"]` import.
+- [ ] **1.4 Verify:** `uv run pytest tests/unit/test_settings.py -v`.
+
+## Phase 2 — `AiPrincipal` + `BasicAuthAiAuthenticator`
+
+- [ ] **2.1 RED: `tests/unit/test_ai_auth.py::test_principal_shape`.**
+      Construct an `AiPrincipal` directly; assert fields, frozen, hashable
+      (tuple scopes, not list).
+- [ ] **2.2 RED: `test_basic_auth_authenticator_valid`.**
+      Build a `BasicAuthAiAuthenticator` over a stub `CalibreAuthValidator`
+      (in-process httpx MockTransport). Send a valid Basic header on a fake
+      Starlette `Request`; assert returned principal `(subject="alice",
+      tenant_id="local", scopes=(), auth_mode="basic", request_id=None)`.
+- [ ] **2.3 RED: `test_basic_auth_authenticator_missing_header`** → 401.
+- [ ] **2.4 RED: `test_basic_auth_authenticator_invalid_credentials`** → 401.
+- [ ] **2.5 RED: `test_basic_auth_principal_carries_request_id`.**
+      Inside the test: set `request_id_var` via `token = request_id_var.set("rid-123")`,
+      call authenticator, assert `principal.request_id == "rid-123"`.
+      `request_id_var.reset(token)` in teardown.
+- [ ] **2.6 GREEN: create `opds_sync/api/ai_auth.py`.** Implement
+      `AiPrincipal` (frozen dataclass), `AiAuthenticator` (Protocol),
+      `BasicAuthAiAuthenticator`. No token impl yet. `get_ai_principal`
+      dependency that pulls `app.state.ai_authenticator`.
+- [ ] **2.7 Verify:** `uv run pytest tests/unit/test_ai_auth.py -v`.
+
+## Phase 3 — `TokenAiAuthenticator`
+
+- [ ] **3.1 Test helper.** Inside `tests/unit/test_ai_auth.py`, add
+      `_sign_token(claims: dict, *, secret: str, kid: str) -> str` and
+      `_decode_segment(b64: str)` helpers. Wire-format follows spec §3.3.
+- [ ] **3.2 RED: `test_token_valid_claims_returns_principal`.**
+      Build authenticator with `{"k1": "<32B+ secret>"}`, mint a token,
+      assert principal `(subject="acme-user", tenant_id="acme", scopes=("ai:read","ai:write"), auth_mode="token", request_id=None)`.
+- [ ] **3.3 RED: kid rotation** — `test_token_two_kids_old_kid_accepted`.
+      Authenticator built with both `k1` and `k2`; token signed under `k1`;
+      accepted.
+- [ ] **3.4 RED: failure modes** (one test each unless noted). Algorithm /
+      header:
+      - `test_token_alg_none_rejected`.
+      - `test_token_alg_wrong_rejected` (e.g. `HS512`).
+      - `test_token_alg_missing_rejected`.
+      - `test_token_kid_missing_in_header_rejected`.
+      - `test_token_kid_empty_in_header_rejected`.
+      - `test_token_kid_in_payload_rejected`.
+      - `test_token_unknown_kid_rejected`.
+      Time:
+      - `test_token_expired` (`exp = now - 1`).
+      - `test_token_exp_equals_now_rejected` (boundary).
+      - `test_token_iat_too_far_in_future` (`iat = now + 3600`).
+      - `test_token_iat_at_boundary_accepted` (`iat = now + 300`).
+      - `test_token_exp_lte_iat_rejected`.
+      - `test_token_lifetime_over_24h_rejected`.
+      Identity:
+      - `test_token_wrong_iss`.
+      - `test_token_wrong_aud`.
+      Signature integrity:
+      - `test_token_tampered_signature` (flip last byte).
+      - `test_token_tampered_payload` (modify a claim, leave sig).
+      - `test_token_signature_wrong_length_rejected`.
+      Claim validation:
+      - `test_token_missing_sub`, `test_token_missing_tenant_id`,
+        `test_token_missing_iss`, `test_token_missing_aud`,
+        `test_token_missing_exp`, `test_token_missing_iat`.
+      - `test_token_exp_as_string_rejected`.
+      - `test_token_iat_as_bool_rejected`.
+      - `test_token_sub_as_list_rejected`.
+      - `test_token_tenant_id_empty_rejected`.
+      - `test_token_tenant_id_over_128_chars_rejected`.
+      - `test_token_tenant_id_disallowed_chars_rejected` (`"a/b"`, `"a b"`).
+      - `test_token_scope_non_string_rejected`.
+      - `test_token_scope_empty_yields_empty_tuple`.
+      - `test_token_scope_parses_into_tuple`.
+      Wire format:
+      - `test_token_bearer_prefix_missing`.
+      - `test_token_wrong_scheme` (`Authorization: Basic ...`).
+      - `test_token_bearer_extra_tokens_rejected` (`Bearer xxx yyy`).
+      - `test_token_segment_count_wrong_rejected` (2 dots not 3).
+      - `test_token_empty_segment_rejected`.
+      - `test_token_padding_present_rejected` (`=` in any segment).
+      - `test_token_non_base64url_chars_rejected` (`+`, `/`, whitespace).
+      - `test_token_header_array_rejected`.
+      - `test_token_payload_array_rejected`.
+      - `test_token_payload_non_json_rejected`.
+- [ ] **3.5 GREEN: implement `TokenAiAuthenticator` in `ai_auth.py`.**
+      Pure-python HMAC-SHA256 verification per spec §3.3. `hmac.compare_digest`
+      for sig compare. Clock injection via `clock: Callable[[], float] = time.time`
+      constructor kwarg for tests.
+- [ ] **3.6 Verify:** `uv run pytest tests/unit/test_ai_auth.py -v`.
+
+## Phase 4 — Startup validation
+
+- [ ] **4.1 RED: `tests/unit/test_main_ai_auth_validation.py`.** Cases:
+      - token mode + `secrets=None` → `RuntimeError`.
+      - token mode + `secrets={}` → `RuntimeError`.
+      - token mode + secret < 32 bytes → `RuntimeError`.
+      - token mode + non-string secret value → `RuntimeError`.
+      - token mode + empty kid key → `RuntimeError`.
+      - token mode + missing issuer → `RuntimeError`.
+      - token mode + whitespace issuer → `RuntimeError`.
+      - token mode + missing audience → `RuntimeError`.
+      - token mode + whitespace audience → `RuntimeError`.
+      - token mode + all set + AI provider unconfigured → no exception, auth
+        is built, `/ai/v1/config` requires Bearer.
+      - basic mode + missing token settings → no exception.
+      - `ai_enabled=false`, token mode misconfigured → no exception (AI block skipped).
+- [ ] **4.2 GREEN: edit `opds_sync/main.py`.** Add
+      `_validate_ai_auth_settings(settings)` helper. Construct authenticator
+      at the TOP of `if settings.ai_enabled:` block (before either the
+      fully-configured `if` or the unconfigured `elif`). Token mode is
+      respected for `/ai/v1/config` even in the unconfigured branch — no
+      silent downgrade to basic.
+- [ ] **4.3 Verify:** `uv run pytest tests/unit/test_main_ai_auth_validation.py -v`.
+
+## Phase 5 — Wire `ai.py` routes through `AiPrincipal`
+
+- [ ] **5.1 RED: update `tests/integration/test_ai_endpoints.py` fixture.**
+      Augment the integration `client_factory` to override BOTH
+      `current_user_id` AND `get_ai_principal`. The principal override returns
+      a basic-mode `AiPrincipal` built from the same decoded Basic header.
+      Existing assertions should continue to pass once routes consume the
+      principal.
+- [ ] **5.2 GREEN: edit `opds_sync/api/ai.py`.** Replace
+      `user_id: Annotated[str, Depends(current_user_id)]` with
+      `principal: Annotated[AiPrincipal, Depends(get_ai_principal)]` on all
+      routes. Internal helpers (`_require_opt_in`) read `principal.subject`.
+      Three orchestrator call sites: `tenant_id=principal.tenant_id` instead
+      of `tenant_id="local"`. Pass `user_id=principal.subject` so orchestrator
+      semantics are unchanged.
+- [ ] **5.3 Verify:** `uv run pytest tests/integration/test_ai_endpoints.py -v`.
+
+## Phase 6 — Mode-switching integration tests
+
+- [ ] **6.1 RED: `tests/integration/test_ai_auth_modes.py`.** Test scenarios:
+      - `basic` mode rejects `Authorization: Bearer …` requests (401).
+      - `token` mode (configured) rejects `Authorization: Basic …` requests (401).
+      - `token` mode + valid token → 200 on `/ai/v1/config`.
+      - `token` mode + rotation: two kids, token signed under older → 200.
+- [ ] **6.2 GREEN: ensure `client_factory` supports skipping the
+      `get_ai_principal` override when the test wants real token behavior.**
+      Add a `disable_auth_overrides=True` kwarg or similar; the new tests use
+      it. Default behavior (used by existing tests) stays.
+- [ ] **6.3 Verify:** `uv run pytest tests/integration/test_ai_auth_modes.py -v`.
+
+## Phase 7 — Audit-log integration (PR-C cross-check)
+
+- [ ] **7.1 RED: extend `tests/integration/test_ai_audit_log.py` with
+      `test_token_auth_writes_tenant_id_to_log`.** Token-mode app + valid token
+      with `tenant_id="acme"`, `sub="acme:alice"`. Setup must include
+      opting the subject in via `PUT /ai/v1/preferences` (token-auth) or
+      seeding the row before lookup, else the request short-circuits at 409.
+      Perform `/ai/v1/insights/lookup`; query `ai_generation_log`; assert
+      `tenant_id == "acme"` and `subject == "acme:alice"`.
+- [ ] **7.1b RED: `test_token_auth_propagates_request_id_to_log`.**
+      Token-mode app + valid token + explicit `X-Request-ID` header on the
+      lookup call; assert that request_id appears in the audit row.
+- [ ] **7.2 Verify:** `uv run pytest tests/integration/test_ai_audit_log.py -v`.
+
+## Phase 8 — Full suite + mode matrix
+
+- [ ] **8.1 Full suite, default mode.** `cd server && uv run pytest -v`.
+      Confirm no regression vs Phase 0 baseline.
+- [ ] **8.2 Sync-only mode.**
+      `OPDS_SYNC_AI_ENABLED=false uv run pytest -v` — `requires_ai` tests skip.
+- [ ] **8.3 AI-only mode.**
+      `OPDS_SYNC_PROGRESS_ENABLED=false uv run pytest -v` — `requires_progress`
+      tests skip.
+- [ ] **8.4 Cache-key audit test.**
+      `uv run pytest tests/integration/test_cache_key_audit.py -v` — passes
+      unchanged.
+
+## Phase 9 — Commit, push, PR
+
+- [ ] **9.1 Pre-commit hooks.** `cd server && uv run ruff format` then
+      `uv run ruff check .` from the worktree root.
+- [ ] **9.2 Commit.** Conventional commit with gitmoji:
+      `:sparkles: feat(server): AI auth abstraction seam`. **No Claude
+      attribution.**
+- [ ] **9.3 Push.** `git push -u origin feat/ai-auth-abstraction`.
+- [ ] **9.4 PR.** `gh pr create --base main --head feat/ai-auth-abstraction`.
+      Title: `feat(server): AI auth abstraction (seam)`. Body covers summary,
+      what changed, test plan, GPT review summary, "no behavior change in
+      default mode" callout. **No Claude attribution.**

--- a/docs/superpowers/specs/2026-05-16-ai-auth-abstraction-design.md
+++ b/docs/superpowers/specs/2026-05-16-ai-auth-abstraction-design.md
@@ -1,0 +1,532 @@
+# Spec — AI auth abstraction (PR-B)
+
+**Date:** 2026-05-16
+**Branch:** `feat/ai-auth-abstraction`
+**Roadmap reference:** `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §PR-B
+**Status:** Draft for architect review
+
+## 1. Motivation
+
+Today every `/ai/v1/*` route depends on `current_user_id`, which validates a
+Basic-auth header by probing calibre-web. The string returned is then used both
+as a logical "subject" (who triggered the call) and — implicitly — as the only
+identity scope in existence. There is no separate notion of "tenant".
+
+PR-C introduced a `tenant_id` kwarg on `InsightOrchestrator.{get,generate,regenerate}`
+and the API layer currently passes the hardcoded literal `"local"` at three
+call sites. That is the seam this PR formalizes.
+
+To unlock the future hosted "Quire Cloud AI" mode (AI-only deploy, multi-tenant)
+without forcing a rewrite of the request path, we need:
+
+1. A typed `AiPrincipal` that bundles `(subject, tenant_id, scopes, auth_mode, request_id)` —
+   the same shape under Basic-auth (single-tenant) and HMAC tokens (multi-tenant).
+2. A pluggable `AiAuthenticator` protocol so the same routes work in both modes.
+3. A FastAPI dependency `get_ai_principal` that picks the implementation off
+   the `OPDS_SYNC_AI_AUTH_MODE` setting.
+4. Two implementations: `BasicAuthAiAuthenticator` (wraps today's calibre-web
+   verifier) and `TokenAiAuthenticator` (HMAC-SHA256 over canonical claims,
+   stub — not wired by default).
+5. `kid` rotation from day one (a JSON map `{kid: secret}` lets us mint under
+   the newest secret while still validating tokens signed under any active
+   secret).
+
+This PR is a **seam-only** change. It does not introduce a token-issuance
+endpoint. It does not change behavior for the default `basic` deploy. Sync
+routes are untouched.
+
+## 2. Non-goals
+
+- A `POST /ai/v1/token` endpoint or any other token issuance flow.
+- JWT support — HMAC-SHA256 is sufficient for the hosted single-issuer case.
+  JWT can come later when third-party IdPs need to mint our tokens.
+- Per-tenant rate limiting / quota enforcement (the existing per-user budget
+  stays exactly as today).
+- Changes to sync routes (`/sync/v1/*`).
+- Multi-tenant data storage changes (PR-C's cache-integrity invariant remains
+  the rule; this PR only changes the call-site that supplied the literal
+  `"local"`).
+
+## 3. Data shapes
+
+### 3.1 `AiPrincipal`
+
+```python
+@dataclass(frozen=True, slots=True)
+class AiPrincipal:
+    subject: str          # user id (basic) or token `sub` claim
+    tenant_id: str        # "local" under basic; token `tenant_id` claim otherwise
+    scopes: tuple[str, ...]  # e.g. ("ai:read", "ai:write"); empty in basic mode for now
+    auth_mode: Literal["basic", "token"]
+    request_id: str | None   # read from request_id_var ContextVar at construction
+```
+
+Implementation detail: a frozen dataclass over a Pydantic model. The principal
+is constructed once per request inside the auth dependency, then read-only.
+Pydantic adds field-coercion overhead with no validation upside (the inputs
+come from validated sources or are constants).
+
+`scopes` is a tuple so the dataclass remains hashable. We keep it as an empty
+tuple under `basic` mode; the token verifier can populate it from a `scope`
+claim later. This PR does not consume `scopes` in any route — but it must
+exist on the type so the future expansion is non-breaking.
+
+### 3.2 `AiAuthenticator` protocol
+
+```python
+class AiAuthenticator(Protocol):
+    async def authenticate(self, request: Request) -> AiPrincipal: ...
+```
+
+One method. Implementations are responsible for reading whatever headers they
+care about, raising `HTTPException(401)` on failure, and returning a fully
+populated `AiPrincipal` on success.
+
+### 3.3 Token claims (HMAC-SHA256)
+
+**Header** (JSON, URL-safe base64-encoded, no `=` padding):
+
+| Field | Type   | Required | Notes |
+|-------|--------|----------|-------|
+| `alg` | string | yes      | Must equal `"HS256"` exactly. Any other value (including `"none"`) → 401. |
+| `kid` | string | yes      | Key id. Resolved against `ai_token_secrets`. Header-only — must NOT appear in payload. |
+
+**Payload claims** (JSON, URL-safe base64-encoded, no `=` padding):
+
+| Claim       | Type   | Required | Notes                                                 |
+|-------------|--------|----------|-------------------------------------------------------|
+| `iss`       | string | yes      | Issuer; must equal `OPDS_SYNC_AI_TOKEN_ISSUER`.       |
+| `aud`       | string | yes      | Audience; must equal `OPDS_SYNC_AI_TOKEN_AUDIENCE`.   |
+| `exp`       | int    | yes      | Unix epoch seconds. Token rejected if `now >= exp`.   |
+| `iat`       | int    | yes      | Unix epoch seconds. Rejected if more than 5 min in future. Also rejected if `exp <= iat`. Max lifetime `exp - iat <= 24h` (hard cap; prevents accidentally-eternal tokens since this PR has no replay protection). |
+| `sub`       | string | yes      | Non-empty bounded string (max 128 chars), regex `[A-Za-z0-9._:@-]+`. Becomes `AiPrincipal.subject`. |
+| `tenant_id` | string | yes      | Non-empty bounded string (max 128 chars), regex `[A-Za-z0-9._:-]+`. Becomes `AiPrincipal.tenant_id`. |
+| `scope`     | string | no       | Space-separated tokens. Parsed into `scopes` tuple; empty/missing → empty tuple. Non-string `scope` → 401. |
+
+**`sub` namespacing invariant**: The token `sub` claim MUST be globally
+unique under the issuer (e.g. tenant-qualified at issuance: `acme:alice`).
+The server stores `principal.subject` directly into `user_ai_preferences.user_id`,
+`ai_usage_daily.user_id`, and `ai_generation_log.subject`. Two tenants with
+overlapping `sub` values (e.g. both have `sub=alice`) would collide on
+preferences and quotas. This is an issuer responsibility, not a server-side
+one: the server does not concatenate `tenant_id` into the storage subject
+because that would break per-user preference continuity if a user's tenant
+ever changes. Documented in the env var help.
+
+**Wire format** (compact, similar to JWT but HMAC-only):
+`header.payload.signature`, each segment URL-safe base64 (`-`/`_` substitutes,
+no `=` padding). Header is `{"alg":"HS256","kid":"<kid>"}`. Payload is the
+JSON-encoded claim object. Signature is HMAC-SHA256 (32 raw bytes) over the
+ASCII string `<header_b64>.<payload_b64>`, then URL-safe base64-encoded.
+
+**Strict canonicalization**:
+- All three segments URL-safe base64. No `=` padding character allowed in
+  any segment (rejected even if the decode would otherwise succeed).
+- No non-base64url characters (`+`, `/`, whitespace) allowed.
+- All three segments must be non-empty.
+- Exactly two `.` separators (three segments). Any other count → 401.
+- Decoded signature must be exactly 32 bytes (the HMAC-SHA256 output size);
+  shorter or longer → 401.
+
+**Verification order (and corresponding failure reason for the structured log)**:
+1. Parse `Authorization: Bearer <token>`. Missing scheme, wrong scheme,
+   extra whitespace, or trailing tokens → 401 (`malformed_authorization`).
+2. Split into three non-empty segments. Wrong count → 401 (`malformed_token`).
+3. Strict-base64-decode header. Non-base64url, padded, or non-JSON → 401
+   (`malformed_header`).
+4. Header MUST have exactly `alg` and `kid` keys (extras tolerated but
+   logged). `alg != "HS256"` → 401 (`bad_alg`).
+5. Missing/empty/non-string `kid` → 401 (`missing_kid`).
+6. Resolve `kid` against `ai_token_secrets`. Unknown → 401 (`unknown_kid`).
+7. Strict-base64-decode signature. Wrong length (not 32 bytes) → 401
+   (`bad_signature`).
+8. Recompute HMAC over `<header_b64>.<payload_b64>` using the resolved
+   secret. Compare via `hmac.compare_digest`. Mismatch → 401 (`bad_signature`).
+9. Strict-base64-decode payload. Non-JSON or non-object → 401 (`malformed_payload`).
+10. Reject if payload contains a `kid` claim (header-only). → 401 (`kid_in_payload`).
+11. Validate types:
+    - `iss`, `aud`: strings.
+    - `exp`, `iat`: `int` (not `bool`; Python's `isinstance(True, int)` is
+      true, so check `type(x) is int` or `isinstance(x, int) and not isinstance(x, bool)`).
+    - `sub`, `tenant_id`: non-empty strings matching the regex.
+    - `scope` (if present): string.
+12. Check `iss == expected_issuer`. Mismatch → 401 (`bad_issuer`).
+13. Check `aud == expected_audience`. Mismatch → 401 (`bad_audience`).
+14. Check `exp > now`. Failure → 401 (`expired`).
+15. Check `iat <= now + 300`. Failure → 401 (`iat_in_future`).
+16. Check `exp > iat` and `exp - iat <= 86_400`. Failure → 401 (`bad_lifetime`).
+17. Build principal. `scopes` = `tuple(s for s in scope.split(" ") if s)` if
+    `scope` present else `()`.
+
+All failures return identical `401 Unauthorized` to the client. The failure
+reason appears only in the structured log line (key: `auth_failure_reason`).
+Principle: never leak validation internals to an unauthenticated caller.
+
+#### 3.3.1 `kid` rotation
+
+`ai_token_secrets` is a JSON object env var like `{"k1":"<32+ bytes>","k2":"<32+ bytes>"}`.
+Verification picks the secret whose `kid` matches the token's header. Both
+keys are simultaneously valid for verification; rotation is "add the new key,
+let old tokens expire, remove the old key". No issuance endpoint in this PR
+means there's nothing to "switch to the new key for minting" — that's the
+issuer's job whenever that PR happens.
+
+Minimum secret length enforced at startup: 32 UTF-8 bytes (a 256-bit random
+secret is the recommended floor; SHA-256's own block size is 64 bytes but
+HMAC accepts arbitrary-length keys, so 32 bytes is a policy choice, not a
+crypto requirement). Shorter secrets are a configuration error. Whitespace-
+only secrets technically pass the length check; this is the operator's
+problem, not the server's (32 random bytes is documented).
+
+### 3.4 `get_ai_principal` dependency
+
+```python
+async def get_ai_principal(
+    request: Request,
+    authenticator: Annotated[AiAuthenticator, Depends(get_ai_authenticator)],
+) -> AiPrincipal:
+    return await authenticator.authenticate(request)
+```
+
+`get_ai_authenticator` is a transitive dependency that returns the singleton
+authenticator instance stored on `app.state.ai_authenticator` (constructed
+once at startup based on `ai_auth_mode`).
+
+## 4. Settings
+
+Two new fields on `Settings` in `config.py`:
+
+```python
+# AI authentication mode for /ai/v1/*. Sync routes are unaffected.
+ai_auth_mode: Literal["basic", "token"] = "basic"
+
+# JSON map of kid → secret (UTF-8 string). Required when ai_auth_mode == "token".
+# Token issuance happens elsewhere (future PR); this server only verifies.
+# Multiple kids enable rotation: tokens signed under any listed kid are
+# accepted. Add the new kid, let old tokens expire, then remove the old kid.
+ai_token_secrets: dict[str, str] | None = None
+
+# Required when ai_auth_mode == "token". Validated against the token's iss
+# claim.
+ai_token_issuer: str | None = None
+
+# Required when ai_auth_mode == "token". Validated against the token's aud
+# claim.
+ai_token_audience: str | None = None
+```
+
+`ai_token_secrets` is parsed from a JSON string env var via Pydantic's
+built-in JSON-string handling (Pydantic v2 auto-parses JSON for dict fields
+when the env value starts with `{`).
+
+### 4.1 Startup validation
+
+`main.py::create_app()` calls a `_validate_ai_auth_settings(settings)` helper
+right after the AI router branch decides to mount. The helper:
+
+- If `ai_auth_mode == "basic"`: no-op (today's behavior).
+- If `ai_auth_mode == "token"`:
+  - `ai_token_secrets` must be a non-empty dict. Empty / `None` → raise
+    `RuntimeError` with a clear message ("token mode requires
+    `OPDS_SYNC_AI_TOKEN_SECRETS` to be a non-empty JSON object").
+  - Every secret value must be at least 32 bytes when encoded as UTF-8.
+    Short secret → raise `RuntimeError`.
+  - `ai_token_issuer` and `ai_token_audience` must both be set. Missing →
+    raise `RuntimeError`.
+
+This is the "fail startup loudly" requirement. The error happens during
+`create_app`, which means k8s rolling deploys catch it via crash-loop —
+no silently-accepting-everything failure mode is possible.
+
+If `ai_enabled` is `false` the entire AI block is skipped, so auth mode
+is also not validated. Sync-only deploys are unaffected.
+
+## 5. Wiring
+
+### 5.1 `opds_sync/api/ai_auth.py` (new)
+
+Module structure:
+
+```
+ai_auth.py
+├── AiPrincipal           (frozen dataclass)
+├── AiAuthenticator       (Protocol)
+├── BasicAuthAiAuthenticator
+│       ├── __init__(validator: CalibreAuthValidator)
+│       └── authenticate(request) -> AiPrincipal
+├── TokenAiAuthenticator
+│       ├── __init__(secrets, issuer, audience, clock=time.time)
+│       └── authenticate(request) -> AiPrincipal
+└── get_ai_principal      (FastAPI dependency)
+    get_ai_authenticator  (depends on app.state.ai_authenticator)
+```
+
+`BasicAuthAiAuthenticator` does:
+1. Read `Authorization` header. Missing → 401.
+2. Delegate to the existing `CalibreAuthValidator.validate()` to verify and
+   extract `user_id` (lowercased CWA username).
+3. Construct `AiPrincipal(subject=user_id, tenant_id="local", scopes=(),
+   auth_mode="basic", request_id=request_id_var.get() or None)`.
+
+`request_id_var.get()` returns the empty string when unset (per PR-A's
+default). We coerce to `None` for the principal so consumers don't have to
+guard `if request_id and ...`.
+
+`TokenAiAuthenticator` reads `Authorization: Bearer <token>`, runs the
+verification algorithm from §3.3, and builds the principal from the verified
+claims. The same `request_id_var` coercion applies.
+
+### 5.2 `opds_sync/api/ai.py` (changes)
+
+All endpoints currently depending on `current_user_id` switch to depending on
+`AiPrincipal`. The three `tenant_id="local"` literals at the orchestrator call
+sites become `principal.tenant_id`. The `user_id` kwarg to the orchestrator
+stays — internally it's the `subject`, and we pass `principal.subject`.
+
+Internal helpers like `_require_opt_in(session, user_id)` keep their
+signatures: they consume `principal.subject` at call time.
+
+### 5.3 `main.py::create_app()` (changes)
+
+The authenticator is built **once per `create_app()`** at the top of the AI
+branch — applies to both the fully-configured `if` branch AND the "AI
+enabled but provider unconfigured" `elif` branch. There is no scenario where
+the AI router is mounted without an authenticator, and there is no
+scenario where `ai_auth_mode=token` silently downgrades to basic.
+
+```python
+from opds_sync.api.ai_auth import (
+    BasicAuthAiAuthenticator,
+    TokenAiAuthenticator,
+)
+
+if settings.ai_enabled:
+    # Validates and raises on any token-mode misconfiguration BEFORE any
+    # AI router could mount. Sync-only deploys (ai_enabled=false) skip
+    # this entirely.
+    _validate_ai_auth_settings(settings)
+
+    if settings.ai_auth_mode == "basic":
+        app.state.ai_authenticator = BasicAuthAiAuthenticator(
+            validator=app.state.auth_validator
+        )
+    else:  # "token"
+        app.state.ai_authenticator = TokenAiAuthenticator(
+            secrets=settings.ai_token_secrets,
+            issuer=settings.ai_token_issuer,
+            audience=settings.ai_token_audience,
+        )
+
+    if settings.ai_base_url and settings.ai_model:
+        # full AI wiring (orchestrator + router) — see existing code
+        ...
+    else:
+        # AI enabled but unconfigured: still mount the router for /config.
+        # Auth mode is whatever the operator set; token-mode /config calls
+        # require valid Bearer tokens. This is intentional — half-configured
+        # token deploys MUST require tokens, not fall back to Basic.
+        from opds_sync.api.ai import router as ai_router
+        app.include_router(ai_router, prefix="/ai/v1")
+```
+
+**Important behavior**: if `ai_auth_mode=token` and provider is unconfigured,
+`/ai/v1/config` still requires a valid Bearer token. This is intentional —
+the operator chose token mode, so `/config` must respect it. The previous
+draft had this wrong (it forced basic in the elif branch); that would have
+been a silent security regression.
+
+### 5.4 Sync routes — unchanged
+
+`/sync/v1/*` continues to depend on `current_user_id` (and `CalibreWebUser` /
+`CalibreAuthValidator`). The `AiPrincipal` type lives in `opds_sync.api.ai_auth`
+and is not imported anywhere outside the AI module surface.
+
+## 6. Cache-hit attribution under token auth
+
+PR-C writes `ai_generation_log` rows whose `tenant_id` comes from the
+orchestrator's kwarg. With this PR:
+
+- Default `basic` mode: `principal.tenant_id == "local"`, log rows carry
+  `"local"` (identical to today).
+- `token` mode: `principal.tenant_id` is whatever the token's `tenant_id`
+  claim says. Log rows carry the real tenant.
+
+The shared cache row (`book_insights`) is still tenant-blind. Multiple tenants
+hitting the same identity still produce one `book_insights` row plus per-call
+`ai_generation_log` rows tagged with each tenant's id. This is exactly what
+PR-C designed for.
+
+Tests assert this end-to-end: a token-auth call writes the `ai_generation_log`
+row with the token's claimed `tenant_id`, not `"local"`.
+
+## 7. Tests
+
+### 7.1 Unit (`server/tests/unit/test_ai_auth.py`, new)
+
+**`BasicAuthAiAuthenticator`**:
+- Valid credential → `AiPrincipal(subject="alice", tenant_id="local", scopes=(), auth_mode="basic", request_id=None)`.
+- Valid credential with request_id_var set → `request_id` matches.
+- Missing `Authorization` header → `HTTPException(401)`.
+- Invalid credential → `HTTPException(401)`.
+- The principal's `request_id` is `None` (not `""`) when the contextvar is at default.
+
+**`TokenAiAuthenticator`** (one test each unless noted):
+- Valid token, single kid → correct principal.
+- Valid token, two kids registered, signed under newer → accepted.
+- Valid token, two kids registered, signed under older → accepted (rotation).
+- `alg != "HS256"` (e.g. `"none"`, `"HS512"`) → 401.
+- `alg` missing → 401.
+- `kid` missing in header → 401.
+- `kid` empty string in header → 401.
+- `kid` present in payload (forbidden) → 401.
+- Unknown `kid` → 401.
+- Expired token (`exp < now`) → 401.
+- `exp == now` → 401 (boundary).
+- `iat` more than 5 min in future → 401.
+- `iat == now + 300` → accepted (boundary).
+- `exp <= iat` → 401.
+- `exp - iat > 86400` → 401 (max lifetime cap).
+- Wrong `iss` → 401.
+- Wrong `aud` → 401.
+- Tampered signature (flip last byte) → 401.
+- Tampered payload (modify a claim, keep sig) → 401.
+- Missing required claim: `sub`, `tenant_id`, `iss`, `aud`, `exp`, `iat` — one
+  test per claim → 401.
+- Wrong claim type: `exp` as string, `iat` as bool, `sub` as list, `tenant_id`
+  as empty string, `tenant_id` over 128 chars, `tenant_id` with disallowed
+  chars (`"a/b"`, `"a b"`) — one test per case → 401.
+- `scope` as non-string → 401.
+- `scope` empty / missing → principal `scopes == ()`.
+- `scope = "ai:read ai:write"` → `scopes == ("ai:read", "ai:write")`.
+- Bearer prefix missing → 401.
+- Wrong scheme (`Basic …`) → 401.
+- `Bearer` with extra trailing tokens (`Bearer xxx yyy`) → 401.
+- Wrong segment count (2 dots not 3) → 401.
+- Empty segment in token → 401.
+- `=` padding present in any segment → 401.
+- Non-base64url chars (`+`, `/`, whitespace) in a segment → 401.
+- Signature segment decodes to ≠ 32 bytes → 401.
+- Header is JSON array (not object) → 401.
+- Payload is JSON array (not object) → 401.
+- Payload non-JSON → 401.
+- Unicode `tenant_id` containing control chars → 401 (regex blocks).
+
+The HMAC signing helper for tests lives in the test module itself
+(`_sign_token(claims, *, secret, kid, alg="HS256", payload_kid=None)` — the
+`alg` and `payload_kid` kwargs let tests construct malformed tokens). We
+deliberately do NOT ship a production minter — issuance is out of scope.
+
+### 7.2 Unit (`server/tests/unit/test_settings.py`, additions)
+
+- `test_ai_auth_mode_defaults_to_basic`.
+- `test_ai_token_secrets_parses_json_object`.
+- Token-mode startup validation (in a dedicated `test_main_ai_auth_validation.py`):
+  - `ai_auth_mode=token`, secrets `None` → `RuntimeError` from `create_app()`.
+  - `ai_auth_mode=token`, secrets `{}` (empty dict) → `RuntimeError`.
+  - `ai_auth_mode=token`, malformed JSON in env var → Pydantic raises at
+    `Settings()` construction (validated separately in test_settings).
+  - `ai_auth_mode=token`, secrets JSON-decodes to a non-object (e.g. `[]`)
+    → Pydantic raises (dict-typed field).
+  - `ai_auth_mode=token`, secret value < 32 UTF-8 bytes → `RuntimeError`.
+  - `ai_auth_mode=token`, secret value is non-string → `RuntimeError`.
+  - `ai_auth_mode=token`, secret key (`kid`) is empty string → `RuntimeError`.
+  - `ai_auth_mode=token`, issuer missing → `RuntimeError`.
+  - `ai_auth_mode=token`, issuer is whitespace-only → `RuntimeError`.
+  - `ai_auth_mode=token`, audience missing → `RuntimeError`.
+  - `ai_auth_mode=token`, audience is whitespace-only → `RuntimeError`.
+  - `ai_auth_mode=token`, all set + AI provider not configured → no exception
+    (auth is built; router mounts for `/config` only; `/config` requires
+    valid Bearer).
+  - `ai_auth_mode=basic` → no exception regardless of token settings.
+  - `ai_enabled=false`, `ai_auth_mode=token`, secrets missing → no exception
+    (the AI block is skipped entirely).
+
+### 7.3 Integration (`server/tests/integration/test_ai_auth_modes.py`, new)
+
+Three scenarios, each spinning up a fresh app via `client_factory` with the
+matching env vars:
+
+- `basic` mode rejects token-style requests: `Authorization: Bearer <whatever>` → 401.
+- `token` mode rejects basic-style requests: `Authorization: Basic <base64>` → 401.
+- `token` mode with a freshly-signed token + correct claims → 200 on
+  `/ai/v1/config`.
+- `token` mode with two kids registered, request signed under the older kid
+  → 200. Demonstrates rotation.
+
+### 7.4 Integration (`server/tests/integration/test_ai_audit_log.py`, additions)
+
+Augment the existing PR-C audit-log integration test:
+
+- `test_token_auth_writes_tenant_id_to_log`: token-mode app + valid token
+  with `tenant_id="acme"`, `sub="acme:alice"`. **Setup:** the token-auth flow
+  must opt the subject in via `PUT /ai/v1/preferences` (or seed a
+  `UserAIPreference` row directly) before `/insights/lookup`, otherwise the
+  lookup short-circuits at 409 (`not_opted_in`) before any
+  `ai_generation_log` row is written. The opt-in itself is a token-auth call
+  too. Then perform `/ai/v1/insights/lookup`; assert the
+  `ai_generation_log` row's `tenant_id == "acme"` and `subject == "acme:alice"`.
+- `test_token_auth_propagates_request_id_to_log`: token-mode app + valid
+  token + explicit `X-Request-ID: rid-test-1` on the request. Assert the
+  `ai_generation_log` row's `request_id == "rid-test-1"`. This locks in
+  that PR-C's ContextVar-at-log-write-time reading actually picks up the
+  request id middleware set.
+
+This is the load-bearing assertion that PR-C's plumbing actually receives
+the PR-B principal's tenant.
+
+### 7.5 Cache-key audit test
+
+PR-C's `tests/integration/test_cache_key_audit.py` continues to pass
+unchanged. This PR adds no shared-cache tables.
+
+### 7.6 Mode-matrix coverage
+
+All new tests use `pytest.mark.requires_ai`. They skip cleanly in sync-only
+mode and run in full + ai-only modes. No `requires_progress` tests added.
+
+## 8. Risks and mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Token verification leaks timing info that distinguishes "bad signature" from "unknown kid". | All 401 responses are identical; only logs differentiate. `hmac.compare_digest` on the signature compare. |
+| Operator misconfigures token mode (forgets secret, short secret) and ships a permissive deployment. | Startup validation raises; pod crashloops; this is the loudest possible failure. |
+| Existing integration tests rely on `app.dependency_overrides[current_user_id]`. | Tests that mock auth still need to override `current_user_id` for the basic path AND, separately, may need to override `get_ai_principal` once AI routes use it. We update the existing `client_factory` fixture to override BOTH dependencies so token-style tests can opt-in by skipping the override. |
+| `request_id_var` contextvar default `""` becomes `None` in the principal. | Test it explicitly; downstream consumers (logs, audit) check for truthy. |
+| Adding `Literal["basic","token"]` to `Settings` may not parse correctly under Pydantic v2. | Pydantic v2 handles literals natively; smoke-test in unit. |
+| HMAC token replay (same valid token used twice). | Out of scope: HMAC has no nonce. Replay protection belongs to the issuer (short `exp`, optional `jti` + Redis denylist) and is a future PR. Document. |
+| Empty / whitespace-only secrets pass the length check via UTF-8 multi-byte chars. | The check is on `len(secret.encode("utf-8")) >= 32`. A pathological secret with 32 whitespace bytes is still 32 bytes by the standard. We accept this — it's the operator's job to use a random secret, not the server's job to validate randomness. |
+| `kid` collision between issuer and verifier when rotating. | Use distinct `kid` values per secret (UUID or year-numbered); document this in the env var help. |
+| `sub` collision across tenants (e.g. tenant `acme` and tenant `beta` both have `sub=alice`). | Issuer responsibility: `sub` must be globally unique under the issuer (e.g. tenant-qualified at issuance, `acme:alice`). Documented in spec §3.3 and env var help; server does not enforce. |
+| Background task reuses an `AiPrincipal` after the request context resets. | `principal.request_id` is captured at construction; PR-C reads `request_id_var` at log-write time, which would be empty in a background task. Background work must explicitly bind the ContextVar (`request_id_var.set(principal.request_id or "")`) or pass the id directly. Documented in code comment on `AiPrincipal`. PR-B does not currently spawn background tasks from the API layer, so this is forward-looking. |
+| `alg=none` HMAC bypass / algorithm confusion. | Explicit `alg == "HS256"` check is the first thing after header decode (verification step 4). Tested. |
+
+## 9. Acceptance checklist
+
+- [ ] `opds_sync/api/ai_auth.py` exists with `AiPrincipal`, `AiAuthenticator`,
+      `BasicAuthAiAuthenticator`, `TokenAiAuthenticator`, `get_ai_principal`.
+- [ ] `opds_sync/config.py` gains `ai_auth_mode`, `ai_token_secrets`,
+      `ai_token_issuer`, `ai_token_audience`.
+- [ ] `opds_sync/main.py::create_app()` validates token-mode settings, builds
+      the authenticator, and stores it on `app.state.ai_authenticator`.
+- [ ] `opds_sync/api/ai.py` routes depend on `AiPrincipal` instead of
+      `current_user_id`. The three `tenant_id="local"` literals become
+      `principal.tenant_id`.
+- [ ] Sync routes unchanged (grep `/sync/v1` for `AiPrincipal` → empty).
+- [ ] Tests pass under all three mode-matrix combinations.
+- [ ] Cache-key audit test still passes (no new shared-cache columns).
+- [ ] `requires_ai` tests skip in sync-only mode.
+- [ ] Spec + plan committed.
+- [ ] PR body documents: default mode = `basic` = no behavior change; token
+      mode is a stub with no issuance endpoint; `kid` rotation supported
+      from day one.
+
+## 10. Out of scope (explicit)
+
+- Token issuance endpoint (`POST /ai/v1/token`) — future PR.
+- JWT (RS256/EdDSA/etc.) — future PR if/when third-party IdPs need to mint.
+- Replay protection / `jti` denylist — future PR.
+- Per-tenant rate limiting / quota — future PR.
+- Android changes — none. The hosted client will need a token; that's a
+  Quire Cloud AI app concern, not the open-source app.
+- Documentation refresh for `docs/sync-api.md` — handled by the batch's
+  closing doc-review step.

--- a/server/opds_sync/api/ai.py
+++ b/server/opds_sync/api/ai.py
@@ -1,4 +1,12 @@
-"""/ai/v1/* endpoints. Auth = same Basic-auth proxy as /sync/v1."""
+"""/ai/v1/* endpoints.
+
+Auth flows through `AiPrincipal` (PR-B). Default deploy: basic-auth wrapper
+around the calibre-web verifier; `principal.tenant_id == "local"`. Hosted
+deploys: HMAC-token verifier; `principal.tenant_id` carries the tenant claim.
+
+Sync routes (`/sync/v1/*`) keep depending on `current_user_id` directly —
+this seam only swings on `/ai/v1/*`.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from opds_sync.api.ai_auth import AiPrincipal, get_ai_principal
 from opds_sync.api.ai_schemas import (
     AiStyle,
     BookInsightResponse,
@@ -24,7 +33,6 @@ from opds_sync.api.ai_schemas import (
 )
 from opds_sync.config import get_settings
 from opds_sync.core.ai.service import InsightOrchestrator, QuotaExceeded
-from opds_sync.core.auth import current_user_id
 from opds_sync.db.models import UserAIPreference
 from opds_sync.db.session import get_session
 
@@ -87,10 +95,11 @@ def _quota_http_exception(exc: QuotaExceeded) -> HTTPException:
 
 @router.get("/config", response_model=ConfigResponse)
 async def get_config(
-    user_id: Annotated[str, Depends(current_user_id)],
+    principal: Annotated[AiPrincipal, Depends(get_ai_principal)],
 ) -> ConfigResponse:
     """Public to authed users; the app needs this to render the AI toggle."""
     settings = get_settings()
+    _ = principal  # auth gate only; config is non-personalized.
     return ConfigResponse(
         configured=bool(settings.ai_enabled and settings.ai_base_url and settings.ai_model),
         base_url_host=_base_url_host() if settings.ai_enabled else None,
@@ -103,11 +112,13 @@ async def get_config(
 
 @router.get("/preferences", response_model=PreferencesResponse)
 async def get_preferences(
-    user_id: Annotated[str, Depends(current_user_id)],
+    principal: Annotated[AiPrincipal, Depends(get_ai_principal)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> PreferencesResponse:
     pref = (
-        await session.execute(select(UserAIPreference).where(UserAIPreference.user_id == user_id))
+        await session.execute(
+            select(UserAIPreference).where(UserAIPreference.user_id == principal.subject)
+        )
     ).scalar_one_or_none()
     if pref is None:
         return PreferencesResponse(ai_enabled=False, style=AiStyle())
@@ -120,15 +131,17 @@ async def get_preferences(
 @router.put("/preferences", response_model=PreferencesResponse)
 async def put_preferences(
     body: PreferencesBody,
-    user_id: Annotated[str, Depends(current_user_id)],
+    principal: Annotated[AiPrincipal, Depends(get_ai_principal)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> PreferencesResponse:
     pref = (
-        await session.execute(select(UserAIPreference).where(UserAIPreference.user_id == user_id))
+        await session.execute(
+            select(UserAIPreference).where(UserAIPreference.user_id == principal.subject)
+        )
     ).scalar_one_or_none()
     if pref is None:
         pref = UserAIPreference(
-            user_id=user_id,
+            user_id=principal.subject,
             ai_enabled=body.ai_enabled if body.ai_enabled is not None else False,
             style=body.style.model_dump() if body.style else None,
         )
@@ -150,21 +163,21 @@ async def put_preferences(
 async def lookup_insight(
     request: Request,
     body: InsightLookupBody,
-    user_id: Annotated[str, Depends(current_user_id)],
+    principal: Annotated[AiPrincipal, Depends(get_ai_principal)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> BookInsightResponse:
     orch = _orchestrator(request)
     if orch is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="ai_disabled")
-    pref = await _require_opt_in(session, user_id)
+    pref = await _require_opt_in(session, principal.subject)
     try:
         return await orch.generate(
             session,
             body.identity,
             body.bundle,
-            user_id=user_id,
+            user_id=principal.subject,
             style=_style_from_pref(pref),
-            tenant_id="local",
+            tenant_id=principal.tenant_id,
         )
     except QuotaExceeded as exc:
         raise _quota_http_exception(exc) from exc
@@ -174,7 +187,7 @@ async def lookup_insight(
 async def regenerate_insight(
     request: Request,
     body: InsightRegenerateBody,
-    user_id: Annotated[str, Depends(current_user_id)],
+    principal: Annotated[AiPrincipal, Depends(get_ai_principal)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> BookInsightResponse:
     """Mark the existing live row as superseded and generate a fresh one
@@ -182,16 +195,16 @@ async def regenerate_insight(
     orch = _orchestrator(request)
     if orch is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="ai_disabled")
-    pref = await _require_opt_in(session, user_id)
+    pref = await _require_opt_in(session, principal.subject)
     try:
         return await orch.regenerate(
             session,
             body.identity,
             body.bundle,
-            user_id=user_id,
+            user_id=principal.subject,
             reason=body.reason,
             style=_style_from_pref(pref),
-            tenant_id="local",
+            tenant_id=principal.tenant_id,
         )
     except QuotaExceeded as exc:
         raise _quota_http_exception(exc) from exc
@@ -201,17 +214,25 @@ async def regenerate_insight(
 async def get_insight(
     request: Request,
     body: InsightGetBody,
-    user_id: Annotated[str, Depends(current_user_id)],
+    principal: Annotated[AiPrincipal, Depends(get_ai_principal)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> BookInsightResponse:
     orch = _orchestrator(request)
     if orch is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="ai_disabled")
     pref = (
-        await session.execute(select(UserAIPreference).where(UserAIPreference.user_id == user_id))
+        await session.execute(
+            select(UserAIPreference).where(UserAIPreference.user_id == principal.subject)
+        )
     ).scalar_one_or_none()
     style = _style_from_pref(pref) if pref is not None else AiStyle()
-    out = await orch.get(session, body.identity, user_id=user_id, style=style, tenant_id="local")
+    out = await orch.get(
+        session,
+        body.identity,
+        user_id=principal.subject,
+        style=style,
+        tenant_id=principal.tenant_id,
+    )
     if out is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="not_cached")
     return out
@@ -221,12 +242,12 @@ async def get_insight(
 async def invalidate_insight(
     request: Request,
     body: InsightInvalidateBody,
-    user_id: Annotated[str, Depends(current_user_id)],
+    principal: Annotated[AiPrincipal, Depends(get_ai_principal)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> dict:
     orch = _orchestrator(request)
     if orch is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="ai_disabled")
-    await _require_opt_in(session, user_id)
+    await _require_opt_in(session, principal.subject)
     n = await orch.invalidate(session, body.identity)
     return {"deleted": n}

--- a/server/opds_sync/api/ai_auth.py
+++ b/server/opds_sync/api/ai_auth.py
@@ -1,0 +1,390 @@
+"""AI auth abstraction (PR-B seam).
+
+The /ai/v1/* routes used to depend on `current_user_id`, a Basic-auth proxy
+to calibre-web. That works for single-tenant deployments (the F-Droid app
+case) but assumes the entire concept of "tenant" is the string "local".
+
+This module introduces:
+
+* `AiPrincipal`  – frozen dataclass bundling (subject, tenant_id, scopes,
+                   auth_mode, request_id). Stored once per request.
+* `AiAuthenticator`  – one-method Protocol the routes depend on (via
+                       `get_ai_principal`).
+* `BasicAuthAiAuthenticator`  – wraps `CalibreAuthValidator`. Today's default.
+                                Emits tenant_id="local", auth_mode="basic".
+* `TokenAiAuthenticator`  – HMAC-SHA256 verifier. Stub for the hosted future;
+                            never wired by default. `kid` rotation supported
+                            from day one via a JSON `{kid: secret}` map.
+
+Sync routes (`/sync/v1/*`) keep depending on `current_user_id` directly.
+The seam only swings on `/ai/v1/*`.
+
+Cache-integrity invariant (PR-C): `book_insights`, `book_themes`,
+`external_source_cache`, and `insight_identity_aliases` are SHARED cache and
+MUST NOT carry user/tenant columns. `AiPrincipal.tenant_id` flows ONLY into
+`ai_generation_log` (per-call audit) — never into a cache row's keying.
+
+Token verification mirrors a stripped-down JWT/HS256 with strict
+canonicalization (no `=` padding, no algorithm confusion, no claim type
+laxity). Verification failures all collapse to a single 401 with no
+discriminating detail in the response — failure reasons live in structured
+logs only. The principle: never leak validation internals to an
+unauthenticated caller.
+
+Background-task caveat: `principal.request_id` is captured when the
+authenticator builds the principal during dependency resolution (i.e. inside
+the request context, AFTER `RequestIDMiddleware` set the ContextVar). PR-C's
+audit logger reads `request_id_var` at log-write time, so background work
+that reuses a principal AFTER the request context unwinds needs to either
+pass `principal.request_id` explicitly or re-bind the ContextVar around the
+task. The API layer does not spawn such tasks today; this is forward-looking.
+"""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Annotated, Literal, Protocol
+
+from fastapi import Depends, HTTPException, Request, status
+
+from opds_sync.core.auth import CalibreAuthValidator
+from opds_sync.core.logging_ctx import request_id_var
+
+logger = logging.getLogger(__name__)
+
+
+# Subject / tenant_id format guards. Tight enough to keep storage keys
+# predictable, lax enough to accept tenant-qualified subjects like
+# "acme:alice". Both share length cap 128.
+_SUBJECT_RE = re.compile(r"^[A-Za-z0-9._:@-]{1,128}$")
+_TENANT_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+# Hard cap on token lifetime. PR-B ships no replay protection, so absent
+# this bound a misconfigured issuer could mint effectively-permanent tokens.
+_MAX_TOKEN_LIFETIME_S = 86_400  # 24h
+_IAT_CLOCK_SKEW_S = 300  # 5 min
+
+# Strict base64url segment matcher. Disallows padding and any non-base64url
+# characters. Length is checked separately for the signature segment.
+_BASE64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class AiPrincipal:
+    """A request's authenticated AI identity.
+
+    `subject` is the user_id today; under token mode it's the token `sub`
+    claim, which must be globally unique under the issuer.
+
+    `tenant_id` is "local" under basic-auth, the token `tenant_id` claim
+    under token-auth. Flows into `ai_generation_log.tenant_id`.
+
+    `scopes` is a tuple (not list) so the dataclass stays hashable.
+
+    `request_id` is captured at construction time from `request_id_var`.
+    See module docstring for the background-task caveat.
+    """
+
+    subject: str
+    tenant_id: str
+    scopes: tuple[str, ...]
+    auth_mode: Literal["basic", "token"]
+    request_id: str | None = field(default=None)
+
+
+class AiAuthenticator(Protocol):
+    """The seam: one method, sync routes can ignore."""
+
+    async def authenticate(self, request: Request) -> AiPrincipal: ...
+
+
+def _read_request_id() -> str | None:
+    """Capture the current request_id, normalizing the ContextVar default."""
+    rid = request_id_var.get()
+    return rid or None
+
+
+class BasicAuthAiAuthenticator:
+    """Wraps the existing calibre-web verifier for today's single-tenant case."""
+
+    def __init__(self, validator: CalibreAuthValidator) -> None:
+        self._validator = validator
+
+    async def authenticate(self, request: Request) -> AiPrincipal:
+        auth = request.headers.get("authorization")
+        if not auth:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="missing credentials",
+            )
+        # CalibreAuthValidator raises HTTPException(401/503) on failure; we
+        # let those propagate verbatim (their detail strings already match
+        # what sync routes return).
+        user_id = await self._validator.validate(auth)
+        return AiPrincipal(
+            subject=user_id,
+            tenant_id="local",
+            scopes=(),
+            auth_mode="basic",
+            request_id=_read_request_id(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Token authenticator
+# ---------------------------------------------------------------------------
+
+
+class _TokenError(Exception):
+    """Internal: one of the verification steps failed. Carries a reason.
+
+    Translated into HTTPException(401) at the boundary so reasons stay in
+    the structured log only.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _b64url_decode_strict(seg: str) -> bytes:
+    """Decode a URL-safe base64 segment, rejecting padding and bad chars.
+
+    Mirrors JOSE's "no padding" canonical form, but we go stricter:
+    `=` is explicitly rejected (urlsafe_b64decode would accept it),
+    and we hand-roll the alphabet check with a regex so empty or
+    weird-character segments fail before stdlib gets a chance to be
+    permissive.
+    """
+    if not seg:
+        raise _TokenError("malformed_token")
+    if "=" in seg:
+        raise _TokenError("malformed_token")
+    if not _BASE64URL_RE.fullmatch(seg):
+        raise _TokenError("malformed_token")
+    # Manually pad for the stdlib call (it requires `=` even though our
+    # input may not have it). Length-mod-4 padding is the standard recipe.
+    pad = "=" * (-len(seg) % 4)
+    try:
+        return base64.urlsafe_b64decode(seg + pad)
+    except (ValueError, base64.binascii.Error) as e:
+        raise _TokenError("malformed_token") from e
+
+
+def _is_real_int(v: object) -> bool:
+    """True for int but NOT for bool. Python's `isinstance(True, int)` is True."""
+    return type(v) is int
+
+
+class TokenAiAuthenticator:
+    """HMAC-SHA256 token verifier with kid rotation.
+
+    Token wire format: `header.payload.signature`, each segment URL-safe
+    base64 with no `=` padding. Header is `{"alg":"HS256","kid":"<kid>"}`.
+    Payload claims are documented in the design spec §3.3.
+
+    Verification is strict: algorithm-confusion attacks (`alg=none`) are
+    rejected; `kid` in the payload is rejected (it lives in the header);
+    `=` padding is rejected; non-base64url chars are rejected; signatures
+    that don't decode to exactly 32 bytes are rejected. All failures
+    raise HTTPException(401) with a non-discriminating detail.
+
+    Multiple `kid -> secret` entries enable rotation: any registered kid
+    is accepted at verification time. Token issuance is out of scope.
+    """
+
+    def __init__(
+        self,
+        *,
+        secrets: dict[str, str],
+        issuer: str,
+        audience: str,
+        clock: callable = time.time,  # type: ignore[valid-type]
+    ) -> None:
+        if not secrets:
+            # Defense-in-depth: startup validation in main.py should already
+            # have raised. Keep this as a hard guarantee.
+            raise ValueError("TokenAiAuthenticator requires non-empty secrets")
+        # Normalize to bytes for hmac.
+        self._secrets: dict[str, bytes] = {
+            kid: secret.encode("utf-8") for kid, secret in secrets.items()
+        }
+        self._issuer = issuer
+        self._audience = audience
+        self._clock = clock
+
+    async def authenticate(self, request: Request) -> AiPrincipal:
+        try:
+            return self._authenticate(request)
+        except _TokenError as e:
+            # All failures collapse to 401. The reason goes to logs only.
+            logger.info(
+                "event=ai.auth.token_rejected reason=%s remote=%s",
+                e.reason,
+                _client_host(request),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid credentials",
+            ) from None
+
+    def _authenticate(self, request: Request) -> AiPrincipal:
+        token = _extract_bearer_token(request)
+        header_b64, payload_b64, sig_b64 = _split_segments(token)
+
+        header = _decode_json_object(header_b64, kind="header")
+        # alg / kid live in the header. Order: check alg first so `alg=none`
+        # tokens never reach the signature comparison.
+        alg = header.get("alg")
+        if not isinstance(alg, str) or alg != "HS256":
+            raise _TokenError("bad_alg")
+        kid = header.get("kid")
+        if not isinstance(kid, str) or not kid:
+            raise _TokenError("missing_kid")
+        secret = self._secrets.get(kid)
+        if secret is None:
+            raise _TokenError("unknown_kid")
+
+        # Signature must decode to exactly 32 bytes (HMAC-SHA256 output).
+        sig = _b64url_decode_strict(sig_b64)
+        if len(sig) != 32:
+            raise _TokenError("bad_signature")
+        signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+        expected = hmac.new(secret, signing_input, "sha256").digest()
+        if not hmac.compare_digest(sig, expected):
+            raise _TokenError("bad_signature")
+
+        payload = _decode_json_object(payload_b64, kind="payload")
+        if "kid" in payload:
+            # `kid` lives in the header; refusing it in the payload prevents
+            # any future "which one wins?" ambiguity.
+            raise _TokenError("kid_in_payload")
+
+        iss = payload.get("iss")
+        aud = payload.get("aud")
+        exp = payload.get("exp")
+        iat = payload.get("iat")
+        sub = payload.get("sub")
+        tenant_id = payload.get("tenant_id")
+        scope = payload.get("scope")
+
+        if not isinstance(iss, str):
+            raise _TokenError("missing_claim:iss")
+        if not isinstance(aud, str):
+            raise _TokenError("missing_claim:aud")
+        if not _is_real_int(exp):
+            raise _TokenError("missing_claim:exp")
+        if not _is_real_int(iat):
+            raise _TokenError("missing_claim:iat")
+        if not isinstance(sub, str) or not _SUBJECT_RE.fullmatch(sub):
+            raise _TokenError("missing_claim:sub")
+        if not isinstance(tenant_id, str) or not _TENANT_RE.fullmatch(tenant_id):
+            raise _TokenError("missing_claim:tenant_id")
+
+        if iss != self._issuer:
+            raise _TokenError("bad_issuer")
+        if aud != self._audience:
+            raise _TokenError("bad_audience")
+
+        now = int(self._clock())
+        if now >= exp:
+            raise _TokenError("expired")
+        if iat > now + _IAT_CLOCK_SKEW_S:
+            raise _TokenError("iat_in_future")
+        if exp <= iat:
+            raise _TokenError("bad_lifetime")
+        if exp - iat > _MAX_TOKEN_LIFETIME_S:
+            raise _TokenError("bad_lifetime")
+
+        # Scope parsing. Spec §3.3: space-separated tokens; absent → ().
+        scopes: tuple[str, ...]
+        if scope is None:
+            scopes = ()
+        elif isinstance(scope, str):
+            scopes = tuple(s for s in scope.split(" ") if s)
+        else:
+            raise _TokenError("bad_scope")
+
+        return AiPrincipal(
+            subject=sub,
+            tenant_id=tenant_id,
+            scopes=scopes,
+            auth_mode="token",
+            request_id=_read_request_id(),
+        )
+
+
+def _extract_bearer_token(request: Request) -> str:
+    auth = request.headers.get("authorization", "")
+    if not auth:
+        raise _TokenError("malformed_authorization")
+    # Single space after "Bearer", exactly one token after. No leading
+    # whitespace, no trailing whitespace, no extra tokens.
+    if not auth.startswith("Bearer "):
+        raise _TokenError("malformed_authorization")
+    token = auth[len("Bearer ") :]
+    if not token or " " in token or "\t" in token:
+        raise _TokenError("malformed_authorization")
+    return token
+
+
+def _split_segments(token: str) -> tuple[str, str, str]:
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise _TokenError("malformed_token")
+    h, p, s = parts
+    if not h or not p or not s:
+        raise _TokenError("malformed_token")
+    return h, p, s
+
+
+def _decode_json_object(seg: str, *, kind: str) -> dict:
+    raw = _b64url_decode_strict(seg)
+    try:
+        obj = json.loads(raw)
+    except (ValueError, json.JSONDecodeError) as e:
+        raise _TokenError(f"malformed_{kind}") from e
+    if not isinstance(obj, dict):
+        raise _TokenError(f"malformed_{kind}")
+    return obj
+
+
+def _client_host(request: Request) -> str:
+    """Best-effort client host for logs. Never raises."""
+    client = getattr(request, "client", None)
+    if client is None:
+        return "-"
+    return getattr(client, "host", "-") or "-"
+
+
+# ---------------------------------------------------------------------------
+# FastAPI dependency wiring
+# ---------------------------------------------------------------------------
+
+
+async def get_ai_authenticator(request: Request) -> AiAuthenticator:
+    """Pull the singleton authenticator stashed on app.state at startup."""
+    auth = getattr(request.app.state, "ai_authenticator", None)
+    if auth is None:
+        # Should never happen if main.py wired correctly. A 500 is correct:
+        # this is a server-side misconfiguration, not an auth failure.
+        logger.error("ai_authenticator missing from app.state")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ai_auth_not_configured",
+        )
+    return auth
+
+
+async def get_ai_principal(
+    request: Request,
+    authenticator: Annotated[AiAuthenticator, Depends(get_ai_authenticator)],
+) -> AiPrincipal:
+    """FastAPI dependency for /ai/v1/* routes."""
+    return await authenticator.authenticate(request)

--- a/server/opds_sync/config.py
+++ b/server/opds_sync/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -45,6 +46,32 @@ class Settings(BaseSettings):
     ai_rate_per_min: int = 10  # process-wide token bucket against AI_BASE_URL
     ai_daily_budget: int = 200  # generations per user per UTC day; 0 disables
     ai_regen_daily_limit: int = 3  # tighter ceiling for /insights/regenerate per user/day
+
+    # ---------------------------------------------------------------------
+    # PR-B: AI auth abstraction (seam-only). Sync routes unaffected.
+    # ---------------------------------------------------------------------
+    # Mode of the /ai/v1/* authenticator:
+    #   * "basic"  – wraps the existing calibre-web Basic-auth verifier;
+    #                tenant_id is always "local". Default.
+    #   * "token"  – validates HMAC-SHA256 bearer tokens with claims
+    #                {iss, aud, exp, iat, sub, tenant_id, scope?} and a
+    #                header {alg=HS256, kid}. Multi-tenant.
+    ai_auth_mode: Literal["basic", "token"] = "basic"
+
+    # JSON object env var mapping `kid -> secret` (UTF-8 string >= 32 bytes).
+    # Required when ai_auth_mode == "token". Multiple kids enable rotation:
+    # tokens signed under any listed kid are accepted. Token issuance is NOT
+    # implemented here — this server only verifies. Token `sub` claims must
+    # be globally unique under the issuer (e.g. tenant-qualified at
+    # issuance) since `principal.subject` is stored verbatim in user-scoped
+    # tables (preferences, daily quota).
+    ai_token_secrets: dict[str, str] | None = None
+
+    # Required when ai_auth_mode == "token". Validated against token `iss`.
+    ai_token_issuer: str | None = None
+
+    # Required when ai_auth_mode == "token". Validated against token `aud`.
+    ai_token_audience: str | None = None
 
 
 @lru_cache(maxsize=1)

--- a/server/opds_sync/main.py
+++ b/server/opds_sync/main.py
@@ -21,10 +21,77 @@ from fastapi import FastAPI
 
 from opds_sync.api import health
 from opds_sync.api.middleware import RequestIDMiddleware, RequestSizeMiddleware
-from opds_sync.config import get_settings
+from opds_sync.config import Settings, get_settings
 from opds_sync.core.auth import CalibreAuthValidator
 from opds_sync.core.logging_ctx import RequestIdLogFilter
 from opds_sync.db.session import configure, make_engine
+
+
+def _validate_ai_auth_settings(settings: Settings) -> None:
+    """Fail loudly when token-mode AI auth is misconfigured.
+
+    Called once during create_app() when settings.ai_enabled is true. The
+    intent: a hosted multi-tenant deployment that intended token mode but
+    forgot the secrets must crashloop rather than silently accept anything.
+
+    Basic mode requires no extra config (today's default).
+    """
+    if settings.ai_auth_mode != "token":
+        return
+    secrets = settings.ai_token_secrets
+    if not isinstance(secrets, dict) or not secrets:
+        raise RuntimeError(
+            "OPDS_SYNC_AI_AUTH_MODE=token requires OPDS_SYNC_AI_TOKEN_SECRETS "
+            "to be a non-empty JSON object mapping kid -> secret"
+        )
+    for kid, secret in secrets.items():
+        if not isinstance(kid, str) or not kid:
+            raise RuntimeError(
+                "OPDS_SYNC_AI_TOKEN_SECRETS has an empty kid; every kid must "
+                "be a non-empty string"
+            )
+        if not isinstance(secret, str):
+            raise RuntimeError(
+                f"OPDS_SYNC_AI_TOKEN_SECRETS[{kid!r}] must be a string"
+            )
+        if len(secret.encode("utf-8")) < 32:
+            raise RuntimeError(
+                f"OPDS_SYNC_AI_TOKEN_SECRETS[{kid!r}] is shorter than 32 bytes; "
+                "use a random 32+ byte secret"
+            )
+    if not settings.ai_token_issuer or not settings.ai_token_issuer.strip():
+        raise RuntimeError(
+            "OPDS_SYNC_AI_AUTH_MODE=token requires OPDS_SYNC_AI_TOKEN_ISSUER"
+        )
+    if not settings.ai_token_audience or not settings.ai_token_audience.strip():
+        raise RuntimeError(
+            "OPDS_SYNC_AI_AUTH_MODE=token requires OPDS_SYNC_AI_TOKEN_AUDIENCE"
+        )
+
+
+def _build_ai_authenticator(settings: Settings, validator: CalibreAuthValidator):
+    """Construct the AiAuthenticator implied by settings.ai_auth_mode.
+
+    Imported here (rather than at module top) to keep the AI auth surface
+    lazy alongside the rest of the AI imports — sync-only deploys never pay
+    for the HMAC / token code.
+    """
+    from opds_sync.api.ai_auth import (
+        BasicAuthAiAuthenticator,
+        TokenAiAuthenticator,
+    )
+
+    if settings.ai_auth_mode == "basic":
+        return BasicAuthAiAuthenticator(validator=validator)
+    # token mode — validation already ran, so secrets/iss/aud are guaranteed.
+    assert settings.ai_token_secrets is not None
+    assert settings.ai_token_issuer is not None
+    assert settings.ai_token_audience is not None
+    return TokenAiAuthenticator(
+        secrets=settings.ai_token_secrets,
+        issuer=settings.ai_token_issuer,
+        audience=settings.ai_token_audience,
+    )
 
 
 def create_app() -> FastAPI:
@@ -69,48 +136,58 @@ def create_app() -> FastAPI:
 
         app.include_router(progress_router, prefix="/sync/v1")
 
-    if settings.ai_enabled and settings.ai_base_url and settings.ai_model:
-        # Lazy imports: only pull AI modules when AI mode is on AND configured.
-        # This is the "provider lazy-import boundary" — keeps the openai-client
-        # surface (httpx wrapper today; possibly the openai SDK tomorrow) and
-        # the Wikipedia/OpenLibrary clients out of sync-only deploys.
-        from opds_sync.api.ai import router as ai_router
-        from opds_sync.core.ai.client import AIClient
-        from opds_sync.core.ai.retrieval import Retriever
-        from opds_sync.core.ai.service import InsightOrchestrator
+    if settings.ai_enabled:
+        # PR-B: validate AI auth settings and build the authenticator BEFORE
+        # either AI router branch mounts. Token-mode misconfiguration must
+        # crashloop here — never silently downgrade to basic. Sync-only
+        # deploys (ai_enabled=false) skip this block entirely.
+        _validate_ai_auth_settings(settings)
+        app.state.ai_authenticator = _build_ai_authenticator(
+            settings, app.state.auth_validator
+        )
 
-        ai_client = AIClient(
-            base_url=settings.ai_base_url,
-            api_key=settings.ai_api_key,
-            model=settings.ai_model,
-        )
-        sources_enabled = tuple(
-            s.strip() for s in (settings.ai_sources or "").split(",") if s.strip()
-        )
-        orch = InsightOrchestrator(
-            ai=ai_client,
-            retriever_factory=lambda s: Retriever(
-                session=s, timeout_s=settings.ai_retrieval_timeout_s
-            ),
-            sources_enabled=sources_enabled,
-            model_id=settings.ai_model,
-            prompt_version=settings.ai_prompt_version,
-            max_concurrency=settings.ai_max_concurrency,
-            ai_timeout_s=settings.ai_timeout_s,
-            rate_per_min=settings.ai_rate_per_min,
-            daily_budget=settings.ai_daily_budget,
-            regen_daily_limit=settings.ai_regen_daily_limit,
-        )
-        app.state.ai_orchestrator = orch
-        app.include_router(ai_router, prefix="/ai/v1")
-    elif settings.ai_enabled:
-        # AI enabled but missing base_url/model — still mount the router so the
-        # /ai/v1/config endpoint can report `configured: false`. This preserves
-        # pre-PR-A behavior for deployments that flip the flag before fully
-        # configuring the provider.
-        from opds_sync.api.ai import router as ai_router
+        if settings.ai_base_url and settings.ai_model:
+            # Lazy imports: only pull AI modules when AI mode is on AND configured.
+            # This is the "provider lazy-import boundary" — keeps the openai-client
+            # surface (httpx wrapper today; possibly the openai SDK tomorrow) and
+            # the Wikipedia/OpenLibrary clients out of sync-only deploys.
+            from opds_sync.api.ai import router as ai_router
+            from opds_sync.core.ai.client import AIClient
+            from opds_sync.core.ai.retrieval import Retriever
+            from opds_sync.core.ai.service import InsightOrchestrator
 
-        app.include_router(ai_router, prefix="/ai/v1")
+            ai_client = AIClient(
+                base_url=settings.ai_base_url,
+                api_key=settings.ai_api_key,
+                model=settings.ai_model,
+            )
+            sources_enabled = tuple(
+                s.strip() for s in (settings.ai_sources or "").split(",") if s.strip()
+            )
+            orch = InsightOrchestrator(
+                ai=ai_client,
+                retriever_factory=lambda s: Retriever(
+                    session=s, timeout_s=settings.ai_retrieval_timeout_s
+                ),
+                sources_enabled=sources_enabled,
+                model_id=settings.ai_model,
+                prompt_version=settings.ai_prompt_version,
+                max_concurrency=settings.ai_max_concurrency,
+                ai_timeout_s=settings.ai_timeout_s,
+                rate_per_min=settings.ai_rate_per_min,
+                daily_budget=settings.ai_daily_budget,
+                regen_daily_limit=settings.ai_regen_daily_limit,
+            )
+            app.state.ai_orchestrator = orch
+            app.include_router(ai_router, prefix="/ai/v1")
+        else:
+            # AI enabled but missing base_url/model — still mount the router
+            # so the /ai/v1/config endpoint can report `configured: false`.
+            # The authenticator is already wired above, so token-mode deploys
+            # still require valid Bearer tokens on /config (no silent downgrade).
+            from opds_sync.api.ai import router as ai_router
+
+            app.include_router(ai_router, prefix="/ai/v1")
 
     # Middleware: registered LAST is OUTERMOST in ASGI execution order.
     # We want RequestID outermost so it can attach X-Request-ID to ANY

--- a/server/opds_sync/main.py
+++ b/server/opds_sync/main.py
@@ -47,26 +47,19 @@ def _validate_ai_auth_settings(settings: Settings) -> None:
     for kid, secret in secrets.items():
         if not isinstance(kid, str) or not kid:
             raise RuntimeError(
-                "OPDS_SYNC_AI_TOKEN_SECRETS has an empty kid; every kid must "
-                "be a non-empty string"
+                "OPDS_SYNC_AI_TOKEN_SECRETS has an empty kid; every kid must be a non-empty string"
             )
         if not isinstance(secret, str):
-            raise RuntimeError(
-                f"OPDS_SYNC_AI_TOKEN_SECRETS[{kid!r}] must be a string"
-            )
+            raise RuntimeError(f"OPDS_SYNC_AI_TOKEN_SECRETS[{kid!r}] must be a string")
         if len(secret.encode("utf-8")) < 32:
             raise RuntimeError(
                 f"OPDS_SYNC_AI_TOKEN_SECRETS[{kid!r}] is shorter than 32 bytes; "
                 "use a random 32+ byte secret"
             )
     if not settings.ai_token_issuer or not settings.ai_token_issuer.strip():
-        raise RuntimeError(
-            "OPDS_SYNC_AI_AUTH_MODE=token requires OPDS_SYNC_AI_TOKEN_ISSUER"
-        )
+        raise RuntimeError("OPDS_SYNC_AI_AUTH_MODE=token requires OPDS_SYNC_AI_TOKEN_ISSUER")
     if not settings.ai_token_audience or not settings.ai_token_audience.strip():
-        raise RuntimeError(
-            "OPDS_SYNC_AI_AUTH_MODE=token requires OPDS_SYNC_AI_TOKEN_AUDIENCE"
-        )
+        raise RuntimeError("OPDS_SYNC_AI_AUTH_MODE=token requires OPDS_SYNC_AI_TOKEN_AUDIENCE")
 
 
 def _build_ai_authenticator(settings: Settings, validator: CalibreAuthValidator):
@@ -142,9 +135,7 @@ def create_app() -> FastAPI:
         # crashloop here — never silently downgrade to basic. Sync-only
         # deploys (ai_enabled=false) skip this block entirely.
         _validate_ai_auth_settings(settings)
-        app.state.ai_authenticator = _build_ai_authenticator(
-            settings, app.state.auth_validator
-        )
+        app.state.ai_authenticator = _build_ai_authenticator(settings, app.state.auth_validator)
 
         if settings.ai_base_url and settings.ai_model:
             # Lazy imports: only pull AI modules when AI mode is on AND configured.

--- a/server/tests/integration/conftest.py
+++ b/server/tests/integration/conftest.py
@@ -146,6 +146,8 @@ def client_factory(monkeypatch, postgres_url, alembic_upgrade, app: _AppProxy):
             try:
                 from opds_sync.api.ai_auth import (
                     AiPrincipal,
+                )
+                from opds_sync.api.ai_auth import (
                     get_ai_principal as _real_principal,
                 )
             except ImportError:

--- a/server/tests/integration/conftest.py
+++ b/server/tests/integration/conftest.py
@@ -92,7 +92,7 @@ def client_factory(monkeypatch, postgres_url, alembic_upgrade, app: _AppProxy):
             r = await client.get("/ai/v1/config", headers=_basic_header("alice"))
     """
 
-    def _factory(**env_kwargs):
+    def _factory(*, skip_auth_overrides: bool = False, **env_kwargs):
         # --- 1. Configure environment ----------------------------------------
         monkeypatch.setenv("OPDS_SYNC_DATABASE_URL", postgres_url)
         monkeypatch.setenv("OPDS_SYNC_CWA_BASE_URL", "http://test-cwa")
@@ -112,30 +112,58 @@ def client_factory(monkeypatch, postgres_url, alembic_upgrade, app: _AppProxy):
         app._set(real_app)
 
         # --- 3. Stub auth via dependency_overrides ---------------------------
-        from opds_sync.core.auth import current_user_id as _real_cuid
+        # Tests that exercise REAL auth (PR-B token-mode tests, for example)
+        # pass `skip_auth_overrides=True` to opt out of the fakes.
+        if not skip_auth_overrides:
+            from opds_sync.core.auth import current_user_id as _real_cuid
 
-        async def _fake_current_user_id(request: Request) -> str:
-            header = request.headers.get("Authorization", "")
-            if not header.lower().startswith("basic "):
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="missing credentials",
-                )
+            async def _fake_current_user_id(request: Request) -> str:
+                header = request.headers.get("Authorization", "")
+                if not header.lower().startswith("basic "):
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="missing credentials",
+                    )
+                try:
+                    decoded = base64.b64decode(header[6:].strip()).decode("utf-8")
+                except Exception:
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="malformed credentials",
+                    ) from None
+                if ":" not in decoded:
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="malformed credentials",
+                    )
+                return decoded.split(":", 1)[0].lower()
+
+            real_app.dependency_overrides[_real_cuid] = _fake_current_user_id
+
+            # PR-B: AI routes depend on get_ai_principal instead of
+            # current_user_id. Mirror the basic-auth fake so existing tests
+            # that use _basic_header() keep working without modification.
             try:
-                decoded = base64.b64decode(header[6:].strip()).decode("utf-8")
-            except Exception:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="malformed credentials",
-                ) from None
-            if ":" not in decoded:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="malformed credentials",
+                from opds_sync.api.ai_auth import (
+                    AiPrincipal,
+                    get_ai_principal as _real_principal,
                 )
-            return decoded.split(":", 1)[0].lower()
+            except ImportError:
+                _real_principal = None
 
-        real_app.dependency_overrides[_real_cuid] = _fake_current_user_id
+            if _real_principal is not None:
+
+                async def _fake_ai_principal(request: Request) -> AiPrincipal:
+                    subject = await _fake_current_user_id(request)
+                    return AiPrincipal(
+                        subject=subject,
+                        tenant_id="local",
+                        scopes=(),
+                        auth_mode="basic",
+                        request_id=None,
+                    )
+
+                real_app.dependency_overrides[_real_principal] = _fake_ai_principal
 
         # --- 4. Return async context manager ---------------------------------
         @asynccontextmanager

--- a/server/tests/integration/test_ai_auth_modes.py
+++ b/server/tests/integration/test_ai_auth_modes.py
@@ -72,10 +72,7 @@ def _good_claims(*, sub: str = "acme:alice", tenant: str = "acme", lifetime_s: i
 
 
 def _basic_header(user: str, password: str = "p") -> dict:
-    return {
-        "Authorization": "Basic "
-        + base64.b64encode(f"{user}:{password}".encode()).decode()
-    }
+    return {"Authorization": "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()}
 
 
 # ---------------------------------------------------------------------------
@@ -126,9 +123,7 @@ async def test_token_mode_valid_token_returns_200(client_factory):
         ai_token_audience=_AUD,
         skip_auth_overrides=True,
     ) as client:
-        r = await client.get(
-            "/ai/v1/config", headers={"Authorization": f"Bearer {token}"}
-        )
+        r = await client.get("/ai/v1/config", headers={"Authorization": f"Bearer {token}"})
     assert r.status_code == 200, r.text
 
 
@@ -145,15 +140,11 @@ async def test_token_mode_kid_rotation_old_kid_accepted(client_factory):
     ) as client:
         # Sign under the older kid.
         t1 = _sign_token(_good_claims(), secret=_SECRET_1, kid="k1")
-        r1 = await client.get(
-            "/ai/v1/config", headers={"Authorization": f"Bearer {t1}"}
-        )
+        r1 = await client.get("/ai/v1/config", headers={"Authorization": f"Bearer {t1}"})
         assert r1.status_code == 200, r1.text
         # Sign under the newer kid.
         t2 = _sign_token(_good_claims(), secret=_SECRET_2, kid="k2")
-        r2 = await client.get(
-            "/ai/v1/config", headers={"Authorization": f"Bearer {t2}"}
-        )
+        r2 = await client.get("/ai/v1/config", headers={"Authorization": f"Bearer {t2}"})
         assert r2.status_code == 200, r2.text
 
 
@@ -206,9 +197,7 @@ def _install_fake_orchestrator(app, payload: dict) -> None:
 
 
 @pytest.mark.requires_ai
-async def test_token_auth_writes_tenant_id_to_generation_log(
-    client_factory, app, session
-):
+async def test_token_auth_writes_tenant_id_to_generation_log(client_factory, app, session):
     """End-to-end proof that PR-B's principal.tenant_id flows into PR-C's log."""
     async with client_factory(
         ai_enabled=True,
@@ -251,13 +240,9 @@ async def test_token_auth_writes_tenant_id_to_generation_log(
         )
         assert r2.status_code == 200, r2.text
 
-    logs = (
-        (await session.execute(select(AIGenerationLog))).scalars().all()
-    )
+    logs = (await session.execute(select(AIGenerationLog))).scalars().all()
     assert len(logs) >= 1
-    assert any(
-        log.tenant_id == "acme" and log.subject == "acme:alice" for log in logs
-    ), [
+    assert any(log.tenant_id == "acme" and log.subject == "acme:alice" for log in logs), [
         (log.tenant_id, log.subject, log.status) for log in logs
     ]
     # And critically: nothing was logged under the legacy "local" tenant.
@@ -265,9 +250,7 @@ async def test_token_auth_writes_tenant_id_to_generation_log(
 
 
 @pytest.mark.requires_ai
-async def test_token_auth_propagates_request_id_to_generation_log(
-    client_factory, app, session
-):
+async def test_token_auth_propagates_request_id_to_generation_log(client_factory, app, session):
     """X-Request-ID set by the client flows through to ai_generation_log."""
     async with client_factory(
         ai_enabled=True,
@@ -289,9 +272,7 @@ async def test_token_auth_propagates_request_id_to_generation_log(
             "Authorization": f"Bearer {token}",
             "X-Request-ID": "rid-test-pr-b",
         }
-        r = await client.put(
-            "/ai/v1/preferences", headers=headers, json={"ai_enabled": True}
-        )
+        r = await client.put("/ai/v1/preferences", headers=headers, json={"ai_enabled": True})
         assert r.status_code == 200
 
         r2 = await client.post(
@@ -305,6 +286,4 @@ async def test_token_auth_propagates_request_id_to_generation_log(
         assert r2.status_code == 200
 
     logs = (await session.execute(select(AIGenerationLog))).scalars().all()
-    assert any(log.request_id == "rid-test-pr-b" for log in logs), [
-        log.request_id for log in logs
-    ]
+    assert any(log.request_id == "rid-test-pr-b" for log in logs), [log.request_id for log in logs]

--- a/server/tests/integration/test_ai_auth_modes.py
+++ b/server/tests/integration/test_ai_auth_modes.py
@@ -1,0 +1,310 @@
+"""End-to-end tests for the AI auth mode switch (PR-B).
+
+Spins up the FastAPI app with `OPDS_SYNC_AI_AUTH_MODE` set to each value,
+then verifies that:
+
+* `basic` mode rejects Bearer tokens (Authorization header doesn't decode as
+  Basic → 401).
+* `token` mode rejects Basic credentials (no Bearer prefix → 401).
+* `token` mode accepts a freshly-minted, properly-signed HMAC token.
+* `token` mode honors `kid` rotation: two secrets registered, token signed
+  under either is accepted.
+* `token` mode + valid token → `ai_generation_log` rows carry the token's
+  `tenant_id` (not the literal `"local"` that PR-C used to hardcode).
+
+These tests pass `skip_auth_overrides=True` to `client_factory` so the real
+authenticator runs.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+from opds_sync.core.ai.client import AIClient
+from opds_sync.core.ai.service import InsightOrchestrator
+from opds_sync.db.models import AIGenerationLog
+
+pytestmark = pytest.mark.requires_ai
+
+
+_SECRET_1 = "k1-" + "x" * 32  # >= 32 utf-8 bytes
+_SECRET_2 = "k2-" + "y" * 32
+_ISS = "quire-cloud"
+_AUD = "opds-sync"
+
+
+def _b64url(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _sign_token(
+    claims: dict,
+    *,
+    secret: str,
+    kid: str = "k1",
+) -> str:
+    header = {"alg": "HS256", "kid": kid}
+    header_b64 = _b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_b64 = _b64url(json.dumps(claims, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    sig = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    return f"{header_b64}.{payload_b64}.{_b64url(sig)}"
+
+
+def _good_claims(*, sub: str = "acme:alice", tenant: str = "acme", lifetime_s: int = 60) -> dict:
+    now = int(time.time())
+    return {
+        "iss": _ISS,
+        "aud": _AUD,
+        "exp": now + lifetime_s,
+        "iat": now - 1,
+        "sub": sub,
+        "tenant_id": tenant,
+    }
+
+
+def _basic_header(user: str, password: str = "p") -> dict:
+    return {
+        "Authorization": "Basic "
+        + base64.b64encode(f"{user}:{password}".encode()).decode()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mode rejection
+# ---------------------------------------------------------------------------
+
+
+async def test_basic_mode_rejects_bearer_token(client_factory):
+    """Basic-mode deploy must not silently accept token-style requests."""
+    async with client_factory(
+        ai_enabled=True,
+        ai_auth_mode="basic",
+        skip_auth_overrides=True,
+    ) as client:
+        r = await client.get(
+            "/ai/v1/config",
+            headers={"Authorization": "Bearer some.thing.signed"},
+        )
+    assert r.status_code == 401
+
+
+async def test_token_mode_rejects_basic_credentials(client_factory):
+    """Token-mode deploy must not silently accept basic-auth requests."""
+    async with client_factory(
+        ai_enabled=True,
+        ai_auth_mode="token",
+        ai_token_secrets=json.dumps({"k1": _SECRET_1}),
+        ai_token_issuer=_ISS,
+        ai_token_audience=_AUD,
+        skip_auth_overrides=True,
+    ) as client:
+        r = await client.get("/ai/v1/config", headers=_basic_header("alice"))
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Happy-path token mode
+# ---------------------------------------------------------------------------
+
+
+async def test_token_mode_valid_token_returns_200(client_factory):
+    token = _sign_token(_good_claims(), secret=_SECRET_1, kid="k1")
+    async with client_factory(
+        ai_enabled=True,
+        ai_auth_mode="token",
+        ai_token_secrets=json.dumps({"k1": _SECRET_1}),
+        ai_token_issuer=_ISS,
+        ai_token_audience=_AUD,
+        skip_auth_overrides=True,
+    ) as client:
+        r = await client.get(
+            "/ai/v1/config", headers={"Authorization": f"Bearer {token}"}
+        )
+    assert r.status_code == 200, r.text
+
+
+async def test_token_mode_kid_rotation_old_kid_accepted(client_factory):
+    """Two kids registered; either accepts."""
+    secrets = json.dumps({"k1": _SECRET_1, "k2": _SECRET_2})
+    async with client_factory(
+        ai_enabled=True,
+        ai_auth_mode="token",
+        ai_token_secrets=secrets,
+        ai_token_issuer=_ISS,
+        ai_token_audience=_AUD,
+        skip_auth_overrides=True,
+    ) as client:
+        # Sign under the older kid.
+        t1 = _sign_token(_good_claims(), secret=_SECRET_1, kid="k1")
+        r1 = await client.get(
+            "/ai/v1/config", headers={"Authorization": f"Bearer {t1}"}
+        )
+        assert r1.status_code == 200, r1.text
+        # Sign under the newer kid.
+        t2 = _sign_token(_good_claims(), secret=_SECRET_2, kid="k2")
+        r2 = await client.get(
+            "/ai/v1/config", headers={"Authorization": f"Bearer {t2}"}
+        )
+        assert r2.status_code == 200, r2.text
+
+
+# ---------------------------------------------------------------------------
+# Token auth → ai_generation_log integration (the load-bearing wire to PR-C)
+# ---------------------------------------------------------------------------
+
+
+def _ai_chat_response(payload: dict) -> dict:
+    return {
+        "id": "x",
+        "model": "test-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": json.dumps(payload)},
+            }
+        ],
+    }
+
+
+def _install_fake_orchestrator(app, payload: dict) -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_ai_chat_response(payload))
+
+    ai = AIClient(
+        base_url="http://fake/v1",
+        api_key=None,
+        model="test-model",
+        transport=httpx.MockTransport(handler),
+    )
+
+    class _NoOpRetriever:
+        async def lookup_wikipedia(self, **kw):
+            return []
+
+        async def lookup_openlibrary(self, **kw):
+            return []
+
+    orch = InsightOrchestrator(
+        ai=ai,
+        retriever_factory=lambda s: _NoOpRetriever(),
+        sources_enabled=(),
+        model_id="test-model",
+        prompt_version="t1",
+        max_concurrency=4,
+        ai_timeout_s=5.0,
+    )
+    app.state.ai_orchestrator = orch
+
+
+@pytest.mark.requires_ai
+async def test_token_auth_writes_tenant_id_to_generation_log(
+    client_factory, app, session
+):
+    """End-to-end proof that PR-B's principal.tenant_id flows into PR-C's log."""
+    async with client_factory(
+        ai_enabled=True,
+        ai_auth_mode="token",
+        ai_token_secrets=json.dumps({"k1": _SECRET_1}),
+        ai_token_issuer=_ISS,
+        ai_token_audience=_AUD,
+        ai_base_url="http://fake/v1",
+        ai_model="test-model",
+        skip_auth_overrides=True,
+    ) as client:
+        _install_fake_orchestrator(
+            app,
+            {"schema_version": 2, "intro": "From acme.", "confidence": "high"},
+        )
+
+        token = _sign_token(
+            _good_claims(sub="acme:alice", tenant="acme"),
+            secret=_SECRET_1,
+            kid="k1",
+        )
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Opt the (token-authenticated) subject in.
+        r = await client.put(
+            "/ai/v1/preferences",
+            headers=headers,
+            json={"ai_enabled": True},
+        )
+        assert r.status_code == 200, r.text
+
+        # Lookup triggers an orchestrator.generate() — which writes the log.
+        r2 = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=headers,
+            json={
+                "identity": {"content_hash": "ch-tok-1"},
+                "bundle": {"title": "Acme Book"},
+            },
+        )
+        assert r2.status_code == 200, r2.text
+
+    logs = (
+        (await session.execute(select(AIGenerationLog))).scalars().all()
+    )
+    assert len(logs) >= 1
+    assert any(
+        log.tenant_id == "acme" and log.subject == "acme:alice" for log in logs
+    ), [
+        (log.tenant_id, log.subject, log.status) for log in logs
+    ]
+    # And critically: nothing was logged under the legacy "local" tenant.
+    assert not any(log.tenant_id == "local" for log in logs)
+
+
+@pytest.mark.requires_ai
+async def test_token_auth_propagates_request_id_to_generation_log(
+    client_factory, app, session
+):
+    """X-Request-ID set by the client flows through to ai_generation_log."""
+    async with client_factory(
+        ai_enabled=True,
+        ai_auth_mode="token",
+        ai_token_secrets=json.dumps({"k1": _SECRET_1}),
+        ai_token_issuer=_ISS,
+        ai_token_audience=_AUD,
+        ai_base_url="http://fake/v1",
+        ai_model="test-model",
+        skip_auth_overrides=True,
+    ) as client:
+        _install_fake_orchestrator(
+            app,
+            {"schema_version": 2, "intro": "From acme.", "confidence": "high"},
+        )
+
+        token = _sign_token(_good_claims(), secret=_SECRET_1, kid="k1")
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "X-Request-ID": "rid-test-pr-b",
+        }
+        r = await client.put(
+            "/ai/v1/preferences", headers=headers, json={"ai_enabled": True}
+        )
+        assert r.status_code == 200
+
+        r2 = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=headers,
+            json={
+                "identity": {"content_hash": "ch-rid-1"},
+                "bundle": {"title": "Rid Book"},
+            },
+        )
+        assert r2.status_code == 200
+
+    logs = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert any(log.request_id == "rid-test-pr-b" for log in logs), [
+        log.request_id for log in logs
+    ]

--- a/server/tests/unit/test_ai_auth.py
+++ b/server/tests/unit/test_ai_auth.py
@@ -1,0 +1,616 @@
+"""Unit tests for the AI auth abstraction (PR-B).
+
+Covers:
+* `AiPrincipal` shape (frozen, hashable, request_id captured).
+* `BasicAuthAiAuthenticator` over an httpx-mocked calibre-web verifier.
+* `TokenAiAuthenticator` HMAC-SHA256 verification, including every claim
+  validation step and corner case enumerated in the design spec §7.1.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from starlette.datastructures import Headers
+from starlette.requests import Request
+
+from opds_sync.api.ai_auth import (
+    AiPrincipal,
+    BasicAuthAiAuthenticator,
+    TokenAiAuthenticator,
+)
+from opds_sync.core.auth import CalibreAuthValidator
+from opds_sync.core.logging_ctx import request_id_var
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(headers: dict[str, str], *, client_host: str = "127.0.0.1") -> Request:
+    """Build a Starlette Request with the given headers. ASGI-shape scope.
+
+    A bare minimum scope keeps Starlette happy without an actual ASGI app.
+    """
+    raw_headers = [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()]
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": raw_headers,
+        "query_string": b"",
+        "client": (client_host, 0),
+    }
+    return Request(scope)
+
+
+def _basic_header_value(user: str, password: str) -> str:
+    token = base64.b64encode(f"{user}:{password}".encode()).decode("ascii")
+    return f"Basic {token}"
+
+
+def _make_calibre_validator(*, valid_user: str = "alice", valid_pass: str = "alicepass"):
+    def handler(req: httpx.Request) -> httpx.Response:
+        auth = req.headers.get("authorization", "")
+        if not auth.lower().startswith("basic "):
+            return httpx.Response(401)
+        try:
+            decoded = base64.b64decode(auth[6:].strip()).decode("utf-8")
+            user, pw = decoded.split(":", 1)
+        except Exception:
+            return httpx.Response(401)
+        if user == valid_user and pw == valid_pass:
+            return httpx.Response(200, text="<feed/>")
+        return httpx.Response(401)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://cwa")
+    return CalibreAuthValidator(client=client, cwa_base_url="http://cwa", clock=lambda: 0.0)
+
+
+# Token signing helper. Lives in the test module on purpose — the production
+# code does NOT ship a minter.
+
+
+def _b64url(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _sign_token(
+    claims: dict,
+    *,
+    secret: str,
+    kid: str | None = "k1",
+    alg: str = "HS256",
+    tamper_sig: bool = False,
+    extra_header: dict | None = None,
+    omit_alg: bool = False,
+) -> str:
+    header: dict = {}
+    if not omit_alg:
+        header["alg"] = alg
+    if kid is not None:
+        header["kid"] = kid
+    if extra_header:
+        header.update(extra_header)
+
+    header_b64 = _b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_b64 = _b64url(json.dumps(claims, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    sig = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    if tamper_sig:
+        sig = sig[:-1] + bytes([sig[-1] ^ 0x01])
+    sig_b64 = _b64url(sig)
+    return f"{header_b64}.{payload_b64}.{sig_b64}"
+
+
+_SECRET = "x" * 32
+_ISS = "quire-cloud"
+_AUD = "opds-sync"
+
+
+def _good_claims(now: int = 1_700_000_000, **overrides) -> dict:
+    base = {
+        "iss": _ISS,
+        "aud": _AUD,
+        "exp": now + 60,
+        "iat": now,
+        "sub": "acme:alice",
+        "tenant_id": "acme",
+    }
+    base.update(overrides)
+    return base
+
+
+def _token_auth(*, secrets=None, issuer=_ISS, audience=_AUD, now: int = 1_700_000_000):
+    return TokenAiAuthenticator(
+        secrets=secrets or {"k1": _SECRET},
+        issuer=issuer,
+        audience=audience,
+        clock=lambda: now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AiPrincipal shape
+# ---------------------------------------------------------------------------
+
+
+def test_principal_shape_is_frozen_and_hashable():
+    p = AiPrincipal(
+        subject="alice",
+        tenant_id="local",
+        scopes=("ai:read",),
+        auth_mode="basic",
+        request_id="rid-1",
+    )
+    assert p.subject == "alice"
+    assert p.tenant_id == "local"
+    assert p.scopes == ("ai:read",)
+    assert p.auth_mode == "basic"
+    assert p.request_id == "rid-1"
+    # frozen → cannot mutate
+    with pytest.raises(Exception):
+        p.subject = "bob"  # type: ignore[misc]
+    # hashable (scopes is a tuple, not a list)
+    {p}
+
+
+def test_principal_request_id_defaults_none():
+    p = AiPrincipal(
+        subject="a", tenant_id="t", scopes=(), auth_mode="basic"
+    )
+    assert p.request_id is None
+
+
+# ---------------------------------------------------------------------------
+# BasicAuthAiAuthenticator
+# ---------------------------------------------------------------------------
+
+
+async def test_basic_auth_valid_credential_returns_principal():
+    auth = BasicAuthAiAuthenticator(validator=_make_calibre_validator())
+    req = _make_request({"authorization": _basic_header_value("alice", "alicepass")})
+    p = await auth.authenticate(req)
+    assert p == AiPrincipal(
+        subject="alice",
+        tenant_id="local",
+        scopes=(),
+        auth_mode="basic",
+        request_id=None,
+    )
+
+
+async def test_basic_auth_missing_header_raises_401():
+    auth = BasicAuthAiAuthenticator(validator=_make_calibre_validator())
+    req = _make_request({})
+    with pytest.raises(HTTPException) as exc:
+        await auth.authenticate(req)
+    assert exc.value.status_code == 401
+
+
+async def test_basic_auth_invalid_credential_raises_401():
+    auth = BasicAuthAiAuthenticator(validator=_make_calibre_validator())
+    req = _make_request({"authorization": _basic_header_value("alice", "wrong")})
+    with pytest.raises(HTTPException) as exc:
+        await auth.authenticate(req)
+    assert exc.value.status_code == 401
+
+
+async def test_basic_auth_carries_request_id_from_contextvar():
+    auth = BasicAuthAiAuthenticator(validator=_make_calibre_validator())
+    token = request_id_var.set("rid-abc-123")
+    try:
+        req = _make_request({"authorization": _basic_header_value("alice", "alicepass")})
+        p = await auth.authenticate(req)
+        assert p.request_id == "rid-abc-123"
+    finally:
+        request_id_var.reset(token)
+
+
+async def test_basic_auth_request_id_none_when_unset():
+    auth = BasicAuthAiAuthenticator(validator=_make_calibre_validator())
+    # ContextVar default is "" — we should normalize that to None.
+    req = _make_request({"authorization": _basic_header_value("alice", "alicepass")})
+    p = await auth.authenticate(req)
+    assert p.request_id is None
+
+
+# ---------------------------------------------------------------------------
+# TokenAiAuthenticator — happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_token_valid_claims_returns_principal():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, scope="ai:read ai:write"), secret=_SECRET)
+    req = _make_request({"authorization": f"Bearer {token}"})
+    p = await auth.authenticate(req)
+    assert p == AiPrincipal(
+        subject="acme:alice",
+        tenant_id="acme",
+        scopes=("ai:read", "ai:write"),
+        auth_mode="token",
+        request_id=None,
+    )
+
+
+async def test_token_two_kids_old_kid_accepted():
+    now = 1_700_000_000
+    secrets = {"k1": _SECRET, "k2": "y" * 32}
+    auth = _token_auth(secrets=secrets, now=now)
+    # Token signed under k1 (the "older" key in operator parlance)
+    token = _sign_token(_good_claims(now), secret=_SECRET, kid="k1")
+    p = await auth.authenticate(_make_request({"authorization": f"Bearer {token}"}))
+    assert p.subject == "acme:alice"
+    # Token signed under k2 (the "newer" key)
+    token2 = _sign_token(_good_claims(now), secret="y" * 32, kid="k2")
+    p2 = await auth.authenticate(_make_request({"authorization": f"Bearer {token2}"}))
+    assert p2.tenant_id == "acme"
+
+
+async def test_token_carries_request_id():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    rid_token = request_id_var.set("rid-token-1")
+    try:
+        req = _make_request({"authorization": f"Bearer {token}"})
+        p = await auth.authenticate(req)
+        assert p.request_id == "rid-token-1"
+    finally:
+        request_id_var.reset(rid_token)
+
+
+async def test_token_scope_empty_yields_empty_tuple():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    # No scope claim at all.
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    p = await auth.authenticate(_make_request({"authorization": f"Bearer {token}"}))
+    assert p.scopes == ()
+    # Explicit empty string.
+    token2 = _sign_token(_good_claims(now, scope=""), secret=_SECRET)
+    p2 = await auth.authenticate(_make_request({"authorization": f"Bearer {token2}"}))
+    assert p2.scopes == ()
+
+
+async def test_token_iat_at_boundary_accepted():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    # iat == now + 300 is the exact upper bound.
+    token = _sign_token(_good_claims(now, iat=now + 300, exp=now + 400), secret=_SECRET)
+    p = await auth.authenticate(_make_request({"authorization": f"Bearer {token}"}))
+    assert p.subject == "acme:alice"
+
+
+# ---------------------------------------------------------------------------
+# TokenAiAuthenticator — failure modes (each raises HTTPException(401))
+# ---------------------------------------------------------------------------
+
+
+def _make_token_req(headers: dict[str, str]) -> Request:
+    return _make_request(headers)
+
+
+async def _expect_401(auth: TokenAiAuthenticator, req: Request) -> None:
+    with pytest.raises(HTTPException) as exc:
+        await auth.authenticate(req)
+    assert exc.value.status_code == 401
+
+
+# Algorithm / header
+async def test_token_alg_none_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET, alg="none")
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_alg_wrong_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET, alg="HS512")
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_alg_missing_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET, omit_alg=True)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_kid_missing_in_header_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET, kid=None)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_kid_empty_in_header_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET, kid="")
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_kid_in_payload_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, kid="k1"), secret=_SECRET, kid="k1")
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_unknown_kid_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET, kid="unknown")
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+# Time
+async def test_token_expired_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, exp=now - 1), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_exp_equals_now_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, exp=now), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_iat_too_far_in_future_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(
+        _good_claims(now, iat=now + 3600, exp=now + 3700), secret=_SECRET
+    )
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_exp_lte_iat_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, iat=now, exp=now - 10), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_lifetime_over_24h_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(
+        _good_claims(now, iat=now, exp=now + 86_401), secret=_SECRET
+    )
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+# Identity
+async def test_token_wrong_iss_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, iss="evil"), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_wrong_aud_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, aud="wrong"), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+# Signature integrity
+async def test_token_tampered_signature_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET, tamper_sig=True)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_tampered_payload_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    # Sign claims A, swap to claims B without re-signing.
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    h, _p_old, s = token.split(".")
+    p_new = _b64url(
+        json.dumps(_good_claims(now, sub="evil"), separators=(",", ":")).encode("utf-8")
+    )
+    tampered = f"{h}.{p_new}.{s}"
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {tampered}"}))
+
+
+async def test_token_signature_wrong_length_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    h, p, _s = token.split(".")
+    short_sig = _b64url(b"\x00" * 16)  # 16 bytes, not 32
+    tampered = f"{h}.{p}.{short_sig}"
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {tampered}"}))
+
+
+# Claim validation
+@pytest.mark.parametrize(
+    "drop", ["iss", "aud", "exp", "iat", "sub", "tenant_id"]
+)
+async def test_token_missing_required_claim_rejected(drop):
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    claims = _good_claims(now)
+    claims.pop(drop)
+    token = _sign_token(claims, secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_exp_as_string_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, exp=str(now + 60)), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_iat_as_bool_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, iat=True), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_sub_as_list_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, sub=["a"]), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_tenant_id_empty_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, tenant_id=""), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_tenant_id_over_128_chars_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, tenant_id="a" * 129), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+@pytest.mark.parametrize("bad", ["a/b", "a b", "a\tb", "a+b"])
+async def test_token_tenant_id_disallowed_chars_rejected(bad):
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, tenant_id=bad), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_scope_non_string_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now, scope=["ai:read"]), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+# Wire format
+async def test_token_bearer_prefix_missing_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    await _expect_401(auth, _make_token_req({"authorization": token}))
+
+
+async def test_token_wrong_scheme_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    await _expect_401(auth, _make_token_req({"authorization": "Basic dXNlcjpwdw=="}))
+
+
+async def test_token_bearer_extra_tokens_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    await _expect_401(
+        auth, _make_token_req({"authorization": f"Bearer {token} extra"})
+    )
+
+
+async def test_token_segment_count_wrong_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    await _expect_401(auth, _make_token_req({"authorization": "Bearer a.b"}))
+    await _expect_401(auth, _make_token_req({"authorization": "Bearer a.b.c.d"}))
+
+
+async def test_token_empty_segment_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    h, _p, s = token.split(".")
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {h}..{s}"}))
+
+
+async def test_token_padding_present_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    # Force = padding into the payload segment.
+    h, p, s = token.split(".")
+    padded = p + "="
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {h}.{padded}.{s}"}))
+
+
+async def test_token_non_base64url_chars_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    token = _sign_token(_good_claims(now), secret=_SECRET)
+    h, p, s = token.split(".")
+    # Inject a `+` (standard base64, NOT url-safe).
+    tampered_p = "+" + p[1:]
+    await _expect_401(
+        auth, _make_token_req({"authorization": f"Bearer {h}.{tampered_p}.{s}"})
+    )
+
+
+async def test_token_header_array_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    # Build by hand: header is a JSON array, not an object.
+    header_b64 = _b64url(json.dumps(["HS256", "k1"]).encode("utf-8"))
+    payload_b64 = _b64url(
+        json.dumps(_good_claims(now), separators=(",", ":")).encode("utf-8")
+    )
+    sig_b64 = _b64url(b"\x00" * 32)
+    token = f"{header_b64}.{payload_b64}.{sig_b64}"
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_payload_array_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    header_b64 = _b64url(json.dumps({"alg": "HS256", "kid": "k1"}).encode("utf-8"))
+    payload_b64 = _b64url(json.dumps(["not", "an", "object"]).encode("utf-8"))
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    sig = hmac.new(_SECRET.encode(), signing_input, hashlib.sha256).digest()
+    token = f"{header_b64}.{payload_b64}.{_b64url(sig)}"
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+async def test_token_payload_non_json_rejected():
+    now = 1_700_000_000
+    auth = _token_auth(now=now)
+    header_b64 = _b64url(json.dumps({"alg": "HS256", "kid": "k1"}).encode("utf-8"))
+    payload_b64 = _b64url(b"not-json-just-bytes")
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    sig = hmac.new(_SECRET.encode(), signing_input, hashlib.sha256).digest()
+    token = f"{header_b64}.{payload_b64}.{_b64url(sig)}"
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
+
+
+# ---------------------------------------------------------------------------
+# TokenAiAuthenticator — guard rails
+# ---------------------------------------------------------------------------
+
+
+def test_token_authenticator_rejects_empty_secrets():
+    with pytest.raises(ValueError):
+        TokenAiAuthenticator(secrets={}, issuer=_ISS, audience=_AUD)
+
+
+# Touch Headers import to keep linters quiet (used implicitly by Request init).
+def test_headers_import_sanity():
+    h = Headers({"x": "y"})
+    assert h.get("x") == "y"

--- a/server/tests/unit/test_ai_auth.py
+++ b/server/tests/unit/test_ai_auth.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import base64
+import dataclasses
 import hashlib
 import hmac
 import json
@@ -27,7 +28,6 @@ from opds_sync.api.ai_auth import (
 )
 from opds_sync.core.auth import CalibreAuthValidator
 from opds_sync.core.logging_ctx import request_id_var
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -156,16 +156,14 @@ def test_principal_shape_is_frozen_and_hashable():
     assert p.auth_mode == "basic"
     assert p.request_id == "rid-1"
     # frozen → cannot mutate
-    with pytest.raises(Exception):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         p.subject = "bob"  # type: ignore[misc]
-    # hashable (scopes is a tuple, not a list)
-    {p}
+    # hashable (scopes is a tuple, not a list) — must not raise
+    hash(p)
 
 
 def test_principal_request_id_defaults_none():
-    p = AiPrincipal(
-        subject="a", tenant_id="t", scopes=(), auth_mode="basic"
-    )
+    p = AiPrincipal(subject="a", tenant_id="t", scopes=(), auth_mode="basic")
     assert p.request_id is None
 
 
@@ -374,9 +372,7 @@ async def test_token_exp_equals_now_rejected():
 async def test_token_iat_too_far_in_future_rejected():
     now = 1_700_000_000
     auth = _token_auth(now=now)
-    token = _sign_token(
-        _good_claims(now, iat=now + 3600, exp=now + 3700), secret=_SECRET
-    )
+    token = _sign_token(_good_claims(now, iat=now + 3600, exp=now + 3700), secret=_SECRET)
     await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
 
 
@@ -390,9 +386,7 @@ async def test_token_exp_lte_iat_rejected():
 async def test_token_lifetime_over_24h_rejected():
     now = 1_700_000_000
     auth = _token_auth(now=now)
-    token = _sign_token(
-        _good_claims(now, iat=now, exp=now + 86_401), secret=_SECRET
-    )
+    token = _sign_token(_good_claims(now, iat=now, exp=now + 86_401), secret=_SECRET)
     await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))
 
 
@@ -443,9 +437,7 @@ async def test_token_signature_wrong_length_rejected():
 
 
 # Claim validation
-@pytest.mark.parametrize(
-    "drop", ["iss", "aud", "exp", "iat", "sub", "tenant_id"]
-)
+@pytest.mark.parametrize("drop", ["iss", "aud", "exp", "iat", "sub", "tenant_id"])
 async def test_token_missing_required_claim_rejected(drop):
     now = 1_700_000_000
     auth = _token_auth(now=now)
@@ -523,9 +515,7 @@ async def test_token_bearer_extra_tokens_rejected():
     now = 1_700_000_000
     auth = _token_auth(now=now)
     token = _sign_token(_good_claims(now), secret=_SECRET)
-    await _expect_401(
-        auth, _make_token_req({"authorization": f"Bearer {token} extra"})
-    )
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token} extra"}))
 
 
 async def test_token_segment_count_wrong_rejected():
@@ -560,9 +550,7 @@ async def test_token_non_base64url_chars_rejected():
     h, p, s = token.split(".")
     # Inject a `+` (standard base64, NOT url-safe).
     tampered_p = "+" + p[1:]
-    await _expect_401(
-        auth, _make_token_req({"authorization": f"Bearer {h}.{tampered_p}.{s}"})
-    )
+    await _expect_401(auth, _make_token_req({"authorization": f"Bearer {h}.{tampered_p}.{s}"}))
 
 
 async def test_token_header_array_rejected():
@@ -570,9 +558,7 @@ async def test_token_header_array_rejected():
     auth = _token_auth(now=now)
     # Build by hand: header is a JSON array, not an object.
     header_b64 = _b64url(json.dumps(["HS256", "k1"]).encode("utf-8"))
-    payload_b64 = _b64url(
-        json.dumps(_good_claims(now), separators=(",", ":")).encode("utf-8")
-    )
+    payload_b64 = _b64url(json.dumps(_good_claims(now), separators=(",", ":")).encode("utf-8"))
     sig_b64 = _b64url(b"\x00" * 32)
     token = f"{header_b64}.{payload_b64}.{sig_b64}"
     await _expect_401(auth, _make_token_req({"authorization": f"Bearer {token}"}))

--- a/server/tests/unit/test_main_ai_auth_validation.py
+++ b/server/tests/unit/test_main_ai_auth_validation.py
@@ -1,0 +1,170 @@
+"""Startup validation of AI auth settings (PR-B).
+
+Verifies that token-mode misconfigurations crash `create_app()` loudly,
+that basic mode is unaffected, and that AI-disabled deploys never check
+auth settings at all.
+
+The tests build the app via `opds_sync.main.create_app()` so they exercise
+the actual production wiring, including `_validate_ai_auth_settings` and
+`_build_ai_authenticator`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from opds_sync.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    # Strip every AI-related env var so each test starts from the documented
+    # defaults. Tests then opt back in via monkeypatch.setenv.
+    for var in (
+        "OPDS_SYNC_AI_ENABLED",
+        "OPDS_SYNC_AI_AUTH_MODE",
+        "OPDS_SYNC_AI_TOKEN_SECRETS",
+        "OPDS_SYNC_AI_TOKEN_ISSUER",
+        "OPDS_SYNC_AI_TOKEN_AUDIENCE",
+        "OPDS_SYNC_AI_BASE_URL",
+        "OPDS_SYNC_AI_MODEL",
+        "OPDS_SYNC_AI_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Avoid the real DB / CWA wiring touching the network in create_app.
+    monkeypatch.setenv("OPDS_SYNC_DATABASE_URL", "postgresql+asyncpg://x/y")
+    monkeypatch.setenv("OPDS_SYNC_CWA_BASE_URL", "http://stub")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _create_app():
+    # Re-import to ensure the function captures the freshly-cleared settings.
+    from opds_sync.main import create_app
+
+    return create_app()
+
+
+# ---------------------------------------------------------------------------
+# Basic mode: untouched
+# ---------------------------------------------------------------------------
+
+
+def test_basic_mode_no_token_settings_required():
+    # Default: ai_enabled=true, ai_auth_mode=basic, nothing token-related set.
+    app = _create_app()
+    assert getattr(app.state, "ai_authenticator", None) is not None
+    # Type sanity: basic implementation wraps the calibre validator.
+    from opds_sync.api.ai_auth import BasicAuthAiAuthenticator
+
+    assert isinstance(app.state.ai_authenticator, BasicAuthAiAuthenticator)
+
+
+def test_basic_mode_ignores_stray_token_settings(monkeypatch):
+    # Operator left token settings around but kept mode=basic — must not raise.
+    monkeypatch.setenv("OPDS_SYNC_AI_TOKEN_SECRETS", '{"k1": "short"}')
+    app = _create_app()
+    from opds_sync.api.ai_auth import BasicAuthAiAuthenticator
+
+    assert isinstance(app.state.ai_authenticator, BasicAuthAiAuthenticator)
+
+
+# ---------------------------------------------------------------------------
+# AI disabled: skip auth wiring entirely
+# ---------------------------------------------------------------------------
+
+
+def test_ai_disabled_skips_token_validation(monkeypatch):
+    # Token mode + missing secrets would normally crash, but ai_enabled=false
+    # bypasses the entire AI block.
+    monkeypatch.setenv("OPDS_SYNC_AI_ENABLED", "false")
+    monkeypatch.setenv("OPDS_SYNC_AI_AUTH_MODE", "token")
+    app = _create_app()
+    assert getattr(app.state, "ai_authenticator", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Token mode: every misconfiguration raises
+# ---------------------------------------------------------------------------
+
+
+def _token_env(monkeypatch, *, secrets='{"k1":"' + "x" * 32 + '"}', iss="quire", aud="opds"):
+    monkeypatch.setenv("OPDS_SYNC_AI_AUTH_MODE", "token")
+    if secrets is not None:
+        monkeypatch.setenv("OPDS_SYNC_AI_TOKEN_SECRETS", secrets)
+    if iss is not None:
+        monkeypatch.setenv("OPDS_SYNC_AI_TOKEN_ISSUER", iss)
+    if aud is not None:
+        monkeypatch.setenv("OPDS_SYNC_AI_TOKEN_AUDIENCE", aud)
+
+
+def test_token_mode_secrets_missing_raises(monkeypatch):
+    _token_env(monkeypatch, secrets=None)
+    with pytest.raises(RuntimeError, match="AI_TOKEN_SECRETS"):
+        _create_app()
+
+
+def test_token_mode_secrets_empty_raises(monkeypatch):
+    _token_env(monkeypatch, secrets="{}")
+    with pytest.raises(RuntimeError, match="AI_TOKEN_SECRETS"):
+        _create_app()
+
+
+def test_token_mode_secret_too_short_raises(monkeypatch):
+    _token_env(monkeypatch, secrets='{"k1": "short"}')
+    with pytest.raises(RuntimeError, match="32 bytes"):
+        _create_app()
+
+
+def test_token_mode_empty_kid_raises(monkeypatch):
+    _token_env(monkeypatch, secrets='{"": "' + "x" * 32 + '"}')
+    with pytest.raises(RuntimeError, match="kid"):
+        _create_app()
+
+
+def test_token_mode_issuer_missing_raises(monkeypatch):
+    _token_env(monkeypatch, iss=None)
+    with pytest.raises(RuntimeError, match="AI_TOKEN_ISSUER"):
+        _create_app()
+
+
+def test_token_mode_issuer_whitespace_raises(monkeypatch):
+    _token_env(monkeypatch, iss="   ")
+    with pytest.raises(RuntimeError, match="AI_TOKEN_ISSUER"):
+        _create_app()
+
+
+def test_token_mode_audience_missing_raises(monkeypatch):
+    _token_env(monkeypatch, aud=None)
+    with pytest.raises(RuntimeError, match="AI_TOKEN_AUDIENCE"):
+        _create_app()
+
+
+def test_token_mode_audience_whitespace_raises(monkeypatch):
+    _token_env(monkeypatch, aud=" \t")
+    with pytest.raises(RuntimeError, match="AI_TOKEN_AUDIENCE"):
+        _create_app()
+
+
+def test_token_mode_unconfigured_provider_still_wires_token_auth(monkeypatch):
+    """AI provider missing but token mode fully configured → /ai/v1/config
+    mounts AND requires a Bearer token. The authenticator must be the token
+    impl, not silently downgraded to basic.
+    """
+    _token_env(monkeypatch)
+    # ai_base_url and ai_model intentionally not set.
+    app = _create_app()
+    from opds_sync.api.ai_auth import TokenAiAuthenticator
+
+    assert isinstance(app.state.ai_authenticator, TokenAiAuthenticator)
+
+
+def test_token_mode_fully_configured(monkeypatch):
+    _token_env(monkeypatch)
+    monkeypatch.setenv("OPDS_SYNC_AI_BASE_URL", "http://ollama.lan:11434/v1")
+    monkeypatch.setenv("OPDS_SYNC_AI_MODEL", "llama3:8b")
+    app = _create_app()
+    from opds_sync.api.ai_auth import TokenAiAuthenticator
+
+    assert isinstance(app.state.ai_authenticator, TokenAiAuthenticator)

--- a/server/tests/unit/test_settings.py
+++ b/server/tests/unit/test_settings.py
@@ -49,3 +49,43 @@ def test_max_request_bytes_env_override(monkeypatch):
     monkeypatch.setenv("OPDS_SYNC_MAX_REQUEST_BYTES", "2048")
     s = Settings()
     assert s.max_request_bytes == 2048
+
+
+# --- PR-B: AI auth abstraction --------------------------------------------
+
+
+def test_ai_auth_mode_defaults_to_basic(monkeypatch):
+    for var in (
+        "OPDS_SYNC_AI_AUTH_MODE",
+        "OPDS_SYNC_AI_TOKEN_SECRETS",
+        "OPDS_SYNC_AI_TOKEN_ISSUER",
+        "OPDS_SYNC_AI_TOKEN_AUDIENCE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    s = Settings()
+    assert s.ai_auth_mode == "basic"
+    assert s.ai_token_secrets is None
+    assert s.ai_token_issuer is None
+    assert s.ai_token_audience is None
+
+
+def test_ai_auth_mode_env_override(monkeypatch):
+    monkeypatch.setenv("OPDS_SYNC_AI_AUTH_MODE", "token")
+    s = Settings()
+    assert s.ai_auth_mode == "token"
+
+
+def test_ai_token_secrets_parses_json_object(monkeypatch):
+    monkeypatch.setenv(
+        "OPDS_SYNC_AI_TOKEN_SECRETS", '{"k1": "a" , "k2": "b"}'
+    )
+    s = Settings()
+    assert s.ai_token_secrets == {"k1": "a", "k2": "b"}
+
+
+def test_ai_token_issuer_audience_env_override(monkeypatch):
+    monkeypatch.setenv("OPDS_SYNC_AI_TOKEN_ISSUER", "quire-cloud")
+    monkeypatch.setenv("OPDS_SYNC_AI_TOKEN_AUDIENCE", "opds-sync")
+    s = Settings()
+    assert s.ai_token_issuer == "quire-cloud"
+    assert s.ai_token_audience == "opds-sync"

--- a/server/tests/unit/test_settings.py
+++ b/server/tests/unit/test_settings.py
@@ -76,9 +76,7 @@ def test_ai_auth_mode_env_override(monkeypatch):
 
 
 def test_ai_token_secrets_parses_json_object(monkeypatch):
-    monkeypatch.setenv(
-        "OPDS_SYNC_AI_TOKEN_SECRETS", '{"k1": "a" , "k2": "b"}'
-    )
+    monkeypatch.setenv("OPDS_SYNC_AI_TOKEN_SECRETS", '{"k1": "a" , "k2": "b"}')
     s = Settings()
     assert s.ai_token_secrets == {"k1": "a", "k2": "b"}
 


### PR DESCRIPTION
## Summary

Introduces an `AiPrincipal` dependency for all `/ai/v1/*` routes so future hosted Quire Cloud AI can swap auth backends without endpoint churn. No new endpoints; no migrations; default-mode (`basic`) deployments see zero behavior change.

## What changed

- **`opds_sync/api/ai_auth.py`** — new module: `AiPrincipal{subject, tenant_id, scopes, auth_mode, request_id}`, `AiAuthenticator` protocol, `BasicAuthAiAuthenticator` (wraps existing calibre-web verifier; `tenant_id="local"`, `auth_mode="basic"`), `TokenAiAuthenticator` (HMAC-SHA256 with kid rotation via `OPDS_SYNC_AI_TOKEN_SECRETS`).
- **`opds_sync/config.py`** — `ai_auth_mode: Literal["basic","token"] = "basic"`, `ai_token_secrets: dict[str,str] | None`. Token mode with absent/empty secrets → startup error.
- **`opds_sync/api/ai.py`** — routes depend on `AiPrincipal` instead of `CalibreWebUser`. The three `tenant_id="local"` hardcodes from PR-C are replaced with `principal.tenant_id`.
- **`opds_sync/main.py`** — fail-fast startup validation for token mode.
- Sync routers (`/sync/v1/*`) unchanged.

## Test plan

- `BasicAuthAiAuthenticator`: valid credential → correct `AiPrincipal`; bad credential → 401.
- `TokenAiAuthenticator`: valid HMAC token → `AiPrincipal`; expired/wrong-aud/wrong-iss/missing-kid/unknown-kid/tampered-signature → 401. Multiple `kid`s for rotation — both accepted.
- Mode-switching: `OPDS_SYNC_AI_AUTH_MODE=basic` rejects token-style requests; `=token` rejects basic-style requests.
- Cache-hit + `ai_generation_log`: with token auth, log rows carry the token's `tenant_id`, not `"local"`.
- 243 / 243 tests pass.

## Spec + plan

- `docs/superpowers/specs/2026-05-16-ai-auth-abstraction-design.md`
- `docs/superpowers/plans/2026-05-16-ai-auth-abstraction.md`

## Review summary

GPT architect review captured in the spec. Verdict: APPROVE.