### PR TITLE
feat: AI provider health endpoint

### DIFF
--- a/app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
+++ b/app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
@@ -74,4 +74,14 @@ class AiRepository(
     suspend fun invalidate(identity: DocumentIdentity) {
         client.invalidateInsight(identity)
     }
+
+    /**
+     * One-shot fetch of the server's AI-provider and retrieval-source health.
+     *
+     * Returns `null` on any HTTP error (including a 404 when the server runs
+     * with AI disabled). The Settings screen treats `null` as "hide the
+     * status row" — never surfaces a stack trace.
+     */
+    suspend fun fetchHealth(): AiHealthResponse? =
+        runCatching { client.getHealth() }.getOrNull()
 }

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
@@ -33,10 +33,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import io.theficos.ereader.data.ai.AiHealthResponse
+import io.theficos.ereader.data.ai.RetrievalSourceHealth
 import io.theficos.ereader.reader.ReaderFontFamily
 import io.theficos.ereader.reader.ReaderTheme
 import io.theficos.ereader.ui.components.QuireCard
 import io.theficos.ereader.ui.components.SectionLabel
+import java.time.Instant
+import java.time.format.DateTimeParseException
 
 /**
  * Curated languages shown in the AI insight language dropdown. The server
@@ -267,7 +271,11 @@ fun SettingsScreen(
             } else {
                 val cfg = aiState.config!!
                 val enabled = aiState.preferences?.aiEnabled == true
+                val health = aiState.health
                 Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    if (health != null) {
+                        AiHealthStatusBlock(health)
+                    }
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.Top,
@@ -400,5 +408,67 @@ private fun formatRelative(epochMs: Long): String {
         deltaSec < 3600 -> "${deltaSec / 60}m ago"
         deltaSec < 86_400 -> "${deltaSec / 3600}h ago"
         else -> "${deltaSec / 86_400}d ago"
+    }
+}
+
+/** Parse an ISO-8601 timestamp into epoch millis, returning null on failure. */
+private fun parseIsoOrNull(iso: String?): Long? {
+    if (iso == null) return null
+    return try {
+        Instant.parse(iso).toEpochMilli()
+    } catch (_: DateTimeParseException) {
+        null
+    }
+}
+
+@Composable
+private fun AiHealthStatusBlock(health: AiHealthResponse) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text("Status", style = MaterialTheme.typography.titleMedium)
+
+        // Provider row.
+        val providerCheckedMs = parseIsoOrNull(health.providerLastCheckedAt)
+        val providerFailureMs = parseIsoOrNull(health.lastFailureAt)
+        val (providerText, providerColor) = when (health.providerReachable) {
+            null -> "Provider: not yet checked" to MaterialTheme.colorScheme.onSurfaceVariant
+            true -> {
+                val modelSuffix = health.modelId?.let { " (model: $it)" } ?: ""
+                val whenSuffix = providerCheckedMs?.let { ", checked ${formatRelative(it)}" } ?: ""
+                "Provider: reachable$modelSuffix$whenSuffix" to MaterialTheme.colorScheme.onSurface
+            }
+            false -> {
+                val errClass = health.lastFailureClass ?: "unknown error"
+                val whenSuffix = providerFailureMs?.let { ", ${formatRelative(it)}" } ?: ""
+                "Provider: unreachable — $errClass$whenSuffix" to MaterialTheme.colorScheme.error
+            }
+        }
+        Text(
+            providerText,
+            style = MaterialTheme.typography.bodyMedium,
+            color = providerColor,
+        )
+
+        // Retrieval sources, one row each.
+        health.retrievalSources.forEach { source ->
+            val (text, color) = formatRetrievalSource(source)
+            Text(text, style = MaterialTheme.typography.bodyMedium, color = color)
+        }
+    }
+}
+
+@Composable
+private fun formatRetrievalSource(source: RetrievalSourceHealth): Pair<String, androidx.compose.ui.graphics.Color> {
+    val label = source.name.replaceFirstChar { it.uppercase() }
+    val checkedMs = parseIsoOrNull(source.lastCheckedAt)
+    return when (source.reachable) {
+        null -> "$label: not yet checked" to MaterialTheme.colorScheme.onSurfaceVariant
+        true -> {
+            val whenSuffix = checkedMs?.let { ", checked ${formatRelative(it)}" } ?: ""
+            "$label: reachable$whenSuffix" to MaterialTheme.colorScheme.onSurface
+        }
+        false -> {
+            val whenSuffix = checkedMs?.let { ", ${formatRelative(it)}" } ?: ""
+            "$label: unreachable$whenSuffix" to MaterialTheme.colorScheme.error
+        }
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import io.theficos.ereader.auth.CalibreCredentialStore
 import io.theficos.ereader.auth.CalibreCredentials
 import io.theficos.ereader.data.ai.AiConfig
+import io.theficos.ereader.data.ai.AiHealthResponse
 import io.theficos.ereader.data.ai.AiPreferences
 import io.theficos.ereader.data.ai.AiRepository
 import io.theficos.ereader.data.local.DocumentRepository
@@ -33,6 +34,7 @@ data class AiState(
     val config: AiConfig? = null,
     val preferences: AiPreferences? = null,
     val toggling: Boolean = false,
+    val health: AiHealthResponse? = null,
 )
 
 class SettingsViewModel(
@@ -52,17 +54,30 @@ class SettingsViewModel(
     private val _sync = MutableStateFlow(SyncUiState(hasCredentials = store.get() != null, lastSyncedAtMs = null))
     val sync: StateFlow<SyncUiState> = _sync.asStateFlow()
 
+    private val _aiHealth = MutableStateFlow<AiHealthResponse?>(null)
+
     val ai: StateFlow<AiState> = combine(
         aiRepository.config,
         aiRepository.preferences,
-    ) { c, p -> AiState(config = c, preferences = p) }.stateIn(
+        _aiHealth,
+    ) { c, p, h -> AiState(config = c, preferences = p, health = h) }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5_000),
         AiState(),
     )
 
     init {
-        viewModelScope.launch { aiRepository.refresh() }
+        viewModelScope.launch {
+            aiRepository.refresh()
+            _aiHealth.value = aiRepository.fetchHealth()
+        }
+    }
+
+    /** Refresh the AI health snapshot. Safe to call from the UI on screen entry. */
+    fun refreshAiHealth() {
+        viewModelScope.launch {
+            _aiHealth.value = aiRepository.fetchHealth()
+        }
     }
 
     private fun loadInitialCalibre(): CalibreUiState {

--- a/app/src/test/java/io/theficos/ereader/data/ai/AiRepositoryHealthTest.kt
+++ b/app/src/test/java/io/theficos/ereader/data/ai/AiRepositoryHealthTest.kt
@@ -1,0 +1,138 @@
+package io.theficos.ereader.data.ai
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Verifies that [AiRepository.fetchHealth] deserializes the server response
+ * shape correctly and returns null on errors instead of throwing.
+ *
+ * The server contract is documented in
+ * `docs/superpowers/specs/2026-05-16-ai-health-endpoint-design.md`.
+ */
+class AiRepositoryHealthTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: AiClient
+    private lateinit var repo: AiRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = AiClient(
+            baseUrlProvider = { server.url("").toString().trimEnd('/') },
+            http = OkHttpClient.Builder()
+                .callTimeout(5, TimeUnit.SECONDS)
+                .build(),
+        )
+        repo = AiRepository(client)
+    }
+
+    @After
+    fun tearDown() = server.shutdown()
+
+    @Test
+    fun `fetchHealth deserializes a typical response`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "provider_reachable": true,
+                  "provider_last_checked_at": "2026-05-16T14:32:11Z",
+                  "model_id": "llama3.1:8b",
+                  "last_failure_at": null,
+                  "last_failure_class": null,
+                  "retrieval_sources": [
+                    {"name": "wikipedia", "reachable": true, "last_checked_at": "2026-05-16T14:32:09Z"},
+                    {"name": "openlibrary", "reachable": null, "last_checked_at": null}
+                  ]
+                }
+                """.trimIndent()
+            )
+        )
+
+        val health = repo.fetchHealth()
+        assertThat(health).isNotNull()
+        assertThat(health!!.providerReachable).isTrue()
+        assertThat(health.modelId).isEqualTo("llama3.1:8b")
+        assertThat(health.providerLastCheckedAt).isEqualTo("2026-05-16T14:32:11Z")
+        assertThat(health.lastFailureClass).isNull()
+        assertThat(health.retrievalSources).hasSize(2)
+        assertThat(health.retrievalSources[0].name).isEqualTo("wikipedia")
+        assertThat(health.retrievalSources[0].reachable).isTrue()
+        assertThat(health.retrievalSources[1].name).isEqualTo("openlibrary")
+        assertThat(health.retrievalSources[1].reachable).isNull()
+        assertThat(health.retrievalSources[1].lastCheckedAt).isNull()
+    }
+
+    @Test
+    fun `fetchHealth deserializes an all-null response`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "provider_reachable": null,
+                  "provider_last_checked_at": null,
+                  "model_id": null,
+                  "last_failure_at": null,
+                  "last_failure_class": null,
+                  "retrieval_sources": []
+                }
+                """.trimIndent()
+            )
+        )
+
+        val health = repo.fetchHealth()
+        assertThat(health).isNotNull()
+        assertThat(health!!.providerReachable).isNull()
+        assertThat(health.modelId).isNull()
+        assertThat(health.retrievalSources).isEmpty()
+    }
+
+    @Test
+    fun `fetchHealth deserializes a failure response with error class`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "provider_reachable": false,
+                  "provider_last_checked_at": "2026-05-16T15:00:00Z",
+                  "model_id": "llama3.1:8b",
+                  "last_failure_at": "2026-05-16T15:00:00Z",
+                  "last_failure_class": "ProviderTimeout",
+                  "retrieval_sources": []
+                }
+                """.trimIndent()
+            )
+        )
+
+        val health = repo.fetchHealth()
+        assertThat(health).isNotNull()
+        assertThat(health!!.providerReachable).isFalse()
+        assertThat(health.lastFailureClass).isEqualTo("ProviderTimeout")
+        // model_id preserved from the prior success even though current state is failed.
+        assertThat(health.modelId).isEqualTo("llama3.1:8b")
+    }
+
+    @Test
+    fun `fetchHealth returns null on 404 (server in AI-disabled mode)`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404).setBody("Not Found"))
+        val health = repo.fetchHealth()
+        assertThat(health).isNull()
+    }
+
+    @Test
+    fun `fetchHealth returns null on 500`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500).setBody("oops"))
+        val health = repo.fetchHealth()
+        assertThat(health).isNull()
+    }
+}

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiClient.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiClient.kt
@@ -40,6 +40,10 @@ class AiClient(
     suspend fun getPreferences(): AiPreferences =
         get("/ai/v1/preferences")
 
+    /** Operational health snapshot for the AI provider + retrieval sources. */
+    suspend fun getHealth(): AiHealthResponse =
+        get("/ai/v1/health")
+
     /** PUT preferences. Either or both fields may be sent; pass nulls for unchanged. */
     suspend fun setPreferences(
         enabled: Boolean? = null,

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt
@@ -97,3 +97,33 @@ data class QuotaInfo(
     val limit: Int,
     @SerialName("resets_at") val resetsAt: String,
 )
+
+/**
+ * One entry in [AiHealthResponse.retrievalSources].
+ *
+ * Tri-state [reachable]:
+ *  - `null`  → never observed this process lifetime.
+ *  - `true`  → last HTTP call to this source completed (any status code).
+ *  - `false` → last call failed at the transport level (timeout, DNS, …).
+ */
+@Serializable
+data class RetrievalSourceHealth(
+    val name: String,
+    val reachable: Boolean? = null,
+    @SerialName("last_checked_at") val lastCheckedAt: String? = null,
+)
+
+/**
+ * Body of `GET /ai/v1/health`. Process-local snapshot from one server replica.
+ * On process restart all fields reset to null; that is part of the contract
+ * and is rendered as "not yet checked" by the UI.
+ */
+@Serializable
+data class AiHealthResponse(
+    @SerialName("provider_reachable") val providerReachable: Boolean? = null,
+    @SerialName("provider_last_checked_at") val providerLastCheckedAt: String? = null,
+    @SerialName("model_id") val modelId: String? = null,
+    @SerialName("last_failure_at") val lastFailureAt: String? = null,
+    @SerialName("last_failure_class") val lastFailureClass: String? = null,
+    @SerialName("retrieval_sources") val retrievalSources: List<RetrievalSourceHealth> = emptyList(),
+)

--- a/docs/superpowers/plans/2026-05-16-ai-health-endpoint.md
+++ b/docs/superpowers/plans/2026-05-16-ai-health-endpoint.md
@@ -1,0 +1,269 @@
+# Plan — PR5 AI provider health endpoint
+
+**Spec:** [`2026-05-16-ai-health-endpoint-design.md`](../specs/2026-05-16-ai-health-endpoint-design.md)
+**Branch:** `feat/ai-health-endpoint`
+**Author/Owner:** PR5 agent
+**Status:** Ready
+
+## Big picture
+
+Add a process-local in-memory health holder, wire it into the AI orchestrator
+and retriever, expose it as `GET /ai/v1/health`, and surface the snapshot in
+the Android Settings AI section. Code-only PR: no migrations, no new env
+vars, no new external destinations.
+
+## Pre-flight
+
+- Worktree: `.claude/worktrees/pr5-ai-health` on `feat/ai-health-endpoint`
+  branched from `origin/main`. ✓ done.
+- Test infra exists: `server/tests/{unit,integration}` with `client_factory`
+  fixture in integration/conftest.py and a working fake-AI-via-httpx-transport
+  pattern.
+
+## Steps
+
+### 1. Server: state holder (TDD)
+
+Files: `server/opds_sync/core/ai/health_state.py`,
+`server/tests/unit/test_ai_health_state.py`.
+
+1. Write `test_ai_health_state.py` first. Cases:
+   - `AiHealthState()` snapshot has all-null fields (`provider_reachable=None`
+     AND `provider_last_checked_at=None`; never one without the other).
+   - `record_provider_success(model_id="m")` sets reachable=True, model_id,
+     `provider_last_checked_at` non-null, and clears `last_failure_at` /
+     `last_failure_class` to None.
+   - `record_provider_failure(error_class="ProviderTimeout")` on a fresh
+     state: reachable=False, `provider_last_checked_at` non-null,
+     `last_failure_at` non-null, `last_failure_class="ProviderTimeout"`,
+     `model_id=None` (no prior success).
+   - `record_provider_failure` after a prior success: model_id preserved
+     from prior success; everything else as above.
+   - Success-after-failure clears failure fields (recovery semantics).
+   - `record_retrieval("wikipedia", True)` adds entry with `reachable=True`
+     and non-null `last_checked_at`.
+   - `record_retrieval("openlibrary", False)` adds independent entry; does
+     not modify wikipedia entry.
+   - Snapshot is an independent deep-ish copy (mutating snapshot.retrieval_sources
+     doesn't mutate the holder).
+   - 1000-call concurrent `asyncio.gather` writes: snapshot remains consistent
+     (reachable matches model_id correctly; tri-state invariants hold).
+2. Implement `health_state.py`:
+   - `RetrievalSourceState` dataclass with tri-state `reachable: bool | None`.
+   - `AiHealthSnapshot` dataclass.
+   - `AiHealthState` class with `asyncio.Lock`-guarded mutations and
+     `snapshot()` that returns an independent copy.
+3. Run unit tests until green.
+
+**Verification:** `uv run pytest server/tests/unit/test_ai_health_state.py -v`
+
+### 2. Server: wire into orchestrator
+
+Files: `server/opds_sync/core/ai/service.py`,
+`server/tests/unit/test_ai_service.py` (regression).
+
+1. Add `health_state: AiHealthState | None = None` constructor param to
+   `InsightOrchestrator`. `None` = no-op updates (keeps existing unit tests
+   that don't care about health from breaking).
+2. In `_do_generate` `try/except` around `chat_structured`:
+   - On success → `await self._health.record_provider_success(model_id=self.model_id)`.
+   - On failure → `await self._health.record_provider_failure(error_class=type(e).__name__)`
+     before re-raise.
+3. Run existing service tests to confirm no regression.
+
+**Verification:** `uv run pytest server/tests/unit/test_ai_service.py -v`
+
+### 3. Server: wire into Retriever
+
+Files: `server/opds_sync/core/ai/retrieval.py`,
+`server/tests/unit/test_ai_retrieval.py` (regression).
+
+1. Add `health_state: AiHealthState | None = None` to `Retriever.__init__`.
+2. In `_fetch_wikipedia`:
+   - Any HTTP response received (including 404, 5xx) →
+     `record_retrieval("wikipedia", True)`. The network call completed, so
+     reachability is True. We do not differentiate "Wikipedia returned a
+     bad page" from "Wikipedia returned a good page" — both prove
+     reachability.
+   - `httpx.HTTPError` (timeout, connection refused, DNS) →
+     `record_retrieval("wikipedia", False)`.
+3. In `lookup_openlibrary`:
+   - Any HTTP response received → `record_retrieval("openlibrary", True)`.
+   - `httpx.HTTPError` → `record_retrieval("openlibrary", False)`.
+4. Cache hits do NOT touch state (the early returns before HTTP call are
+   already untouched by these edits).
+5. Add tests in `test_ai_retrieval.py` verifying state transitions.
+
+**Verification:** `uv run pytest server/tests/unit/test_ai_retrieval.py -v`
+
+### 4. Server: schema + endpoint
+
+Files: `server/opds_sync/api/ai_schemas.py`,
+`server/opds_sync/api/ai.py`.
+
+1. Add `RetrievalSourceHealth` and `AiHealthResponse` Pydantic models.
+   `retrieval_sources` is a list, not a map, for ordering and Android-friendly
+   serialization.
+2. Add `from_snapshot(snap: AiHealthSnapshot, *, seed_sources: tuple[str, ...])`
+   classmethod that emits one entry per configured source even if it has no
+   state yet (so the UI never silently drops a source).
+3. Add `GET /ai/v1/health` route. No `Depends(current_user_id)` — unauth'd.
+4. Mount: in `main.py`, when AI is enabled + configured, create the health
+   holder, attach to `app.state.ai_health`, and pass to the orchestrator + a
+   retriever-factory closure so the retriever gets it too.
+5. In the "enabled but unconfigured" branch, also create a holder and attach
+   it so the endpoint still answers with all-null (instead of mismatch with
+   `/ai/v1/config`).
+
+**Verification:** `uv run pytest server/tests/integration/test_ai_endpoints.py -v`
+
+### 5. Server: endpoint integration tests
+
+File: `server/tests/integration/test_ai_health_endpoint.py` (new).
+
+Cases (all using `client_factory` + `configure_ai` patterns):
+
+1. `test_ai_health_404_when_disabled`: AI disabled → 404.
+2. `test_ai_health_200_when_enabled_unconfigured`: AI enabled, no
+   base_url/model → 200, all-null snapshot. retrieval_sources empty list
+   (no configured sources, nothing to seed).
+3. `test_ai_health_seeded_sources_before_any_call`: AI configured with
+   `ai_sources=wikipedia,openlibrary` and no lookups yet → both sources
+   appear with `reachable=null`.
+4. `test_ai_health_provider_success`: fake AI returns 200 → lookup completes
+   → health shows `provider_reachable=true`, `model_id`, `provider_last_checked_at`
+   populated.
+5. `test_ai_health_provider_timeout`: fake AI httpx mock raises
+   `httpx.ReadTimeout` (mapped to `ProviderTimeout` in `AIClient`) → health
+   shows `provider_reachable=false`, `last_failure_class="ProviderTimeout"`,
+   `provider_last_checked_at` non-null.
+6. `test_ai_health_provider_502`: fake AI returns 502 → health shows
+   `provider_reachable=false`, `last_failure_class="ProviderUnreachable"`.
+7. `test_ai_health_provider_400`: fake AI returns 4xx → health shows
+   `provider_reachable=false`, `last_failure_class="ProviderRejected"`.
+8. `test_ai_health_provider_parse_error`: fake AI returns malformed JSON →
+   `last_failure_class="ProviderParseError"`.
+9. `test_ai_health_recovery_clears_failure`: failure → success → snapshot's
+   `last_failure_at` and `last_failure_class` are null again.
+10. `test_ai_health_cache_hit_doesnt_touch_state`: success → record initial
+    timestamp → cache-hit lookup → snapshot's `provider_last_checked_at`
+    unchanged.
+11. `test_ai_health_no_auth_required`: endpoint returns 200 with no
+    Authorization header (operational visibility).
+12. `test_retriever_cache_hit_doesnt_touch_state` (unit-level): direct
+    Retriever test with a mocked `_read_cache` returning a hit — assert no
+    `record_retrieval` calls happen.
+13. `test_retriever_wikipedia_404_records_reachable_true`: synthetic 404 →
+    health shows `wikipedia.reachable=true` (network worked).
+
+**Verification:** `uv run pytest server/tests/integration/test_ai_health_endpoint.py -v`
+
+### 6. Server: full test sweep
+
+```sh
+cd server
+uv run ruff format .
+uv run ruff check . --fix
+uv run pytest tests/ -v
+```
+
+All three modes (full, sync-only, AI-only) must still pass.
+
+### 7. Android: DTOs + client
+
+Files: `data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt`,
+`data/ai/src/main/java/io/theficos/ereader/data/ai/AiClient.kt`,
+`data/ai/src/test/java/io/theficos/ereader/data/ai/AiClientTest.kt` (extend if exists; new test file otherwise).
+
+1. Add `RetrievalSourceHealth` and `AiHealthResponse` `@Serializable` classes
+   mirroring the server schema.
+2. Add `suspend fun getHealth(): AiHealthResponse` to `AiClient`.
+3. Add a test verifying deserialization (typical + all-null shape).
+
+### 8. Android: repository + ViewModel + UI
+
+Files: `app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt`,
+`app/src/test/java/io/theficos/ereader/data/ai/AiRepositoryHealthTest.kt` (new),
+`app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt`,
+`app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt`.
+
+1. `AiRepository.fetchHealth()`: thin suspend wrapper; no caching at the
+   repo level. Catches `AiHttpException` returns `null` (AI disabled or any
+   error -> UI just hides the row).
+2. `AiRepositoryHealthTest`: MockWebServer-based test that calls
+   `repo.fetchHealth()`, returns canned JSON, asserts the DTO values.
+3. `SettingsViewModel`:
+   - `AiState` gains `health: AiHealthResponse? = null`.
+   - On init alongside `aiRepository.refresh()`, fire `fetchHealth()` and
+     update the state.
+   - Add `refreshAiHealth()` callable from the screen if needed.
+4. `SettingsScreen`: under the existing AI block (when configured), render a
+   small "Status" subsection:
+   - "Provider: reachable (model: <id>)" / "Provider: unreachable —
+     <error_class>, <relative_time>" / "Provider: not yet checked".
+   - One line per retrieval source with the same tri-state rendering.
+   - Reuse the existing `formatRelative` helper for timestamps.
+
+### 9. Android: full sweep
+
+```sh
+./scripts/dgradle :data:ai:test :app:test
+./scripts/dgradle :app:lintDebug
+```
+
+### 10. Docs
+
+File: `docs/sync-api.md`. Add a row to the AI endpoint table and a short
+subsection for `GET /ai/v1/health` describing tri-state semantics, the
+no-active-probing rule, and the process-restart behavior.
+
+### 11. GPT architect review
+
+Per workflow: read
+`/Users/vito/.claude/plugins/marketplaces/jarrodwatts-claude-delegator/prompts/architect.md`,
+delegate via `mcp__codex__codex` with sandbox=read-only. Ask:
+
+1. Tri-state correctness (`None` vs `False` rendering).
+2. Async safety: simple `asyncio.Lock` adequate or do we need
+   `contextvars` / `threading.Lock` for any reason?
+3. Retrieval-source naming convention durability.
+4. Process-restart behavior — confirm reset-to-null is acceptable.
+5. Should retrieval-source state be seeded from `settings.ai_sources` at
+   startup, or lazy on first call?
+
+Max 3 rounds. Capture verdict in PR body.
+
+### 12. Commit + push + PR
+
+- Pre-commit hooks run on commit.
+- Commit message: `:sparkles: feat: AI provider health endpoint`. **No Claude
+  trailer.**
+- Push: `git push -u origin feat/ai-health-endpoint`.
+- PR: `gh pr create --base main --head feat/ai-health-endpoint`.
+
+## Definition of done
+
+- Spec + plan + sync-api.md update committed.
+- Server unit + integration tests green in all three modes.
+- Android tests green.
+- GPT verdict captured in PR body.
+- PR open against `main`. STOP.
+
+## Risks / unknowns
+
+- The orchestrator's `_do_generate` already has a structured `try/except`
+  around `chat_structured`. Inserting the health-state hook there is the
+  minimal change; verify no other code path produces a successful or failed
+  generation that bypasses this method (regenerate goes through the same
+  helper).
+- The retriever's caching layer must not record health on cache hits.
+  Verify the early `return` after `_read_cache` returns non-None bypasses
+  the network code paths.
+
+## Out of scope (documented for next batch)
+
+- Active probing.
+- Multi-replica observability (would require external store).
+- Latency histograms in the response (use `ai_generation_log` joins from
+  PR-C).
+- Operator-only auth.

--- a/docs/superpowers/specs/2026-05-16-ai-health-endpoint-design.md
+++ b/docs/superpowers/specs/2026-05-16-ai-health-endpoint-design.md
@@ -1,0 +1,317 @@
+# PR5 — AI provider health endpoint
+
+**Date:** 2026-05-16
+**Branch:** code-only (no migration)
+**Effort:** Short
+**Deps:** PR-A (mode flags / branch split)
+**Status:** Draft — ready for review
+
+## Goal
+
+Surface AI provider + retrieval-source reachability to operators and users
+without log-scraping. A single `GET /ai/v1/health` returns an in-memory
+snapshot of the last observed call outcomes for:
+
+- The OpenAI-compatible AI provider (`AI_BASE_URL`).
+- Each retrieval source the server is configured to hit (Wikipedia, OpenLibrary).
+
+The endpoint is operational only: it mounts when AI mode is enabled, and is
+distinct from the always-on `/health` and `/readyz` k8s probes (which never
+touched the AI provider and never will — provider downtime is not a deploy
+failure).
+
+## Why now
+
+`PR-A` introduced three deploy modes and an always-on `/health` for k8s. That
+endpoint reports `{ready, modes}` only — it never calls the provider. Operators
+debugging "is the model unreachable today?" today either:
+
+1. Tail the server logs for `ai.generate.error`, OR
+2. Wait for a user to complain that an insight fails.
+
+Both are bad. A small in-memory state holder, updated as a side-effect of
+every `chat_structured` and retrieval call, is enough to answer the question
+cheaply.
+
+This also unblocks a small UX item: the Android Settings AI section can show
+"Provider: reachable" / "unreachable — Timeout 3m ago" without bespoke
+plumbing.
+
+## Non-goals
+
+- **Active health checks.** The server does not ping the provider or Wikipedia
+  proactively. State updates only on real user-driven calls. (Active probing
+  doubles cost on a hosted setup and races against rate limits.)
+- **Persistent state across restarts.** The holder is process-local. On
+  restart everything resets to `None` ("not yet checked"). Multi-replica
+  observability is out of scope per the project's "in-process lock stays"
+  non-goal.
+- **Latency histograms.** Already captured in `ai_generation_log.latency_ms`
+  (PR-C). Health endpoint reports reachability only, not performance.
+- **Per-user state.** Health is server-wide. No `user_id` involvement.
+- **Authn/authz.** The endpoint is unauthenticated for operational visibility.
+  It leaks the configured `model_id` (already exposed by `/ai/v1/config` to
+  authed users) and the names of enabled retrieval sources (already exposed
+  by `/ai/v1/config`). Adding auth would force ops dashboards through Basic
+  auth for no security gain.
+
+## Data model
+
+`opds_sync/core/ai/health_state.py` — new module.
+
+```python
+@dataclass
+class RetrievalSourceState:
+    reachable: bool | None = None         # tri-state: None = never observed
+    last_checked_at: datetime | None = None
+
+@dataclass
+class AiHealthSnapshot:
+    provider_reachable: bool | None = None
+    provider_last_checked_at: datetime | None = None
+    model_id: str | None = None           # latest model we observed succeed
+    last_failure_at: datetime | None = None
+    last_failure_class: str | None = None # type(exc).__name__ from the orchestrator
+    retrieval_sources: dict[str, RetrievalSourceState] = field(default_factory=dict)
+
+
+class AiHealthState:
+    """Process-local in-memory health state for the AI provider and retrieval sources.
+
+    All fields tri-state: None means "never observed". False means "last call failed".
+    True means "last call succeeded". Render False as failing in the UI — but only
+    after a transition from None or True.
+    """
+
+    def __init__(self) -> None: ...
+    async def record_provider_success(self, *, model_id: str) -> None: ...
+    async def record_provider_failure(self, *, error_class: str) -> None: ...
+    async def record_retrieval(self, *, name: str, success: bool) -> None: ...
+    async def snapshot(self) -> AiHealthSnapshot: ...
+```
+
+### Tri-state invariants (post-architect-review)
+
+- `provider_reachable=None` ⇔ `provider_last_checked_at=None` (never observed).
+- `provider_reachable=True` requires `provider_last_checked_at` non-null. Also
+  clears `last_failure_at` and `last_failure_class` to `None` — the contract
+  is "this is the current state", not "this is the all-time history". The
+  audit trail for failures lives in `ai_generation_log` (PR-C) and the
+  structured warning logs, not in this in-memory holder.
+- `provider_reachable=False` requires `provider_last_checked_at`,
+  `last_failure_at`, and `last_failure_class` all non-null. `model_id` is
+  preserved from the most recent success (gives the operator "last seen
+  model" context even when the model is currently down).
+- For each retrieval source: `reachable=None` ⇔ `last_checked_at=None`. A
+  successful round-trip sets `reachable=True`; a network/HTTP failure sets
+  `reachable=False`.
+
+The `model_id` field reports the **most recently observed model** on a
+successful chat completion. We do not echo the configured `AI_MODEL` — that
+is already returned by `/ai/v1/config` and would create a confusing
+"configured=llama3.1:8b but reachable=false on a different model_id" state
+when the provider rejects the configured model. Reporting the observed model
+is the right operational signal.
+
+### Concurrency
+
+FastAPI runs request handlers on the asyncio event loop in a single thread per
+worker. `chat_structured` and retrieval calls happen inside async coroutines.
+Mutations of `AiHealthState` are short critical sections (single attribute
+writes), so they are technically safe under the GIL even without a lock.
+
+We still add an `asyncio.Lock` for the writer side because:
+
+- Future iterations may pack multiple writes into a single update (e.g.
+  "record provider success AND clear last_failure"). A lock now means we
+  don't have to retrofit when that happens.
+- Snapshots compose 6+ attributes plus a dict; a lock guarantees the reader
+  sees a coherent view (no torn read where `provider_reachable=False` but
+  `last_failure_class=None`).
+
+Reads use the same lock and produce a deep-enough copy (dict copy + dataclass
+copy) that the caller can mutate freely without poisoning the holder.
+
+### Process-restart behavior
+
+On restart, all fields reset to `None`. This is intentional and acceptable
+for the use case ("did the last user-driven call work?"). Documented in
+the endpoint response: clients render `null` as "not yet checked", which is
+the truthful state until the first real call lands.
+
+## Hook points
+
+### Provider
+
+`opds_sync/core/ai/service.py::InsightOrchestrator._do_generate` already wraps
+the `chat_structured` call in `try/except`. We extend that block:
+
+```python
+try:
+    payload = await self.ai.chat_structured(...)
+except Exception as e:
+    ...
+    await self._health.record_provider_failure(error_class=type(e).__name__)
+    raise
+await self._health.record_provider_success(model_id=self.model_id)
+```
+
+The orchestrator gets a new `health_state: AiHealthState` field, supplied via
+the constructor. `main.py` creates one `AiHealthState` instance per process
+and wires it into the orchestrator.
+
+### Retrieval
+
+`opds_sync/core/ai/retrieval.py::Retriever`:
+
+- `_fetch_wikipedia`: on any HTTP response (including 404, which Wikipedia
+  legitimately returns for unknown titles) → `record_retrieval("wikipedia", True)`.
+  The reachability signal is "did the network call complete?" — a 404 means
+  Wikipedia was reached and answered cleanly. Only `httpx.HTTPError` (timeout,
+  connection refused, DNS, etc.) or other non-HTTP-response failures →
+  `record_retrieval("wikipedia", False)`.
+- `lookup_openlibrary`: on any HTTP response (including non-200) →
+  `record_retrieval("openlibrary", True)`. OpenLibrary's REST surface treats
+  non-200 as a regular response, not an outage. Only `httpx.HTTPError` and
+  similar transport failures → `record_retrieval("openlibrary", False)`.
+
+Retrieval source names are restricted to the canonical lowercase set
+(`"wikipedia"`, `"openlibrary"`) that the orchestrator already uses for
+`sources_enabled`. The retriever passes them as bare string literals — no
+configuration-driven naming. This prevents an `ai_sources` env var typo
+from leaking into the health response as a new source row.
+
+**Cache hits do not update state.** If the retrieval cache hits, the network
+was not touched and the state from the last real fetch should remain. This
+matters: a cached 30-day-old Wikipedia entry should not refresh "reachable=true"
+because nothing was actually reached.
+
+The `Retriever` constructor takes an optional `health_state: AiHealthState | None`.
+When `None` (e.g. unit tests that don't care about health), updates are no-ops.
+
+## Endpoint
+
+`opds_sync/api/ai.py`:
+
+```python
+@router.get("/health", response_model=AiHealthResponse)
+async def get_ai_health(request: Request) -> AiHealthResponse:
+    state = getattr(request.app.state, "ai_health", None)
+    if state is None:
+        # AI router mounted (ai_enabled=true) but health holder wasn't wired —
+        # only happens in the "enabled but unconfigured" branch of main.py.
+        # Return an empty snapshot so the endpoint still behaves uniformly.
+        return AiHealthResponse(...)  # all-null
+    snap = await state.snapshot()
+    return AiHealthResponse.from_snapshot(snap)
+```
+
+No auth. The endpoint mounts only when `ai_enabled=true` (router gate). AI-
+disabled deploys → 404 (router not mounted).
+
+### Response schema (`AiHealthResponse` in `ai_schemas.py`)
+
+```json
+{
+  "provider_reachable": true,
+  "provider_last_checked_at": "2026-05-16T14:32:11Z",
+  "model_id": "llama3.1:8b",
+  "last_failure_at": null,
+  "last_failure_class": null,
+  "retrieval_sources": [
+    {"name": "wikipedia", "reachable": true, "last_checked_at": "2026-05-16T14:32:09Z"},
+    {"name": "openlibrary", "reachable": null, "last_checked_at": null}
+  ]
+}
+```
+
+Retrieval sources are emitted as a list (not a map) for stable ordering and to
+match the Android serializer style used elsewhere. Sources are listed even if
+never observed (`reachable=null`), seeded from `settings.ai_sources` at app
+startup. This way the UI shows "OpenLibrary: not yet checked" instead of
+silently omitting it.
+
+## Android
+
+`:data:ai` adds `AiHealthResponse` DTOs and `AiClient.getHealth()`.
+`AiRepository.fetchHealth()` is a one-shot `suspend` (no caching at the
+repository level — the Settings screen calls it on screen entry).
+
+Settings screen: small status block in the AI section under the model line.
+Renders three states per row:
+
+- `null` → `"Provider: not yet checked"` (muted text).
+- `true` → `"Provider: reachable (model: llama3.1:8b)"`.
+- `false` → `"Provider: unreachable — ProviderTimeout, 4m ago"` (error color).
+
+Same shape for each retrieval source.
+
+## Tests
+
+### Server unit tests (`test_ai_health_state.py`)
+
+- Fresh state: all fields null.
+- `record_provider_success` → `provider_reachable=True`, `model_id` set,
+  `provider_last_checked_at` set.
+- `record_provider_failure` after success → `provider_reachable=False`,
+  `last_failure_*` set; `model_id` preserved from prior success.
+- `record_retrieval(name, True/False)` → entry created or updated; never
+  overwrites other source entries.
+- `snapshot()` returns an independent copy: mutating the snapshot doesn't
+  mutate the holder.
+- Concurrent writes: 1000 record-success calls from `asyncio.gather` produce
+  no torn reads.
+
+### Server integration tests (`test_ai_health_endpoint.py`)
+
+- AI-disabled mode: `GET /ai/v1/health` → 404.
+- AI-enabled but unconfigured: `GET /ai/v1/health` → 200, snapshot all-null.
+- AI-enabled + configured + zero calls: 200, snapshot all-null except
+  retrieval sources list with `reachable=null` entries.
+- Provider call sequence:
+  1. Fake AI returns 200 → call lookup → health shows `provider_reachable=true`.
+  2. Fake AI raises `ProviderTimeout` → call lookup (catches) → health shows
+     `provider_reachable=false`, `last_failure_class="ProviderTimeout"`,
+     `model_id` still set from step 1.
+  3. Fake AI 502 → `provider_reachable=false`, `last_failure_class=
+     "ProviderUnreachable"`.
+- Cache-hit case does NOT touch health state (second identical lookup → no
+  new `provider_last_checked_at`).
+- Retrieval reachable/unreachable transitions for both wikipedia and
+  openlibrary.
+
+### Android unit tests (`AiRepositoryHealthTest`)
+
+- `getHealth` deserializes a typical response.
+- `getHealth` deserializes an all-null response.
+- `getHealth` propagates 404 (AI disabled) as `AiHttpException`.
+
+## Schema-version implications
+
+None. This PR does not touch `book_insights`, prompts, or any cached field.
+The cache-version checklist does not apply.
+
+## Documentation deltas
+
+- `docs/sync-api.md` AI section gets a new `GET /ai/v1/health` row in the
+  endpoint table, plus a small subsection describing the tri-state semantics
+  and the no-active-probing rule.
+- `server/README.md` env vars unchanged (no new flags).
+- `docs/architecture.md` already mentions an AI module; no change needed
+  (the health endpoint is implementation detail, not architecture).
+
+## Risks
+
+- **Forgotten hook in a future `chat_structured` caller.** Today there is
+  exactly one call site. If a second arises and forgets to update health
+  state, the snapshot drifts. Mitigation: keep the calls inside
+  `InsightOrchestrator`, not on `AIClient` (the client doesn't know about
+  reachability state; the orchestrator owns the policy).
+- **Retrieval source naming drift.** Names are bare strings (`"wikipedia"`,
+  `"openlibrary"`). If a future PR renames an external source, the Settings
+  screen will show two rows for a brief period until ops restarts the
+  server. Acceptable.
+- **Multi-replica blindness.** With 2+ replicas behind a load balancer, each
+  replica reports its own state. A failing-only-on-replica-B condition won't
+  show on replica-A's `/ai/v1/health`. Out of scope per the project non-goal
+  ("Multi-replica deployments — in-process lock stays").

--- a/server/opds_sync/api/ai.py
+++ b/server/opds_sync/api/ai.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from opds_sync.api.ai_auth import AiPrincipal, get_ai_principal
 from opds_sync.api.ai_schemas import (
+    AiHealthResponse,
     AiStyle,
     BookInsightResponse,
     ConfigResponse,
@@ -30,8 +31,10 @@ from opds_sync.api.ai_schemas import (
     PreferencesBody,
     PreferencesResponse,
     QuotaResponse,
+    RetrievalSourceHealth,
 )
 from opds_sync.config import get_settings
+from opds_sync.core.ai.health_state import AiHealthState
 from opds_sync.core.ai.service import InsightOrchestrator, QuotaExceeded
 from opds_sync.db.models import UserAIPreference
 from opds_sync.db.session import get_session
@@ -251,3 +254,53 @@ async def invalidate_insight(
     await _require_opt_in(session, principal.subject)
     n = await orch.invalidate(session, body.identity)
     return {"deleted": n}
+
+
+@router.get("/health", response_model=AiHealthResponse)
+async def get_ai_health(request: Request) -> AiHealthResponse:
+    """Operational visibility for AI provider + retrieval reachability.
+
+    Unauthenticated by design — operators and the Android Settings screen
+    poll this without going through Basic auth (consistent with the
+    always-on root ``/health`` and ``/readyz`` probes; nothing in the body
+    is more sensitive than ``/ai/v1/config`` already exposes).
+
+    Snapshot semantics:
+      * Process-local: each replica reports its own state. Reset to all-null
+        on restart.
+      * Passive: state updates only as a side effect of real user-driven
+        chat_structured + retrieval calls. We never actively ping providers.
+      * Tri-state ``reachable``: see ``AiHealthResponse`` and
+        ``RetrievalSourceHealth`` for the contract.
+    """
+    state: AiHealthState | None = getattr(request.app.state, "ai_health", None)
+    sources_seed = _enabled_sources()
+    if state is None:
+        # AI router mounted but no health holder was wired (the
+        # "enabled-but-unconfigured" branch of main.py before this PR ran;
+        # defensive in case any future wiring forgets to attach the holder).
+        return AiHealthResponse(
+            retrieval_sources=[RetrievalSourceHealth(name=n) for n in sources_seed],
+        )
+    snap = await state.snapshot()
+    # Seed configured sources so the UI always sees a row per source, even
+    # before the first call. Observed sources override seeded null entries.
+    sources: dict[str, RetrievalSourceHealth] = {
+        n: RetrievalSourceHealth(name=n) for n in sources_seed
+    }
+    for name, s in snap.retrieval_sources.items():
+        sources[name] = RetrievalSourceHealth(
+            name=name,
+            reachable=s.reachable,
+            last_checked_at=s.last_checked_at.isoformat() if s.last_checked_at else None,
+        )
+    return AiHealthResponse(
+        provider_reachable=snap.provider_reachable,
+        provider_last_checked_at=(
+            snap.provider_last_checked_at.isoformat() if snap.provider_last_checked_at else None
+        ),
+        model_id=snap.model_id,
+        last_failure_at=snap.last_failure_at.isoformat() if snap.last_failure_at else None,
+        last_failure_class=snap.last_failure_class,
+        retrieval_sources=list(sources.values()),
+    )

--- a/server/opds_sync/api/ai_schemas.py
+++ b/server/opds_sync/api/ai_schemas.py
@@ -353,3 +353,46 @@ class QuotaResponse(BaseModel):
     used: int
     limit: int
     resets_at: str  # ISO-8601, next UTC midnight
+
+
+class RetrievalSourceHealth(BaseModel):
+    """One row in ``AiHealthResponse.retrieval_sources``.
+
+    Tri-state ``reachable``:
+      * ``null`` — never observed by this process (fresh start, or no
+        lookup has ever consulted this source).
+      * ``true`` — last HTTP call to this source completed (any status code).
+      * ``false`` — last attempt failed at the transport level (timeout, DNS,
+        connection reset, etc.).
+    """
+
+    name: str
+    reachable: bool | None = None
+    last_checked_at: str | None = None  # ISO-8601
+
+
+class AiHealthResponse(BaseModel):
+    """Body of ``GET /ai/v1/health``.
+
+    Process-local snapshot of the most recently observed reachability of the
+    AI provider and configured retrieval sources. Reset to all-null on
+    process restart. Multi-replica deployments report per-replica state.
+
+    Field semantics:
+      * ``provider_reachable`` — tri-state, same shape as
+        ``RetrievalSourceHealth.reachable``.
+      * ``provider_last_checked_at`` — non-null whenever
+        ``provider_reachable`` is non-null.
+      * ``model_id`` — most recently observed model on a successful chat
+        completion (NOT the configured ``AI_MODEL``; see ``/ai/v1/config``
+        for that). Null until the first success.
+      * ``last_failure_at`` / ``last_failure_class`` — set when
+        ``provider_reachable=false``; cleared on the next success.
+    """
+
+    provider_reachable: bool | None = None
+    provider_last_checked_at: str | None = None  # ISO-8601
+    model_id: str | None = None
+    last_failure_at: str | None = None  # ISO-8601
+    last_failure_class: str | None = None
+    retrieval_sources: list[RetrievalSourceHealth] = Field(default_factory=list)

--- a/server/opds_sync/core/ai/health_state.py
+++ b/server/opds_sync/core/ai/health_state.py
@@ -1,0 +1,137 @@
+"""In-memory holder for AI-provider and retrieval-source reachability state.
+
+Process-local. Multi-replica observability is out of scope per the project's
+"in-process lock stays" non-goal.
+
+Tri-state semantics
+-------------------
+Every reachability flag is `None | bool`:
+
+* ``None``  → never observed. ``last_checked_at`` MUST also be None.
+* ``True``  → last network call succeeded. ``last_checked_at`` MUST be set.
+* ``False`` → last network call failed. ``last_checked_at``,
+              ``last_failure_at``, and ``last_failure_class`` MUST be set.
+
+A success-after-failure clears ``last_failure_at`` and ``last_failure_class``
+to None — the holder reflects the CURRENT state, not history. Historical
+failures live in ``ai_generation_log`` (PR-C) and structured warning logs.
+
+Concurrency
+-----------
+FastAPI handlers run on a single asyncio event loop per worker. Single-attribute
+writes are technically safe under the GIL, but a coherent multi-field snapshot
+requires a critical section. We use ``asyncio.Lock`` to guard both writers and
+reads. The lock is uncontended in practice (one writer per AI call), and
+snapshots are O(few fields), so the cost is negligible.
+
+Process restart
+---------------
+All fields reset to None. The endpoint's tri-state contract surfaces this
+faithfully as "not yet checked" until the first real call lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from copy import copy
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+@dataclass
+class RetrievalSourceState:
+    """Reachability state for one named retrieval source (wikipedia, openlibrary, ...)."""
+
+    reachable: bool | None = None
+    last_checked_at: datetime | None = None
+
+
+@dataclass
+class AiHealthSnapshot:
+    """Point-in-time copy of ``AiHealthState``. Safe to mutate by callers."""
+
+    provider_reachable: bool | None = None
+    provider_last_checked_at: datetime | None = None
+    model_id: str | None = None
+    last_failure_at: datetime | None = None
+    last_failure_class: str | None = None
+    retrieval_sources: dict[str, RetrievalSourceState] = field(default_factory=dict)
+
+
+class AiHealthState:
+    """Mutable, async-safe holder for the most recently observed AI reachability state.
+
+    Public API is intentionally tiny: three writers (provider success, provider
+    failure, retrieval) and a snapshot reader. All methods are coroutines so
+    callers can compose them with other async work without thinking about
+    sync-vs-async barriers.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._provider_reachable: bool | None = None
+        self._provider_last_checked_at: datetime | None = None
+        self._model_id: str | None = None
+        self._last_failure_at: datetime | None = None
+        self._last_failure_class: str | None = None
+        self._retrieval: dict[str, RetrievalSourceState] = {}
+
+    async def record_provider_success(self, *, model_id: str) -> None:
+        """Record a successful provider chat completion.
+
+        Sets ``provider_reachable=True`` and ``model_id``. Clears the failure
+        fields — the holder reflects current state, not history.
+        """
+        now = datetime.now(UTC)
+        async with self._lock:
+            self._provider_reachable = True
+            self._provider_last_checked_at = now
+            self._model_id = model_id
+            self._last_failure_at = None
+            self._last_failure_class = None
+
+    async def record_provider_failure(self, *, error_class: str) -> None:
+        """Record a failed provider chat completion.
+
+        Sets ``provider_reachable=False``, ``provider_last_checked_at``,
+        ``last_failure_at``, and ``last_failure_class``. ``model_id`` is
+        preserved from any prior success (gives the operator "last seen
+        working model" context).
+        """
+        now = datetime.now(UTC)
+        async with self._lock:
+            self._provider_reachable = False
+            self._provider_last_checked_at = now
+            self._last_failure_at = now
+            self._last_failure_class = error_class
+
+    async def record_retrieval(self, *, name: str, success: bool) -> None:
+        """Record the outcome of one retrieval-source HTTP call.
+
+        ``name`` is one of the canonical lowercase identifiers used by the
+        orchestrator (``"wikipedia"``, ``"openlibrary"``). Callers pass bare
+        string literals — no config-driven naming, so a typo in ``ai_sources``
+        cannot leak into the health response.
+        """
+        now = datetime.now(UTC)
+        async with self._lock:
+            self._retrieval[name] = RetrievalSourceState(
+                reachable=success,
+                last_checked_at=now,
+            )
+
+    async def snapshot(self) -> AiHealthSnapshot:
+        """Return an independent copy of the current state.
+
+        The returned object can be freely mutated by the caller; subsequent
+        writes to the holder will not affect it, and vice versa.
+        """
+        async with self._lock:
+            return AiHealthSnapshot(
+                provider_reachable=self._provider_reachable,
+                provider_last_checked_at=self._provider_last_checked_at,
+                model_id=self._model_id,
+                last_failure_at=self._last_failure_at,
+                last_failure_class=self._last_failure_class,
+                retrieval_sources={name: copy(state) for name, state in self._retrieval.items()},
+            )

--- a/server/opds_sync/core/ai/retrieval.py
+++ b/server/opds_sync/core/ai/retrieval.py
@@ -27,6 +27,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opds_sync.api.ai_schemas import Citation
+from opds_sync.core.ai.health_state import AiHealthState
 from opds_sync.db.models import ExternalSourceCacheEntry
 
 logger = logging.getLogger(__name__)
@@ -47,10 +48,18 @@ class Retriever:
         session: AsyncSession,
         transport: httpx.AsyncBaseTransport | None = None,
         timeout_s: float = 8.0,
+        health_state: AiHealthState | None = None,
     ) -> None:
         self._session = session
         self._transport = transport
         self._timeout_s = timeout_s
+        # When None, retrieval reachability updates are no-ops. Cache hits
+        # never touch health regardless — the network wasn't called.
+        self._health = health_state
+
+    async def _record_retrieval(self, *, name: str, success: bool) -> None:
+        if self._health is not None:
+            await self._health.record_retrieval(name=name, success=success)
 
     async def lookup_wikipedia(self, *, author: str | None, title: str) -> list[Citation]:
         key = f"title:{_normalize_key(title)}"
@@ -102,12 +111,15 @@ class Retriever:
         try:
             async with self._http() as http:
                 r = await http.get(f"{_OL_BASE}/search.json", params=params)
+                # OpenLibrary responded — reachable regardless of status code.
+                await self._record_retrieval(name="openlibrary", success=True)
                 if r.status_code != 200:
                     citations = []
                 else:
                     citations = self._parse_openlibrary_response(r.json())
         except httpx.HTTPError as e:
             logger.info("ai.retrieval.openlibrary.fail err=%s", e)
+            await self._record_retrieval(name="openlibrary", success=False)
             citations = []
 
         await self._write_cache(
@@ -123,6 +135,10 @@ class Retriever:
                 # Wikipedia's REST API takes a slug; URL-encode + replace spaces.
                 slug = quote(term.strip().replace(" ", "_"), safe="")
                 r = await http.get(f"{_WIKI_BASE}/page/summary/{slug}")
+                # We reached Wikipedia and got a response — regardless of
+                # status code (404 for unknown titles is normal). The
+                # reachability signal is "did the network call complete?".
+                await self._record_retrieval(name="wikipedia", success=True)
                 if r.status_code == 404:
                     return []
                 if r.status_code != 200:
@@ -133,6 +149,7 @@ class Retriever:
                 data = r.json()
         except httpx.HTTPError as e:
             logger.info("ai.retrieval.wikipedia.fail err=%s term=%s", e, term)
+            await self._record_retrieval(name="wikipedia", success=False)
             return []
 
         if data.get("type") == "disambiguation":

--- a/server/opds_sync/core/ai/service.py
+++ b/server/opds_sync/core/ai/service.py
@@ -34,6 +34,7 @@ from opds_sync.api.ai_schemas import (
     MetadataBundle,
     SeriesInsight,
 )
+from opds_sync.core.ai.health_state import AiHealthState
 from opds_sync.core.ai.prompts import SYSTEM_PROMPT, compose_user_prompt
 from opds_sync.core.logging_ctx import request_id_var
 from opds_sync.db.models import AIGenerationLog, AIUsageDaily, BookInsight
@@ -102,6 +103,7 @@ class InsightOrchestrator:
         rate_per_min: int = 10,
         daily_budget: int = 200,
         regen_daily_limit: int = 3,
+        health_state: AiHealthState | None = None,
     ) -> None:
         self.ai = ai
         self.retriever_factory = retriever_factory
@@ -115,6 +117,9 @@ class InsightOrchestrator:
         self._bucket = TokenBucket(rate_per_min=rate_per_min)
         self._daily_budget = daily_budget
         self._regen_daily_limit = regen_daily_limit
+        # When None, the orchestrator silently skips health updates. Tests
+        # that don't care about reachability state can omit it.
+        self._health = health_state
 
     # ------- public API -------
 
@@ -332,7 +337,13 @@ class InsightOrchestrator:
                     latency_ms,
                     type(e).__name__,
                 )
+                # PR5: surface provider reachability to GET /ai/v1/health.
+                if self._health is not None:
+                    await self._health.record_provider_failure(error_class=type(e).__name__)
                 raise
+            # PR5: chat_structured succeeded → provider is reachable now.
+            if self._health is not None:
+                await self._health.record_provider_success(model_id=self.model_id)
             latency_ms = int((time.monotonic() - t0) * 1000)
             logger.info(
                 "ai.generate content_hash=%s model=%s latency_ms=%d sources=%s regen=%s",

--- a/server/opds_sync/main.py
+++ b/server/opds_sync/main.py
@@ -144,6 +144,7 @@ def create_app() -> FastAPI:
             # the Wikipedia/OpenLibrary clients out of sync-only deploys.
             from opds_sync.api.ai import router as ai_router
             from opds_sync.core.ai.client import AIClient
+            from opds_sync.core.ai.health_state import AiHealthState
             from opds_sync.core.ai.retrieval import Retriever
             from opds_sync.core.ai.service import InsightOrchestrator
 
@@ -155,10 +156,16 @@ def create_app() -> FastAPI:
             sources_enabled = tuple(
                 s.strip() for s in (settings.ai_sources or "").split(",") if s.strip()
             )
+            # PR5: process-local reachability holder, fed by chat_structured +
+            # retrieval calls. Exposed via GET /ai/v1/health.
+            ai_health = AiHealthState()
+            app.state.ai_health = ai_health
             orch = InsightOrchestrator(
                 ai=ai_client,
                 retriever_factory=lambda s: Retriever(
-                    session=s, timeout_s=settings.ai_retrieval_timeout_s
+                    session=s,
+                    timeout_s=settings.ai_retrieval_timeout_s,
+                    health_state=ai_health,
                 ),
                 sources_enabled=sources_enabled,
                 model_id=settings.ai_model,
@@ -168,6 +175,7 @@ def create_app() -> FastAPI:
                 rate_per_min=settings.ai_rate_per_min,
                 daily_budget=settings.ai_daily_budget,
                 regen_daily_limit=settings.ai_regen_daily_limit,
+                health_state=ai_health,
             )
             app.state.ai_orchestrator = orch
             app.include_router(ai_router, prefix="/ai/v1")
@@ -177,7 +185,11 @@ def create_app() -> FastAPI:
             # The authenticator is already wired above, so token-mode deploys
             # still require valid Bearer tokens on /config (no silent downgrade).
             from opds_sync.api.ai import router as ai_router
+            from opds_sync.core.ai.health_state import AiHealthState
 
+            # Attach an empty holder so GET /ai/v1/health returns an all-null
+            # snapshot rather than the "defensive empty body" branch.
+            app.state.ai_health = AiHealthState()
             app.include_router(ai_router, prefix="/ai/v1")
 
     # Middleware: registered LAST is OUTERMOST in ASGI execution order.

--- a/server/tests/integration/test_ai_health_endpoint.py
+++ b/server/tests/integration/test_ai_health_endpoint.py
@@ -1,0 +1,358 @@
+"""Integration tests for GET /ai/v1/health.
+
+These tests run the full FastAPI app via ``client_factory`` so the routing,
+mode-gating, lazy-import boundary, and orchestrator wiring are all exercised
+the same way they will be in production.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from opds_sync.core.ai.client import (
+    AIClient,
+    ProviderRejected,
+    ProviderTimeout,
+    ProviderUnreachable,
+)
+from opds_sync.core.ai.health_state import AiHealthState
+from opds_sync.core.ai.service import InsightOrchestrator
+
+# All tests in this file hit /ai/v1/* and so require the ai router.
+pytestmark = pytest.mark.requires_ai
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _basic_header(user: str, password: str = "p") -> dict:
+    import base64
+
+    return {"Authorization": "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()}
+
+
+def _ai_chat_response(payload: dict) -> dict:
+    return {
+        "id": "x",
+        "model": "test-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": json.dumps(payload)},
+            }
+        ],
+    }
+
+
+def _install_fake_ai(
+    app,
+    *,
+    fake_handler,
+    sources_enabled: tuple[str, ...] = (),
+) -> InsightOrchestrator:
+    """Replace the orchestrator with one whose AIClient uses ``fake_handler``.
+
+    The orchestrator created by ``main.create_app`` is wired to a real
+    ``AIClient`` against the configured base URL. For tests we substitute one
+    that talks to a MockTransport — but we keep the same ``app.state.ai_health``
+    holder that ``main.py`` created, so the health endpoint reads from the
+    same store the orchestrator writes to.
+    """
+    ai = AIClient(
+        base_url="http://fake/v1",
+        api_key=None,
+        model="test-model",
+        transport=httpx.MockTransport(fake_handler),
+    )
+
+    class _NoOpRetriever:
+        async def lookup_wikipedia(self, **kw):
+            return []
+
+        async def lookup_openlibrary(self, **kw):
+            return []
+
+    # Reuse the holder created in main.py so the endpoint sees the same state.
+    health: AiHealthState = app.state.ai_health
+    orch = InsightOrchestrator(
+        ai=ai,
+        retriever_factory=lambda s: _NoOpRetriever(),
+        sources_enabled=sources_enabled,
+        model_id="test-model",
+        prompt_version="t1",
+        max_concurrency=4,
+        ai_timeout_s=5.0,
+        health_state=health,
+    )
+    app.state.ai_orchestrator = orch
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_health_404_when_ai_disabled(client_factory):
+    async with client_factory(ai_enabled=False) as client:
+        r = await client.get("/ai/v1/health")
+    assert r.status_code == 404
+
+
+async def test_health_200_when_ai_enabled_unconfigured(client_factory):
+    """AI enabled but base_url/model missing: endpoint mounts; snapshot is all-null."""
+    async with client_factory(ai_enabled=True, ai_sources="") as client:
+        r = await client.get("/ai/v1/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["provider_reachable"] is None
+    assert body["provider_last_checked_at"] is None
+    assert body["model_id"] is None
+    assert body["last_failure_at"] is None
+    assert body["last_failure_class"] is None
+    # No retrieval sources configured in this mode.
+    assert body["retrieval_sources"] == []
+
+
+async def test_health_no_auth_required(client_factory):
+    """Operational endpoint — no Authorization header should still return 200."""
+    async with client_factory(ai_enabled=True) as client:
+        r = await client.get("/ai/v1/health")  # no header
+    assert r.status_code == 200
+
+
+async def test_health_seeds_configured_sources(client_factory):
+    """Sources from ai_sources appear as null-state rows before any lookup."""
+    async with client_factory(
+        ai_enabled=True,
+        ai_base_url="http://x",
+        ai_model="m",
+        ai_sources="wikipedia,openlibrary",
+    ) as client:
+        r = await client.get("/ai/v1/health")
+    assert r.status_code == 200
+    body = r.json()
+    names = {s["name"]: s for s in body["retrieval_sources"]}
+    assert set(names) == {"wikipedia", "openlibrary"}
+    assert names["wikipedia"]["reachable"] is None
+    assert names["openlibrary"]["reachable"] is None
+
+
+async def test_health_provider_success(client_factory, app, session):
+    """A successful chat_structured call flips provider_reachable to True."""
+
+    def ok_handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=_ai_chat_response({"schema_version": 2, "intro": "ok", "confidence": "low"}),
+        )
+
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        _install_fake_ai(app, fake_handler=ok_handler)
+
+        # Opt-in + lookup to exercise the orchestrator.
+        await client.put(
+            "/ai/v1/preferences",
+            headers=_basic_header("alice"),
+            json={"ai_enabled": True},
+        )
+        await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"content_hash": "ch-ok"},
+                "bundle": {"title": "Foundation"},
+            },
+        )
+
+        r = await client.get("/ai/v1/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["provider_reachable"] is True
+    assert body["provider_last_checked_at"] is not None
+    assert body["model_id"] == "test-model"
+    assert body["last_failure_at"] is None
+    assert body["last_failure_class"] is None
+
+
+async def test_health_provider_timeout_classified(client_factory, app, session):
+    """httpx.ReadTimeout → ProviderTimeout → last_failure_class='ProviderTimeout'."""
+
+    def timeout_handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("simulated")
+
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        _install_fake_ai(app, fake_handler=timeout_handler)
+        await client.put(
+            "/ai/v1/preferences",
+            headers=_basic_header("alice"),
+            json={"ai_enabled": True},
+        )
+        # The orchestrator re-raises the provider exception; ASGITransport
+        # propagates app exceptions by default, so we catch here and confirm
+        # the side effect on the health endpoint below.
+        with pytest.raises(ProviderTimeout):
+            await client.post(
+                "/ai/v1/insights/lookup",
+                headers=_basic_header("alice"),
+                json={
+                    "identity": {"content_hash": "ch-to"},
+                    "bundle": {"title": "X"},
+                },
+            )
+
+        r = await client.get("/ai/v1/health")
+    body = r.json()
+    assert body["provider_reachable"] is False
+    assert body["provider_last_checked_at"] is not None
+    assert body["last_failure_at"] is not None
+    assert body["last_failure_class"] == "ProviderTimeout"
+
+
+async def test_health_provider_502_classified(client_factory, app, session):
+    """5xx → ProviderUnreachable → last_failure_class='ProviderUnreachable'."""
+
+    def err_handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="bad gateway")
+
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        _install_fake_ai(app, fake_handler=err_handler)
+        await client.put(
+            "/ai/v1/preferences",
+            headers=_basic_header("alice"),
+            json={"ai_enabled": True},
+        )
+        with pytest.raises(ProviderUnreachable):
+            await client.post(
+                "/ai/v1/insights/lookup",
+                headers=_basic_header("alice"),
+                json={
+                    "identity": {"content_hash": "ch-502"},
+                    "bundle": {"title": "X"},
+                },
+            )
+
+        r = await client.get("/ai/v1/health")
+    body = r.json()
+    assert body["provider_reachable"] is False
+    assert body["last_failure_class"] == "ProviderUnreachable"
+
+
+async def test_health_provider_400_classified(client_factory, app, session):
+    """4xx (other than 429) → ProviderRejected."""
+
+    def reject_handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="nope")
+
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        _install_fake_ai(app, fake_handler=reject_handler)
+        await client.put(
+            "/ai/v1/preferences",
+            headers=_basic_header("alice"),
+            json={"ai_enabled": True},
+        )
+        with pytest.raises(ProviderRejected):
+            await client.post(
+                "/ai/v1/insights/lookup",
+                headers=_basic_header("alice"),
+                json={
+                    "identity": {"content_hash": "ch-400"},
+                    "bundle": {"title": "X"},
+                },
+            )
+
+        r = await client.get("/ai/v1/health")
+    body = r.json()
+    assert body["provider_reachable"] is False
+    assert body["last_failure_class"] == "ProviderRejected"
+
+
+async def test_health_recovery_clears_failure(client_factory, app, session):
+    """Failure followed by success clears last_failure_* in the health snapshot."""
+    handler_state = {"mode": "fail"}
+
+    def flip_handler(req: httpx.Request) -> httpx.Response:
+        if handler_state["mode"] == "fail":
+            return httpx.Response(502, text="bad")
+        return httpx.Response(
+            200,
+            json=_ai_chat_response({"schema_version": 2, "intro": "ok", "confidence": "low"}),
+        )
+
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        _install_fake_ai(app, fake_handler=flip_handler)
+        await client.put(
+            "/ai/v1/preferences",
+            headers=_basic_header("alice"),
+            json={"ai_enabled": True},
+        )
+
+        # First call: fails.
+        with pytest.raises(ProviderUnreachable):
+            await client.post(
+                "/ai/v1/insights/lookup",
+                headers=_basic_header("alice"),
+                json={
+                    "identity": {"content_hash": "ch-rec-1"},
+                    "bundle": {"title": "X"},
+                },
+            )
+        r1 = await client.get("/ai/v1/health")
+        assert r1.json()["provider_reachable"] is False
+
+        # Switch to success and call again with a DIFFERENT identity so we
+        # don't hit the cache.
+        handler_state["mode"] = "ok"
+        await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"content_hash": "ch-rec-2"},
+                "bundle": {"title": "X"},
+            },
+        )
+
+        r = await client.get("/ai/v1/health")
+    body = r.json()
+    assert body["provider_reachable"] is True
+    assert body["last_failure_at"] is None
+    assert body["last_failure_class"] is None
+
+
+async def test_health_cache_hit_does_not_update_timestamp(client_factory, app, session):
+    """Second lookup that hits the insight cache must not touch health state."""
+
+    def ok_handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=_ai_chat_response({"schema_version": 2, "intro": "cached", "confidence": "low"}),
+        )
+
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        _install_fake_ai(app, fake_handler=ok_handler)
+        await client.put(
+            "/ai/v1/preferences",
+            headers=_basic_header("alice"),
+            json={"ai_enabled": True},
+        )
+
+        body = {
+            "identity": {"metadata_id": "id1", "content_hash": "ch-cache"},
+            "bundle": {"title": "X"},
+        }
+        await client.post("/ai/v1/insights/lookup", headers=_basic_header("alice"), json=body)
+        r1 = await client.get("/ai/v1/health")
+        ts1 = r1.json()["provider_last_checked_at"]
+        assert ts1 is not None
+
+        # Second lookup hits cache.
+        await client.post("/ai/v1/insights/lookup", headers=_basic_header("alice"), json=body)
+
+        r2 = await client.get("/ai/v1/health")
+    ts2 = r2.json()["provider_last_checked_at"]
+    assert ts2 == ts1, "cache hit must not touch provider_last_checked_at"

--- a/server/tests/unit/test_ai_health_state.py
+++ b/server/tests/unit/test_ai_health_state.py
@@ -1,0 +1,192 @@
+"""Unit tests for opds_sync.core.ai.health_state.
+
+These tests pin down the tri-state contract exposed by ``AiHealthState`` so
+the endpoint, the orchestrator, and the Android UI all share one definition
+of what each combination of fields means.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from opds_sync.core.ai.health_state import AiHealthState
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_fresh_state_is_all_null() -> None:
+    state = AiHealthState()
+    snap = await state.snapshot()
+    assert snap.provider_reachable is None
+    assert snap.provider_last_checked_at is None
+    assert snap.model_id is None
+    assert snap.last_failure_at is None
+    assert snap.last_failure_class is None
+    assert snap.retrieval_sources == {}
+
+
+async def test_record_provider_success_populates_fields() -> None:
+    state = AiHealthState()
+    await state.record_provider_success(model_id="llama3.1:8b")
+    snap = await state.snapshot()
+    assert snap.provider_reachable is True
+    assert snap.provider_last_checked_at is not None
+    assert snap.model_id == "llama3.1:8b"
+    # Success clears failure fields (contract: holder reflects CURRENT state).
+    assert snap.last_failure_at is None
+    assert snap.last_failure_class is None
+
+
+async def test_record_provider_failure_on_fresh_state() -> None:
+    """A first observed failure must produce coherent state.
+
+    ``provider_reachable=False`` MUST come with both timestamps and the error
+    class — never ``False + null`` for ``provider_last_checked_at``.
+    """
+    state = AiHealthState()
+    await state.record_provider_failure(error_class="ProviderTimeout")
+    snap = await state.snapshot()
+    assert snap.provider_reachable is False
+    assert snap.provider_last_checked_at is not None
+    assert snap.last_failure_at is not None
+    assert snap.last_failure_class == "ProviderTimeout"
+    # No prior success: model_id stays null. The operator hasn't seen the
+    # provider work yet.
+    assert snap.model_id is None
+
+
+async def test_record_provider_failure_preserves_prior_model_id() -> None:
+    """After a success, a subsequent failure preserves the last-seen model."""
+    state = AiHealthState()
+    await state.record_provider_success(model_id="llama3.1:8b")
+    await state.record_provider_failure(error_class="ProviderUnreachable")
+    snap = await state.snapshot()
+    assert snap.provider_reachable is False
+    assert snap.model_id == "llama3.1:8b"
+    assert snap.last_failure_class == "ProviderUnreachable"
+
+
+async def test_recovery_clears_failure_fields() -> None:
+    """A success after a failure clears the failure fields.
+
+    The contract is "current state, not history". Historical failures live
+    in ai_generation_log and structured logs.
+    """
+    state = AiHealthState()
+    await state.record_provider_failure(error_class="ProviderTimeout")
+    await state.record_provider_success(model_id="llama3.1:8b")
+    snap = await state.snapshot()
+    assert snap.provider_reachable is True
+    assert snap.last_failure_at is None
+    assert snap.last_failure_class is None
+    assert snap.model_id == "llama3.1:8b"
+
+
+async def test_record_retrieval_creates_entry() -> None:
+    state = AiHealthState()
+    await state.record_retrieval(name="wikipedia", success=True)
+    snap = await state.snapshot()
+    assert "wikipedia" in snap.retrieval_sources
+    wiki = snap.retrieval_sources["wikipedia"]
+    assert wiki.reachable is True
+    assert wiki.last_checked_at is not None
+
+
+async def test_record_retrieval_failure() -> None:
+    state = AiHealthState()
+    await state.record_retrieval(name="openlibrary", success=False)
+    snap = await state.snapshot()
+    ol = snap.retrieval_sources["openlibrary"]
+    assert ol.reachable is False
+    assert ol.last_checked_at is not None
+
+
+async def test_multiple_retrieval_sources_are_independent() -> None:
+    state = AiHealthState()
+    await state.record_retrieval(name="wikipedia", success=True)
+    await state.record_retrieval(name="openlibrary", success=False)
+    snap = await state.snapshot()
+    assert snap.retrieval_sources["wikipedia"].reachable is True
+    assert snap.retrieval_sources["openlibrary"].reachable is False
+
+
+async def test_retrieval_update_replaces_prior_state() -> None:
+    """A second record_retrieval for the same name overwrites the prior entry."""
+    state = AiHealthState()
+    await state.record_retrieval(name="wikipedia", success=False)
+    snap1 = await state.snapshot()
+    first_ts = snap1.retrieval_sources["wikipedia"].last_checked_at
+    # Sleep a hair so the timestamp can advance even on fast machines.
+    await asyncio.sleep(0.001)
+    await state.record_retrieval(name="wikipedia", success=True)
+    snap2 = await state.snapshot()
+    second = snap2.retrieval_sources["wikipedia"]
+    assert second.reachable is True
+    assert second.last_checked_at is not None
+    assert second.last_checked_at >= first_ts
+
+
+async def test_snapshot_is_independent_copy() -> None:
+    """Mutating a snapshot must not affect the holder, and vice versa."""
+    state = AiHealthState()
+    await state.record_provider_success(model_id="m1")
+    await state.record_retrieval(name="wikipedia", success=True)
+    snap = await state.snapshot()
+
+    # Mutate the snapshot.
+    snap.provider_reachable = False
+    snap.retrieval_sources["wikipedia"].reachable = False
+    snap.retrieval_sources["injected"] = snap.retrieval_sources["wikipedia"]
+
+    # Holder unaffected.
+    snap2 = await state.snapshot()
+    assert snap2.provider_reachable is True
+    assert snap2.retrieval_sources["wikipedia"].reachable is True
+    assert "injected" not in snap2.retrieval_sources
+
+
+async def test_concurrent_writers_preserve_tri_state_invariants() -> None:
+    """Hammer the holder from many coroutines.
+
+    After 1000 mixed writes the holder must still satisfy:
+      - provider_reachable in {None, True, False}
+      - if True: provider_last_checked_at is not None and last_failure_* are None
+      - if False: provider_last_checked_at, last_failure_at, last_failure_class all set
+    """
+    state = AiHealthState()
+
+    async def successes() -> None:
+        for _ in range(500):
+            await state.record_provider_success(model_id="m")
+
+    async def failures() -> None:
+        for _ in range(500):
+            await state.record_provider_failure(error_class="ProviderUnreachable")
+
+    async def retrievals() -> None:
+        for i in range(1000):
+            await state.record_retrieval(
+                name="wikipedia" if i % 2 == 0 else "openlibrary",
+                success=bool(i % 3),
+            )
+
+    await asyncio.gather(successes(), failures(), retrievals())
+
+    snap = await state.snapshot()
+    assert snap.provider_reachable in (True, False)
+    if snap.provider_reachable is True:
+        assert snap.provider_last_checked_at is not None
+        assert snap.last_failure_at is None
+        assert snap.last_failure_class is None
+    else:
+        assert snap.provider_last_checked_at is not None
+        assert snap.last_failure_at is not None
+        assert snap.last_failure_class is not None
+
+    # Both retrieval sources should be present.
+    assert set(snap.retrieval_sources.keys()) == {"wikipedia", "openlibrary"}
+    for source in snap.retrieval_sources.values():
+        assert source.reachable in (True, False)
+        assert source.last_checked_at is not None

--- a/server/tests/unit/test_ai_retrieval.py
+++ b/server/tests/unit/test_ai_retrieval.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from opds_sync.core.ai.health_state import AiHealthState
 from opds_sync.core.ai.retrieval import (
     Retriever,
     _normalize_key,
@@ -156,3 +157,136 @@ async def test_lookup_wikipedia_percent_encodes_special_chars(session: AsyncSess
     assert any("C%23" in u or "C%23" in str(u) for u in seen_urls), (
         f"expected percent-encoded C# in URL, got: {seen_urls}"
     )
+
+
+# ---------------------------------------------------------------------------
+# PR5: health-state hooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wikipedia_200_records_reachable_true(session: AsyncSession):
+    health = AiHealthState()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_wiki_summary_response("Foundation", "ext"))
+
+    r = Retriever(
+        session=session,
+        transport=httpx.MockTransport(handler),
+        timeout_s=5.0,
+        health_state=health,
+    )
+    await r.lookup_wikipedia(author=None, title="Foundation")
+    snap = await health.snapshot()
+    assert snap.retrieval_sources["wikipedia"].reachable is True
+
+
+@pytest.mark.asyncio
+async def test_wikipedia_404_records_reachable_true(session: AsyncSession):
+    """404 still means the network reached Wikipedia. Reachability is True."""
+    health = AiHealthState()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "missing"})
+
+    r = Retriever(
+        session=session,
+        transport=httpx.MockTransport(handler),
+        timeout_s=5.0,
+        health_state=health,
+    )
+    cites = await r.lookup_wikipedia(author=None, title="DefinitelyNotAPage")
+    assert cites == []
+    snap = await health.snapshot()
+    assert snap.retrieval_sources["wikipedia"].reachable is True
+
+
+@pytest.mark.asyncio
+async def test_wikipedia_timeout_records_reachable_false(session: AsyncSession):
+    health = AiHealthState()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("simulated")
+
+    r = Retriever(
+        session=session,
+        transport=httpx.MockTransport(handler),
+        timeout_s=1.0,
+        health_state=health,
+    )
+    cites = await r.lookup_wikipedia(author=None, title="X")
+    assert cites == []
+    snap = await health.snapshot()
+    assert snap.retrieval_sources["wikipedia"].reachable is False
+
+
+@pytest.mark.asyncio
+async def test_openlibrary_200_records_reachable_true(session: AsyncSession):
+    health = AiHealthState()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_ol_search_response([]))
+
+    r = Retriever(
+        session=session,
+        transport=httpx.MockTransport(handler),
+        timeout_s=5.0,
+        health_state=health,
+    )
+    await r.lookup_openlibrary(author="Asimov", title="Foundation", isbn=None)
+    snap = await health.snapshot()
+    assert snap.retrieval_sources["openlibrary"].reachable is True
+
+
+@pytest.mark.asyncio
+async def test_openlibrary_timeout_records_reachable_false(session: AsyncSession):
+    health = AiHealthState()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated")
+
+    r = Retriever(
+        session=session,
+        transport=httpx.MockTransport(handler),
+        timeout_s=1.0,
+        health_state=health,
+    )
+    cites = await r.lookup_openlibrary(author="X", title="Y", isbn=None)
+    assert cites == []
+    snap = await health.snapshot()
+    assert snap.retrieval_sources["openlibrary"].reachable is False
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_does_not_update_health(session: AsyncSession):
+    """A second lookup that hits the cache must NOT call record_retrieval.
+
+    The network wasn't reached on the second call, so reachability stays as
+    it was after the first call.
+    """
+    health = AiHealthState()
+    call_count = 0
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(200, json=_wiki_summary_response("Foundation", "ext"))
+
+    r = Retriever(
+        session=session,
+        transport=httpx.MockTransport(handler),
+        timeout_s=5.0,
+        health_state=health,
+    )
+    await r.lookup_wikipedia(author=None, title="Foundation")
+    snap1 = await health.snapshot()
+    first_ts = snap1.retrieval_sources["wikipedia"].last_checked_at
+
+    # Second lookup: should hit cache.
+    await r.lookup_wikipedia(author=None, title="Foundation")
+    assert call_count == 1  # confirm cache hit
+
+    snap2 = await health.snapshot()
+    # Timestamp unchanged because the second call didn't touch the network.
+    assert snap2.retrieval_sources["wikipedia"].last_checked_at == first_ts


### PR DESCRIPTION
## Summary

Adds `GET /ai/v1/health` (mode-gated under `AI_ENABLED`) and an in-memory health state holder updated by every `chat_structured` and retrieval call. Surfaces AI provider + Wikipedia + OpenLibrary reachability without log scraping.

## What changed

- **`opds_sync/core/ai/health_state.py`** — new module: tri-state (null / true / false) reachability per source, `record_provider_success/failure`, `record_retrieval`. All fields start at `null` so the UI doesn't show false-as-failure before the first call. Async-safe via module-level lock.
- **`opds_sync/core/ai/service.py`** — `chat_structured` success → `record_provider_success`; failure → `record_provider_failure`.
- **`opds_sync/core/ai/retrieval.py`** — Wikipedia + OpenLibrary fetches → `record_retrieval` (cache hits don't update state).
- **`opds_sync/api/ai.py`** — new `GET /ai/v1/health` route, no auth (operational visibility), 404 when AI mode disabled.
- **Android** — `AiHealthResponse` DTO, `AiRepository.fetchHealth()`, Settings AI section renders one of: "Provider: not yet checked", "Provider: reachable (model: <id>)", "Provider: unreachable — <error_class> at <relative_time>".

## Test plan

- State holder unit tests: null → success → failure transitions.
- Endpoint test: synthetic 200 / 502 / timeout sequences flip state correctly.
- Endpoint 404 when AI disabled.
- `AiRepositoryHealthTest`: DTO deserialization.
- 190 / 190 server tests pass.

## Caveats

- In-memory only. Process restart resets state. `ai_events` table is deferred per roadmap.
- Endpoint is unauthenticated; the data exposed (last failure class, model id, retrieval reachability) is operational, not sensitive.

## Spec + plan

- `docs/superpowers/specs/2026-05-16-ai-health-endpoint-design.md`
- `docs/superpowers/plans/2026-05-16-ai-health-endpoint.md`