### PR TITLE
feat: library_items table + Android upload

### DIFF
--- a/docs/superpowers/plans/2026-05-16-library-items.md
+++ b/docs/superpowers/plans/2026-05-16-library-items.md
@@ -1,0 +1,312 @@
+# PR1 — `library_items` table + Android upload — Implementation Plan
+
+**Spec:** `docs/superpowers/specs/2026-05-16-library-items-design.md`
+**Branch:** `feat/library-items` (in worktree `.claude/worktrees/pr1-library-items`)
+**Base:** `main` at `769e9e4`
+
+## Status legend
+
+- `[ ]` pending
+- `[x]` done
+
+## Stage 1 — Server: schema + ORM
+
+Goal: a new `library_items` table on the `progress` alembic branch, plus its SQLAlchemy model.
+
+- [ ] **1.1 Author migration `progress_001_library_items`.**
+  - File: `server/migrations/versions/progress_001_library_items.py`.
+  - `revision = "progress_001"`, `down_revision = "0004"`, `branch_labels = ("progress",)`.
+  - Columns per spec (`user_id`, `metadata_id`, `content_hash`, `title`, `authors` jsonb, `series_name`, `series_index` numeric, `isbn`, `language`, `subjects` jsonb, `opds_href`, `created_at`, `updated_at`, `deleted_at`). Surrogate `pk` (BigInteger autoincrement) primary key.
+  - Indexes: `uq_library_items_user_content` unique on `(user_id, content_hash)`; `uq_library_items_user_metadata` partial unique on `(user_id, metadata_id) WHERE metadata_id IS NOT NULL`; `ix_library_items_user_series_alive` partial on `(user_id, series_name) WHERE deleted_at IS NULL`; `ix_library_items_user_updated` on `(user_id, updated_at)`.
+  - `downgrade()` drops indexes then the table.
+  - Verify: `cd server && uv run alembic heads --verbose` shows both `progress@head` and `ai@head` after this lands.
+
+- [ ] **1.2 Add `LibraryItem` ORM model in `server/opds_sync/db/models.py`.**
+  - Mirror the migration. Use SQLAlchemy `JSONB` (via `from sqlalchemy.dialects.postgresql import JSONB`) for `authors`/`subjects`. Use `Numeric` for `series_index`.
+  - The model lives next to `Document`/`Progress` (progress-mode neighbours).
+  - **No relationship to `Document`** — `library_items` is keyed by `(user_id, content_hash)`, not by `documents.pk`. They will converge in PR2 via identity aliases; PR1 keeps them independent.
+
+**Verification**: `cd server && uv run pytest tests/integration/test_schema.py -v`. The new test in stage 4 will exercise this.
+
+## Stage 2 — Server: API + Pydantic schemas
+
+Goal: `/library/v1/items` PUT/GET/DELETE, mode-gated.
+
+- [ ] **2.1 Create `server/opds_sync/api/library_schemas.py`.**
+  - `LibraryItemRequest` (the body of a PUT): `metadata_id: str | None`, `content_hash: str`, `title: str`, `authors: list[str]`, `series_name: str | None`, `series_index: float | None`, `isbn: str | None`, `language: str | None`, `subjects: list[str] = []`, `opds_href: str | None`.
+  - `LibraryItemPutBody { item: LibraryItemRequest }`.
+  - `LibraryItemIdentity { content_hash: str }`.
+  - `LibraryItemDeleteBody { item: LibraryItemIdentity }`.
+  - `LibraryItemResponse` (the persisted row): all request fields PLUS `created_at`, `updated_at`, `deleted_at` (datetimes; nullable for `deleted_at`).
+  - `LibraryItemListResponse { items: list[LibraryItemResponse], server_time: datetime }`.
+  - Use `pydantic.field_serializer` for datetimes (match `progress.py` style).
+
+- [ ] **2.2 Create `server/opds_sync/api/library.py`.**
+  - `router = APIRouter(tags=["library"])`.
+  - `PUT /items` handler:
+    - Resolve `user_id` via `current_user_id` dep.
+    - Find by `(user_id, content_hash)`. If found and `metadata_id` differs and `body.metadata_id` matches another existing row, return `409` with `{"error": "metadata_id_conflict", "existing_content_hash": "<other>"}`.
+    - Else upsert: update all payload fields, set `updated_at = now()`, clear `deleted_at`.
+    - Return `LibraryItemResponse`.
+  - `GET /items` handler:
+    - Query params: `since: str | None`, `limit: int = 200` (cap 1000), `offset: int = 0`.
+    - `server_time = datetime.now(UTC)` (captured BEFORE the SELECT).
+    - Base query filtered to `user_id`; if `since` absent, also filter `deleted_at IS NULL`.
+    - Else: parse `since` with `datetime.fromisoformat(since.replace(" ", "+"))`, filter `updated_at > since_dt`, AND `updated_at <= server_time`.
+    - `ORDER BY updated_at ASC, pk ASC`; apply `limit` + `offset`.
+    - Return `LibraryItemListResponse`.
+  - `DELETE /items` handler:
+    - Body shape `LibraryItemDeleteBody`. Find by `(user_id, content_hash)`.
+    - `404` if absent.
+    - If already deleted: return existing row UNCHANGED (no timestamp refresh).
+    - Else: `deleted_at = now()`, `updated_at = now()`. Return updated row.
+
+- [ ] **2.3 Mount the router in `server/opds_sync/main.py`.**
+  - Inside `if settings.progress_enabled:` block, after the existing progress router mount:
+    ```python
+    from opds_sync.api.library import router as library_router
+    app.include_router(library_router, prefix="/library/v1")
+    ```
+  - Verify lazy-import boundary: the import sits inside the `if` block.
+
+## Stage 3 — Server: tests
+
+- [ ] **3.1 Extend `server/tests/integration/test_schema.py`.**
+  - Add `test_library_items_table_exists` marked `@pytest.mark.requires_progress`.
+  - Introspect columns, partial unique index on `(user_id, metadata_id)`, partial series-name index, `(user_id, updated_at)` index.
+
+- [ ] **3.2 Create `server/tests/integration/test_library_items.py`.**
+  - Module-level `pytestmark = pytest.mark.requires_progress`.
+  - Tests (every spec'd test from §"Tests / Server"):
+    - `test_put_creates_then_returns_row`
+    - `test_put_idempotent_updates_payload`
+    - `test_delete_soft_deletes_then_put_reactivates`
+    - `test_get_since_includes_tombstones`
+    - `test_user_isolation`
+    - `test_large_arrays_round_trip` (50 authors, 50 subjects)
+    - `test_put_missing_required_fields_returns_422` (3 sub-cases)
+    - `test_metadata_id_conflict_returns_409`
+    - `test_pagination_limit_and_offset`
+    - `test_get_ordering_stable_with_pk_tiebreaker`
+    - `test_get_server_time_bounds_concurrent_writes`
+    - `test_delete_bumps_updated_at_for_tombstone_delivery`
+    - `test_delete_idempotent_does_not_refresh_updated_at`
+  - Use `app_under_test` fixture + httpx `AsyncClient` + ASGITransport, basic auth headers via `_basic("alice", "alicepass")`.
+
+- [ ] **3.3 Extend `server/tests/integration/test_modes.py`.**
+  - Existing test enumerates mode-gated paths. Add `/library/v1/items` to the list so AI-only mode confirms it returns 404.
+
+**Verification (all stages 1–3):**
+
+```bash
+cd server && uv run pytest -v
+# All three modes (the existing matrix CI runs these via env-var flips):
+cd server && OPDS_SYNC_PROGRESS_ENABLED=true OPDS_SYNC_AI_ENABLED=true uv run pytest -v
+cd server && OPDS_SYNC_PROGRESS_ENABLED=true OPDS_SYNC_AI_ENABLED=false uv run pytest -v
+cd server && OPDS_SYNC_PROGRESS_ENABLED=false OPDS_SYNC_AI_ENABLED=true uv run pytest -v
+```
+
+All three modes must be green. Cache-key audit (`test_cache_key_audit.py`) remains untouched and must still pass — `library_items` is user-scoped and out of scope for that audit.
+
+## Stage 4 — Android: Room v4 → v5
+
+- [ ] **4.1 Update `DocumentEntity`.** Add `val seriesName: String? = null, val seriesIndex: Double? = null`.
+
+- [ ] **4.2 Update `EReaderDatabase`.** Bump `version = 5`. Add `MIGRATION_4_5`:
+  ```kotlin
+  internal val MIGRATION_4_5 = object : Migration(4, 5) {
+      override fun migrate(db: SupportSQLiteDatabase) {
+          db.execSQL("ALTER TABLE documents ADD COLUMN seriesName TEXT")
+          db.execSQL("ALTER TABLE documents ADD COLUMN seriesIndex REAL")
+      }
+  }
+  ```
+  Append to `addMigrations(...)`.
+
+- [ ] **4.3 Update `core/model/Document.kt`.** Add `val seriesName: String? = null, val seriesIndex: Double? = null` to the data class.
+
+- [ ] **4.4 Update `DocumentRepository.toDomain()` and `.insert()`.**
+  - `toDomain` propagates the two new fields.
+  - `.insert(...)` grows two new parameters with defaults `null`.
+
+- [ ] **4.5 Update `MetadataBundle`.** Change `seriesPosition: Int? = null` to `seriesPosition: Double? = null`.
+
+- [ ] **4.6 Update `OpfMetadataExtractor.parseSeries()`.** Return `Pair<String?, Double?>` instead of `Pair<String?, Int?>`. Replace `toFloatOrNull()?.toInt()` with `toDoubleOrNull()` in both branches.
+
+- [ ] **4.7 Regenerate exported Room schema.** Running tests writes `data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/5.json`. Commit it.
+
+- [ ] **4.8 Migration test.**
+  - Extend `data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt` with `migrate 4 to 5 adds series columns`:
+    - Create v4 DB, insert a document row.
+    - Run `MIGRATION_4_5`.
+    - Assert `seriesName IS NULL` and `seriesIndex IS NULL` on the migrated row.
+    - Assert a fresh insert can write non-null series values.
+
+- [ ] **4.9 Repository round-trip test.**
+  - Extend `DocumentRepositoryTest` (or new file) to insert a document with `seriesName="Foundation"`, `seriesIndex=1.5`, read back, assert equality.
+
+- [ ] **4.10 OPF extractor test.** Extend `OpfMetadataExtractorTest` with a fixture containing `<meta name="calibre:series_index" content="1.5"/>`; assert `bundle.seriesPosition == 1.5`.
+
+**Verification:**
+```bash
+scripts/dgradle :data:local:testDebugUnitTest :core:metadata:testDebugUnitTest
+```
+
+## Stage 5 — Android: sync DTOs + client
+
+- [ ] **5.1 New file `data/sync/src/main/java/io/theficos/ereader/data/sync/LibraryItemDtos.kt`.**
+  - `LibraryItemRequestDto` (data class, `@Serializable`): all payload fields, `@SerialName` mappings to snake_case.
+  - `LibraryItemPutBody { val item: LibraryItemRequestDto }`.
+  - `LibraryItemIdentityDto { @SerialName("content_hash") val contentHash: String }`.
+  - `LibraryItemDeleteBody { val item: LibraryItemIdentityDto }`.
+  - `LibraryItemResponseDto` — same fields as request plus `@SerialName("created_at") val createdAt: String`, `@SerialName("updated_at") val updatedAt: String`, `@SerialName("deleted_at") val deletedAt: String?`.
+  - `LibraryItemListResponse { val items: List<LibraryItemResponseDto>, @SerialName("server_time") val serverTime: String }`.
+
+- [ ] **5.2 Update `SyncApi.kt`.** Add `const val PATH_LIBRARY_ITEMS = "/library/v1/items"`.
+
+- [ ] **5.3 Extend `SyncClient.kt`.**
+  - `putLibraryItem(body: LibraryItemPutBody): SyncResult<LibraryItemResponseDto>` — PUT with JSON body.
+  - `deleteLibraryItem(body: LibraryItemDeleteBody): SyncResult<LibraryItemResponseDto>` — DELETE with body via `Request.Builder.method("DELETE", payload)`.
+  - `pullLibraryItems(sinceIso8601: String?, limit: Int = 200, offset: Int = 0): SyncResult<LibraryItemListResponse>` — GET with query params.
+  - Add a `put(...)` helper symmetric with the existing `post(...)` private helper.
+
+- [ ] **5.4 Tests in `SyncClientTest`.**
+  - 200 → Success (parses response, including timestamps).
+  - 401 → Unauthorized.
+  - 422 → HttpFailure(422).
+  - 409 → HttpFailure(409).
+  - DELETE-with-body sends body bytes (capture the request and assert on the JSON shape).
+  - `pullLibraryItems` round-trips `server_time` and an item list.
+
+**Verification:**
+```bash
+scripts/dgradle :data:sync:testDebugUnitTest
+```
+
+## Stage 6 — Android: orchestrator wiring
+
+- [ ] **6.1 Add `SyncOrchestrator.uploadLibraryItem(documentId, bundle, opdsHref)`.**
+  - Looks up the document via `documentRepo.findById(documentId)`.
+  - Builds a `LibraryItemRequestDto`:
+    - `contentHash = doc.identity.contentHash` (always).
+    - `metadataId = doc.identity.metadataId`.
+    - `title = bundle.title.ifBlank { doc.title }`.
+    - `authors = listOfNotNull(bundle.author ?: doc.author).filter { it.isNotBlank() }` — single-element list per spec.
+    - `seriesName = bundle.seriesName`, `seriesIndex = bundle.seriesPosition`.
+    - `isbn = bundle.isbn`, `language = bundle.language`, `subjects = bundle.subjects`.
+    - `opdsHref = opdsHref`.
+  - Calls `client.putLibraryItem(...)`. On `HttpFailure(409)` log and return — terminal.
+  - Other failures log and return (download path is fire-and-forget; reconcile pass picks up later).
+
+- [ ] **6.2 Add `SyncOrchestrator.deleteLibraryItem(identity)`.**
+  - Calls `client.deleteLibraryItem(LibraryItemDeleteBody(LibraryItemIdentityDto(contentHash = identity.contentHash)))`.
+  - Returns `SyncResult<Unit>` (the response body is the soft-deleted row, but callers don't need it).
+  - 404 is benign — treat as success-ish (log, return Success).
+
+- [ ] **6.3 Add `SyncOrchestrator.reconcileLibraryItems()`.**
+  - Pulls the server alive set: page through `client.pullLibraryItems(sinceIso8601 = null, limit = 200, offset = ...)` until short page.
+  - Collects server `content_hash` set.
+  - Loads local `documentRepo.observeLibrary().first()` (or a snapshot dao method).
+  - For each local doc whose `contentHash` is missing from the server set, opens the EPUB OPF, extracts metadata via `OpfMetadataExtractor`, calls `uploadLibraryItem(...)`.
+  - Reconcile uses no OPDS `opdsHref` — that's an immediate-path field; reconcile sends `null`.
+  - Errors logged and swallowed; the next `runOnce()` will retry.
+
+- [ ] **6.4 Call reconcile in `runOnce()`.**
+  - After the existing pull block, before `return SyncResult.Success(Unit)`, call `runCatching { reconcileLibraryItems() }.onFailure { /* log */ }`.
+
+- [ ] **6.5 Inject `openOpfBytes` / extractor into `SyncOrchestrator`.**
+  - The current orchestrator has no metadata extraction dependency. Add a `epubOpfReader: (Document) -> ByteArray?` constructor param (default delegating to a `:core:metadata`-side helper).
+  - Promote `AppContainer.readOpfBytes` to a public `EpubOpfReader` object in `:core:metadata` so both `BookDetailViewModel` and `SyncOrchestrator` use it.
+
+- [ ] **6.6 Tests in `SyncOrchestratorTest`.**
+  - `uploadLibraryItem invokes putLibraryItem with mapped payload`.
+  - `uploadLibraryItem treats 409 as terminal (does not retry)`.
+  - `reconcileLibraryItems pulls then puts missing locals`.
+  - `reconcileLibraryItems pages until short page`.
+  - `runOnce calls reconcile after progress pull` (verify call sequence with a mock client).
+
+**Verification:**
+```bash
+scripts/dgradle :data:sync:testDebugUnitTest
+```
+
+## Stage 7 — Android: app-level wiring
+
+- [ ] **7.1 Promote `readOpfBytes` to `:core:metadata`.**
+  - New file `core/metadata/src/main/java/io/theficos/ereader/core/metadata/EpubOpfReader.kt` with an `object EpubOpfReader { suspend fun read(localPath: String): ByteArray? }`.
+  - Move the implementation from `AppContainer.readOpfBytes`.
+  - Update `AppContainer` to call `EpubOpfReader.read(doc.localPath)`.
+  - Update `BookDetailViewModel` wiring via `AppContainer` (already uses `openOpfBytes`; just route through the new object).
+
+- [ ] **7.2 Wire orchestrator with `EpubOpfReader`.**
+  - In `AppContainer.kt`, pass an `epubOpfReader = { doc -> EpubOpfReader.read(doc.localPath) }` to `SyncOrchestrator(...)`.
+
+- [ ] **7.3 Update `CatalogViewModel.download()` success path.**
+  - After `docs.insert(...)` returns the local id, before `syncEnqueuer(context)`:
+    - Read OPF bytes from `file.absolutePath` via `EpubOpfReader.read(...)`.
+    - Extract `MetadataBundle` via `OpfMetadataExtractor.extract(bytes, fallbackTitle = pub.title)`.
+    - If `bundle.seriesName != null || bundle.seriesPosition != null`, update the local `documents` row with the new series fields (add `DocumentDao.updateSeries(id, seriesName, seriesIndex)` query; small SQL update).
+    - Call `syncOrchestrator.uploadLibraryItem(documentId = localId, bundle, opdsHref = pub.epubDownloadHref)` inside a `runCatching` — log failures.
+  - This requires plumbing `syncOrchestrator` into `CatalogViewModel`. Constructor injection per existing pattern.
+
+- [ ] **7.4 Wire delete propagation.**
+  - In `DocumentRepository.delete(...)`, before the `dao.deleteById(...)` call, attempt the server DELETE via an injected callback. Simplest shape: add an optional `onDelete: suspend (DocumentIdentity) -> Unit = {}` constructor param to the repository, wired in `AppContainer` to call `syncOrchestrator.deleteLibraryItem(identity)`. This keeps `:data:local` from gaining a `:data:sync` dependency.
+  - Same hook for `deleteAll` — iterate local docs, fire deletes, then bulk-clear local rows.
+  - Best-effort — server failures log but don't block local delete.
+
+- [ ] **7.5 Update `AppContainer.kt` and `CatalogViewModelFactory` / call sites.** Pass orchestrator/repository wiring through. Existing tests for `CatalogViewModel` may need `SyncOrchestrator` mocks — handle minimally (no-op stub works).
+
+**Verification:**
+```bash
+scripts/dgradle :app:testDebugUnitTest :data:local:testDebugUnitTest :data:sync:testDebugUnitTest :core:metadata:testDebugUnitTest
+```
+
+## Stage 8 — Docs
+
+- [ ] **8.1 Update `docs/sync-api.md`.**
+  - Add `/library/v1/items` PUT, GET, DELETE rows to the endpoints table.
+  - New section describing the body shape, `since=` cursor semantics, pagination contract, and reactivation flow.
+  - Mention the `OPDS_SYNC_PROGRESS_ENABLED` gate.
+
+- [ ] **8.2 No README changes** unless docs review (batch closer) finds anything.
+
+## Stage 9 — Verify, commit, push, PR
+
+- [ ] **9.1 Full server test run, three modes.**
+- [ ] **9.2 Full Android test run.**
+  ```bash
+  scripts/dgradle test
+  ```
+- [ ] **9.3 Cache-key audit still passes** (sanity — not extended, but should stay green).
+- [ ] **9.4 Commit.**
+  - Message: `:sparkles: feat: library_items table + Android upload`.
+  - No Claude attribution (no `Co-Authored-By: Claude…`, no generated-with footer).
+  - Pre-commit hooks will run.
+- [ ] **9.5 Push.**
+  ```bash
+  git push -u origin feat/library-items
+  ```
+- [ ] **9.6 Open PR.**
+  ```bash
+  gh pr create --base main --head feat/library-items \
+    --title "feat: library_items table + Android upload" \
+    --body "..."
+  ```
+  Body: summary, schema diff, test plan, GPT verdict, `docs/sync-api.md` additions. No Claude attribution.
+
+## Risks and notes
+
+- **PR-A dependency.** This PR relies on `scripts/migrate.py` and `PROGRESS_ENABLED`. Both shipped in PR-A which is already in `main` (the worktree is based on `769e9e4`). No coordination needed beyond rebasing if PR-A's followups land.
+- **Concurrent batch-2 PRs.** PR-B, PR5, docs-review are running. Each works in its own worktree. The only shared file PR1 touches that they also might is `docs/sync-api.md` — the merge order resolves it. None of them touch `db/models.py`, `main.py`'s mode-gating block (PR1 adds *inside* the existing `progress_enabled` block), or any Android module we modify.
+- **Reconcile pass cost.** One paged GET per `runOnce()`. For ≤500-book libraries that's ≤3 pages of 200 each. Acceptable; revisit if metrics show otherwise.
+- **F-Droid posture.** All new traffic targets the existing calibre-web / opds-sync host using existing Basic auth. No new destinations.
+
+## Definition of done
+
+- Migration applied cleanly on a fresh DB in `progress_enabled=true` modes; not applied in `progress_enabled=false` mode.
+- All three server test modes green.
+- All Android unit tests green.
+- `feat/library-items` pushed to `origin`; PR open against `main`.
+- Spec and plan committed.
+- `docs/sync-api.md` updated.
+- No Claude attribution anywhere.

--- a/docs/superpowers/specs/2026-05-16-library-items-design.md
+++ b/docs/superpowers/specs/2026-05-16-library-items-design.md
@@ -1,0 +1,293 @@
+# PR1 — `library_items` table + Android upload
+
+**Date:** 2026-05-16
+**Status:** Design locked in `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §"PR1". This spec captures execution-level detail. No re-design is in scope; only the small implementation choices needed to write the plan and code.
+
+## Problem
+
+The server today knows progress (`documents` + `progress`) but has no library metadata. AI Phase 2, library stats (PR9), the series-continuity shelf (PR8), and any future cross-device library view all need a server-side mirror of what's on each user's device.
+
+A `library_items` table fixes that. It is **user-scoped** (unlike `book_insights`, which is a shared cache) and lives on the new `progress` alembic branch introduced by PR-A. Android uploads one row per downloaded book after the download settles.
+
+## Non-goals
+
+- Eager backfill of every existing library on first run. The reconcile pass (see "Retry semantics") catches local rows missing on the server lazily — over a few sync cycles a long-running install will converge — but PR1 does not block the first sync on a full upload. PR9 stats tolerate partial coverage.
+- Server-side OPF parsing. Android sends pre-extracted `MetadataBundle` fields; the server stores them verbatim.
+- Hard deletes. PR1 ships soft-delete only.
+- Sync of bookmarks, annotations, or reader state.
+- Multi-replica coordination (the in-process lock the rest of the server uses is fine).
+- Any AI work — `library_items` is progress-mode only.
+
+## Schema
+
+New table on the `progress` alembic branch (first migration on that branch):
+
+```
+user_id        text         NOT NULL
+metadata_id    text         NULL
+content_hash   text         NOT NULL
+title          text         NOT NULL
+authors        jsonb        NOT NULL DEFAULT '[]'
+series_name    text         NULL
+series_index   numeric      NULL
+isbn           text         NULL
+language       text         NULL
+subjects       jsonb        NOT NULL DEFAULT '[]'
+opds_href      text         NULL
+created_at     timestamptz  NOT NULL DEFAULT now()
+updated_at     timestamptz  NOT NULL DEFAULT now()
+deleted_at     timestamptz  NULL
+
+UNIQUE (user_id, content_hash)                                  → uq_library_items_user_content
+UNIQUE (user_id, metadata_id) WHERE metadata_id IS NOT NULL     → uq_library_items_user_metadata (partial)
+INDEX  (user_id, series_name) WHERE deleted_at IS NULL          → ix_library_items_user_series_alive (partial)
+INDEX  (user_id, updated_at)                                    → ix_library_items_user_updated (for since= queries)
+
+PRIMARY KEY: surrogate bigint `pk` (autoincrement). Matches the `documents` table convention.
+```
+
+Identity contract per `2026-05-16-next-deliverables.md` §"Identity hierarchy":
+- `content_hash` is mandatory and is the cache-key floor.
+- `metadata_id` is opportunistic; client backfills it the moment OPF parsing yields one.
+- Neither is part of the primary key. The two uniqueness constraints above prevent duplicates.
+
+`authors` and `subjects` are `jsonb` arrays (not `text[]`) so a future PR can add per-author metadata (role, sort key) without a column-type migration. Default empty array, not NULL, so client code never branches on `null` vs `[]`.
+
+`series_index` is `numeric` (not `int`) because EPUB 3 `group-position` allows fractional positions (`1.5` for novellas). Android-side this carries through as Kotlin `Double?` end-to-end:
+- Wire DTO: `series_index: Double?`.
+- Room column: `seriesIndex` `REAL` (nullable).
+- `MetadataBundle.seriesPosition` is widened from `Int?` to `Double?` (small breaking change inside `:core:metadata`; the only existing reader is `BookDetailViewModel` which doesn't surface it numerically).
+- `OpfMetadataExtractor.parseSeries` is updated to return `Double?` (was `Int?`); the `toFloatOrNull()?.toInt()` truncation is removed and `toDoubleOrNull()` replaces it. Existing tests get adjusted.
+- Server stores `numeric`; SQLAlchemy maps to `Decimal` on read, but JSON serialisation coerces to a number. Round-trip precision on the few-decimal-place values that EPUB practice uses is fine.
+
+`opds_href` is a free-form text field carrying the catalog acquisition URL that produced this download. Optional. Useful for PR7 catalog-detail screen reconciliation.
+
+## API
+
+Mounted under `/library/v1/*`. Gated behind `OPDS_SYNC_PROGRESS_ENABLED` — sync-only and full-stack deploys mount it; AI-only deploys do not.
+
+Identity travels in the JSON body, never the path. URL-encoded sha256s are a footgun (`+`/`/`/`=`).
+
+### `PUT /library/v1/items` — upsert
+
+```jsonc
+{
+  "item": {
+    "metadata_id": "abc-123",      // optional
+    "content_hash": "sha256...",   // required
+    "title": "Foundation",         // required
+    "authors": ["Isaac Asimov"],   // required (may be empty list)
+    "series_name": "Foundation",   // optional
+    "series_index": 1,             // optional, numeric
+    "isbn": "9780553293357",       // optional
+    "language": "en",              // optional, ISO 639-1
+    "subjects": ["Science Fiction"],
+    "opds_href": "https://..."     // optional
+  }
+}
+```
+
+- Idempotent. Server resolves on `(user_id, content_hash)`. If a row exists with `deleted_at` set, clears it (reactivates) AND refreshes `updated_at = now()`.
+- **Every state-changing path advances `updated_at = now()`**: create, payload update (even if values are byte-equal to existing — keeps the contract simple), reactivation (`deleted_at` cleared), and soft-delete. This is load-bearing for `GET ?since=` tombstone delivery; see GET semantics.
+- If a different existing row collides on `(user_id, metadata_id)` (rare: client learned a stronger metadata_id for a row keyed under the old content_hash), this PR keeps it simple: return `409 Conflict` with body `{"error": "metadata_id_conflict", "existing_content_hash": "..."}`. PR2 identity-aliases is the proper fix; PR1 just refuses to silently merge.
+- Returns `200 OK` with a `LibraryItemResponse` (the persisted row, including `created_at`, `updated_at`, `deleted_at`).
+- `422` on missing required fields.
+- `401` if Basic auth fails.
+
+### `GET /library/v1/items?since=<ISO8601>&limit=<int>&offset=<int>` — list
+
+- `since` is optional. When present, returns rows whose `updated_at > since` (server-side comparison after normalising to UTC). When given, includes soft-deleted rows so clients can mirror tombstones. (Both create/update and soft-delete bump `updated_at`, so a tombstone is just another row whose `updated_at` advanced past the client's last cursor.)
+- `since` absent → returns alive rows only (`deleted_at IS NULL`). This is the reconcile-pass shape; see "Retry semantics".
+- **Ordering and high-water bound:** rows are returned `ORDER BY updated_at ASC, pk ASC` (the `pk` tiebreaker prevents same-timestamp collisions from skipping rows). The server captures `server_time = now()` BEFORE executing the query and additionally filters `updated_at <= server_time` so concurrent writes don't leak into the current page.
+- `limit` defaults to 200, hard-capped at 1000.
+- `offset` defaults to 0. Clients page until they get a short page (`len(items) < limit`), then persist `server_time` as their next `since` cursor. Mid-page cursor persistence is unsafe — a write during pagination can shift offsets — so clients MUST drain to a short page before advancing the cursor.
+- Returns `{"items": [...], "server_time": "ISO8601"}`.
+- User-scoped: only items where `user_id == authenticated user`.
+
+### `DELETE /library/v1/items` — soft delete
+
+Body identifies which item:
+
+```jsonc
+{"item": {"content_hash": "sha256..."}}
+```
+
+- First DELETE on an alive row: sets `deleted_at = now()` AND `updated_at = now()`. The `updated_at` bump is what lets the next `GET ?since=<old_cursor>` deliver the tombstone.
+- Idempotent — `DELETE` on an already-deleted row returns `200`; **both `deleted_at` and `updated_at` are preserved** (not refreshed) so the tombstone doesn't spuriously re-appear in every subsequent `since=` window.
+- Returns `200 OK` with the persisted `LibraryItemResponse` (including `deleted_at`).
+- `404` if no such row for this user.
+- A subsequent `PUT` for the same `content_hash` clears `deleted_at`, refreshes `updated_at`, and updates the payload (reactivation).
+
+### Mode-gating
+
+- `OPDS_SYNC_PROGRESS_ENABLED=false` → router not mounted at all; the path 404s.
+- `OPDS_SYNC_PROGRESS_ENABLED=true` → router mounted; migration `progress_001_library_items` applied by the existing `scripts/migrate.py` wrapper.
+
+## Server module layout
+
+```
+server/migrations/versions/progress_001_library_items.py    # alembic, splice, branch_labels=("progress",)
+server/opds_sync/db/models.py                                # add `LibraryItem` declarative model
+server/opds_sync/api/library.py                              # new router, body-keyed identity
+server/opds_sync/api/library_schemas.py                      # Pydantic LibraryItem{Request,Response}
+server/opds_sync/main.py                                     # mount router under PROGRESS_ENABLED gate
+server/tests/integration/test_library_items.py               # endpoint round-trip suite
+server/tests/integration/test_schema.py                      # extend with library_items table introspection
+```
+
+The router uses the existing `current_user_id` dependency for Basic auth — the same one progress uses.
+
+## Android changes
+
+Three modules touch the wire:
+
+### 1. `:data:local` — Room migration v4 → v5
+
+Add `seriesName` (TEXT, NULL) and `seriesIndex` (REAL, NULL) columns to `documents`. Bump database version to 5 and add `MIGRATION_4_5`. This lets PR8 (series shelf) query Room without another migration.
+
+The local schema does NOT mirror the full `library_items` shape — Android already has `documents` carrying the on-device truth. Series fields are the only additions because PR8 needs them.
+
+Implementation checklist:
+- `DocumentEntity`: add `seriesName: String?` and `seriesIndex: Double?` fields.
+- `EReaderDatabase`: bump `version = 5`, append `MIGRATION_4_5` to the migrations list.
+- `MIGRATION_4_5`: two `ALTER TABLE documents ADD COLUMN ...` statements; both nullable, no default.
+- Exported Room schema: regenerate `data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/5.json` by running the tests (or `:data:local:assembleDebug`); commit the generated file.
+- `Document` domain model (in `:core:model`): add `seriesName: String?` and `seriesIndex: Double?` fields with default `null`.
+- `DocumentRepository.toDomain()` + `.insert()` propagate the new fields.
+- `DocumentDao`: no new methods needed; the existing `findById`/`observeAll` queries return the full entity.
+
+### 2. `:data:sync` — LibraryItem DTOs + client method
+
+Two distinct DTOs so request and response shapes don't drift:
+
+- `LibraryItemRequestDto` — what the client PUTs. Fields: `metadata_id`, `content_hash`, `title`, `authors` (List<String>), `series_name`, `series_index` (Double?), `isbn`, `language`, `subjects` (List<String>), `opds_href`. Wrapped in `LibraryItemPutBody { item: LibraryItemRequestDto }`.
+- `LibraryItemResponseDto` — what the server returns. Superset: same payload fields PLUS `created_at`, `updated_at`, `deleted_at` (all ISO-8601 strings; `deleted_at` nullable).
+- `LibraryItemsListResponse { items: List<LibraryItemResponseDto>, server_time: String }`.
+- `LibraryItemIdentityDto { content_hash: String }` and `LibraryItemDeleteBody { item: LibraryItemIdentityDto }`.
+- `SyncApi.PATH_LIBRARY_ITEMS = "/library/v1/items"`.
+- `SyncClient.putLibraryItem(body)`, `SyncClient.deleteLibraryItem(body)`, `SyncClient.pullLibraryItems(sinceIso?, limit, offset)`.
+- DELETE must send a body — use OkHttp's `Request.Builder.method("DELETE", jsonBody)` because `.delete()` overloads vary in body acceptance.
+- `SyncOrchestrator` gets two new helpers (see "Retry semantics" below):
+  - `uploadLibraryItem(documentId, bundle, opdsHref)` — single PUT, best-effort.
+  - `reconcileLibraryItems()` — full alive-list scan (no `since=`), uploads local rows the server doesn't have.
+
+### 3. App-level wiring
+
+**Download path** — `CatalogViewModel.download()` is where downloads complete today. After `docs.insert(...)` returns the local id and before `syncEnqueuer(context)` fires:
+
+1. Extract OPF bytes from the downloaded EPUB (reuse `AppContainer.readOpfBytes(...)` — promote it to a public helper or move it to `:core:metadata` as `EpubOpfReader`).
+2. Run `OpfMetadataExtractor.extract(bytes, fallbackTitle = pub.title)`.
+3. Backfill the local `documents` row with `seriesName` / `seriesIndex` from the bundle.
+4. Build a `LibraryItemRequestDto` from `(identity, bundle, pub.epubDownloadHref)` (see "Author mapping" below).
+5. Fire `syncOrchestrator.uploadLibraryItem(...)` — best-effort; failure logs but does not break the download flow.
+
+**Delete path** — local deletes must propagate so server rows don't strand:
+
+- `LibraryViewModel.delete(document)` and any other call site that ends up at `DocumentRepository.delete(...)` or `.deleteAll(...)` must, **before** the local row is removed, fire `syncOrchestrator.deleteLibraryItem(document.identity)`. Best-effort: a network failure logs and continues with the local delete. The server row remains alive in that case; future PRs can clean up stranded rows, but the F-Droid posture is "user's local device is authoritative", so a stranded server row is annoying but not corrupting.
+- `deleteAll` iterates one DELETE per document; this is fine for PR1 (a "wipe library" action is rare). A bulk-delete endpoint can come later.
+
+**Author mapping** — server requires `authors: list[str]`; current `MetadataBundle` has singular `author: String?`. PR1 mapping:
+- Prefer `bundle.author` (from OPF), else `pub.author` (from OPDS), else empty list.
+- Single-element list when present; we do NOT split on `;` / `&` / `and` in PR1 (calibre-web already splits, and OPDS feeds have wildly inconsistent author syntax — wrong-splitting is worse than under-splitting).
+- DTO test covers all three branches.
+
+### Retry semantics
+
+For PR1, library-item PUTs are **fire-and-forget on download** with a **reconcile-on-sync** safety net:
+
+- **Immediate path:** `CatalogViewModel.download()` triggers an in-process upload right after `docs.insert(...)`. Failure logs a warning.
+- **Reconcile path:** `SyncOrchestrator.runOnce()` (already called periodically by `SyncWorker`) calls `reconcileLibraryItems()` after the progress pull. This pulls the server's alive set (`GET /library/v1/items` with NO `since=`, paging by `limit/offset` until short page) and PUTs any local `documents` rows whose `content_hash` is missing from the server set.
+  - Why no `since=`: a PUT that never reached the server will never appear in a delta-only view. The full alive-list scan is the only way to prove membership without per-document upload state, and per-document upload state was rejected (no new persistent queue).
+  - Cost: one paged GET per `runOnce()`. For typical libraries (≤500 books) that's one or two pages. Acceptable.
+  - This makes the reconcile pass functionally a lazy backfill — a fresh install of the app on an existing local library will, over a few sync cycles, upload everything. The non-goals section calls this out explicitly.
+- **409 handling:** `metadata_id_conflict` is treated as terminal — log and move on. Do NOT retry indefinitely; PR2 ships the proper fix. Orchestrator and `SyncClient` tests cover this code path.
+
+The reconcile pass is the next `runOnce()` after the failure, not a new background queue.
+
+### Identity binding
+
+The `documents` table's `(metadata_id, content_hash)` is the local identity. `LibraryItemDto.content_hash` always uses `documents.contentHash` (computed by `core.identity.extractIdentity`). `LibraryItemDto.metadata_id` mirrors `documents.metadataId` when non-null. This is the only mapping the orchestrator does — it does not derive identity from the EPUB at upload time, because the source of truth lives in `documents` already.
+
+## Tests
+
+### Server (pytest, all three modes)
+
+In `test_library_items.py` (new):
+- `test_put_creates_then_returns_row` — PUT new item, expect 200; GET lists it.
+- `test_put_idempotent_updates_payload` — PUT twice, second time with a different title, expect updated title and same `created_at` but newer `updated_at`.
+- `test_delete_soft_deletes_then_put_reactivates` — PUT → DELETE → GET (without since) excludes it → PUT clears deleted_at → GET includes it.
+- `test_get_since_includes_tombstones` — soft-deleted row appears when `since` precedes the deletion.
+- `test_user_isolation` — alice's row invisible to bob.
+- `test_large_arrays_round_trip` — 50-element authors and 50-element subjects survive byte-for-byte.
+- `test_put_missing_required_fields_returns_422` — missing `content_hash`, missing `title`, missing `authors`.
+- `test_metadata_id_conflict_returns_409` — pre-existing row A with metadata_id "X", second PUT with different content_hash but same metadata_id "X" gets 409.
+- `test_pagination_limit_and_offset` — 5 items, page through with `limit=2`.
+- `test_get_ordering_stable_with_pk_tiebreaker` — three rows with identical `updated_at` (same-second writes) page deterministically across two `limit=2` pages without dropping or duplicating any row.
+- `test_get_server_time_bounds_concurrent_writes` — capture `server_time` before a query, write a new row with a later `updated_at`, confirm it does NOT appear in the response page bounded by that `server_time`.
+- `test_delete_bumps_updated_at_for_tombstone_delivery` — PUT at t0, capture `t1=now`, DELETE at t2 > t1, GET with `since=t1` returns the tombstone.
+- `test_delete_idempotent_does_not_refresh_updated_at` — DELETE twice; the second response's `updated_at` equals the first's.
+
+In `test_schema.py` (extend):
+- `test_library_items_table_exists` (marked `requires_progress`) — introspect columns, partial unique index, partial series-name index.
+
+In `test_modes.py` (extend): assert `/library/v1/items` returns 404 when `PROGRESS_ENABLED=false`. The existing mode-matrix already covers gating; add the path to its enumeration.
+
+The existing cache-key audit test (`test_cache_key_audit.py`) does NOT need to be extended — `library_items` is user-scoped and explicitly outside that audit's scope.
+
+### Android (`scripts/dgradle :data:local:testDebugUnitTest` and `:data:sync:testDebugUnitTest`)
+
+- `MigrationTest`: extend with `migrate 4 to 5 adds series columns` — pre-populate v4 data, run `MIGRATION_4_5`, assert the new columns exist with nullable storage and old rows have NULL series fields.
+- `DocumentRepositoryTest` (or a new `DocumentSeriesTest`): inserting a document with `seriesName` and `seriesIndex` round-trips them.
+- `OpfMetadataExtractorTest`: extend existing tests; assert `parseSeries` returns `Double?` and `1.5` survives round-trip.
+- `SyncClientTest`:
+  - `putLibraryItem` returns 200 → `Success` with parsed `LibraryItemResponseDto` (including `created_at`).
+  - `putLibraryItem` returns 401 → `Unauthorized`.
+  - `putLibraryItem` returns 422 → `HttpFailure(422)`.
+  - `putLibraryItem` returns 409 → `HttpFailure(409)` (orchestrator interprets this as terminal).
+  - `deleteLibraryItem` with body PUTs the right JSON (asserts the request body, since DELETE-with-body is unusual).
+  - `pullLibraryItems` round-trips `server_time` and `items`.
+- `SyncOrchestratorTest`:
+  - `uploadLibraryItem` invokes `SyncClient.putLibraryItem` once with the expected payload.
+  - `reconcileLibraryItems` pulls the alive set, diffs against local `documents`, and PUTs exactly the missing rows.
+  - `reconcileLibraryItems` handles 409 by logging and NOT retrying.
+  - `runOnce()` calls reconcile after progress pull (sequence test).
+
+## Rollout
+
+PR-A is in flight. PR1 waits for it to land before merging because it depends on the `scripts/migrate.py` wrapper and the `PROGRESS_ENABLED` flag. The migration file itself can be authored against PR-A's branching convention while PR-A is open.
+
+PR1 ships:
+- `progress_001_library_items` migration.
+- `LibraryItem` ORM model.
+- `/library/v1/items` PUT/GET/DELETE endpoints, gated.
+- Android Room v4→v5 migration.
+- Android sync DTOs + client + orchestrator hook.
+- Catalog-download path uploads after a successful download.
+- Tests above.
+- `docs/sync-api.md` update.
+
+## Resolved execution choices
+
+- **`numeric` vs `real` for `series_index`** — postgres `numeric`, Room `REAL`, wire `Double?`. Sqlite `REAL` is float-64; postgres `numeric` is exact. EPUB practice uses small fractions (`1.5`); precision loss on a few-decimal-place value is undetectable in practice. The architect call-out about `MetadataBundle.seriesPosition: Int?` truncating is handled by widening that field to `Double?` and updating the extractor (see the Android section).
+- **`409` vs silent merge on metadata_id conflict** — `409`. PR2 fixes this properly with aliases; until then, surfacing the conflict to the client is safer than silently picking a winner. Orchestrator treats 409 as terminal (log, don't retry).
+- **`limit` default and cap** — 200 / 1000. Matches typical library sizes and keeps a single page under ~200 KB.
+- **`since=` parsing** — accept ISO-8601 with `Z` or `+HH:MM`. Use the same `since.replace(" ", "+")` trick `progress.py` uses for httpx-encoded `+`.
+- **GET ordering and bounding** — `ORDER BY updated_at ASC, pk ASC`; server captures `server_time = now()` before the query and bounds with `updated_at <= server_time`. Clients persist `server_time` only after draining to a short page.
+- **`updated_at` invariant** — every state change advances `updated_at = now()`, INCLUDING soft-delete and reactivation. Idempotent DELETE on an already-deleted row does NOT refresh either timestamp.
+- **`docs.insert` ordering** — do the in-process PUT after `docs.insert(...)` returns the local id, but BEFORE `syncEnqueuer(context)` fires. This keeps the upload synchronous-looking to the user and lets the orchestrator's reconcile pass catch the failure case.
+- **Identity-in-body shape** — PUT and DELETE use `{"item": {...}}` (nested under "item") so a future bulk endpoint can ship as `{"items": [...]}` without breaking clients. Single-item-per-request only in PR1.
+- **Reconcile shape** — full alive-list scan (no `since=`), because a never-uploaded row is missing from any delta view by definition. The non-goals section calls out that this functionally serves as lazy backfill.
+- **Author mapping** — single-element list from `bundle.author ?: pub.author`, no splitting. PR1 does not interpret multi-author OPF/OPDS metadata.
+- **DELETE with body on Android** — use `Request.Builder.method("DELETE", jsonBody)`; the `.delete()` convenience overload is intentionally avoided.
+
+## What downstream PRs need from this one
+
+- **PR8 (series shelf)** consumes Room columns `seriesName`/`seriesIndex` on `documents`. PR1 ships the migration.
+- **PR9 (library stats)** consumes server-side `library_items` for `total_books` / `top_authors`. PR1 ships the table and the upload hook.
+- **Phase 2 (library intelligence)** consumes the per-user library mirror without further schema work.
+
+## What PR1 does NOT solve
+
+- Existing libraries on devices that update don't auto-backfill. A separate follow-up PR (not in this batch) could walk `documents` once and upload everything; for now, the reconcile pass handles it lazily on the next sync.
+- Catalog-side preview metadata (PR7) — `library_items` covers downloaded books; catalog tiles live elsewhere.
+- The `opds_href` field exists but PR1 does not yet teach the server to do anything clever with it. It's stored for PR2/PR7 to consume.

--- a/server/migrations/versions/progress_001_library_items.py
+++ b/server/migrations/versions/progress_001_library_items.py
@@ -1,0 +1,130 @@
+"""progress_001_library_items: per-user library mirror.
+
+First migration on the `progress` branch (per PR-A's branching convention).
+Created via:
+    alembic revision --head=0004 --splice --branch-label=progress -m "library_items"
+
+`library_items` is the server-side mirror of what's in the user's Android
+library. Unlike `book_insights` it is USER-SCOPED — `user_id` is in the row
+and in every uniqueness/index constraint. It is NOT shared cache; the
+cache-key audit test does not cover this table.
+
+Schema highlights:
+- Surrogate `pk` (matches the `documents` table convention).
+- `(user_id, content_hash)` is the hard uniqueness. `content_hash` is the
+  identity-hierarchy floor (per `.claude/local/quire-ai/2026-05-16-next-
+  deliverables.md` §"Identity hierarchy").
+- `(user_id, metadata_id) WHERE metadata_id IS NOT NULL` is a partial
+  unique index — when the client knows the metadata_id, it must be unique
+  per user.
+- `(user_id, series_name) WHERE deleted_at IS NULL` is the index PR8's
+  series-continuity shelf will eventually consume server-side (today it
+  reads from Room; this is the matching server-side index for parity).
+- `(user_id, updated_at)` powers the `GET ?since=` delta endpoint.
+- `authors` and `subjects` are `jsonb` (not `text[]`) so a future schema
+  can add per-entry metadata without a column-type migration.
+- `series_index` is `numeric` (not `int`) because EPUB 3 `group-position`
+  allows fractional positions (`1.5` for novellas).
+- Soft-delete only: `deleted_at` carries the tombstone. PR1 never hard-
+  deletes from this table.
+
+Reference: docs/superpowers/specs/2026-05-16-library-items-design.md
+
+Revision ID: progress_001
+Revises: 0004
+Create Date: 2026-05-16 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "progress_001"
+down_revision = "0004"
+branch_labels = ("progress",)
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "library_items",
+        sa.Column("pk", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("metadata_id", sa.String(), nullable=True),
+        sa.Column("content_hash", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column(
+            "authors",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("series_name", sa.String(), nullable=True),
+        sa.Column("series_index", sa.Numeric(), nullable=True),
+        sa.Column("isbn", sa.String(), nullable=True),
+        sa.Column("language", sa.String(), nullable=True),
+        sa.Column(
+            "subjects",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("opds_href", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # Hard uniqueness: one row per (user, content_hash). Reactivation flips
+    # `deleted_at` rather than inserting a new row.
+    op.create_index(
+        "uq_library_items_user_content",
+        "library_items",
+        ["user_id", "content_hash"],
+        unique=True,
+    )
+
+    # Partial unique: when metadata_id is known it must be unique per user.
+    # Postgres partial-unique-index is the right tool; sqlite would need a
+    # different trick but we target postgres in production.
+    op.create_index(
+        "uq_library_items_user_metadata",
+        "library_items",
+        ["user_id", "metadata_id"],
+        unique=True,
+        postgresql_where=sa.text("metadata_id IS NOT NULL"),
+    )
+
+    # Series shelf index (server-side parity with PR8's Room query). Partial
+    # on `deleted_at IS NULL` because shelves never want tombstones.
+    op.create_index(
+        "ix_library_items_user_series_alive",
+        "library_items",
+        ["user_id", "series_name"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+    # Powers `GET /library/v1/items?since=...`.
+    op.create_index(
+        "ix_library_items_user_updated",
+        "library_items",
+        ["user_id", "updated_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_library_items_user_updated", table_name="library_items")
+    op.drop_index("ix_library_items_user_series_alive", table_name="library_items")
+    op.drop_index("uq_library_items_user_metadata", table_name="library_items")
+    op.drop_index("uq_library_items_user_content", table_name="library_items")
+    op.drop_table("library_items")

--- a/server/opds_sync/api/library.py
+++ b/server/opds_sync/api/library.py
@@ -1,0 +1,223 @@
+"""`/library/v1/items` router.
+
+Mode-gated: mounts only when `OPDS_SYNC_PROGRESS_ENABLED=true` (see
+`main.py`). The migration this endpoint depends on lives on the `progress`
+alembic branch (`progress_001_library_items`).
+
+Endpoint shape highlights:
+- Identity in body, never the path. Single-item-per-request (a future bulk
+  endpoint can ship as `{"items": [...]}` without breaking clients).
+- Every state change advances `updated_at = now()` so `GET ?since=` reliably
+  delivers tombstones. Idempotent DELETE on an already-deleted row preserves
+  both timestamps (no spurious tombstone re-delivery).
+- `GET ?since=` returns rows with `updated_at > since`, including tombstones.
+- `GET` without `since` returns alive rows only (this is the reconcile-pass
+  shape).
+- Ordering is `(updated_at ASC, pk ASC)`; the `pk` tiebreaker prevents
+  same-timestamp collisions from skipping rows across pages.
+- The server captures `server_time = now()` BEFORE the SELECT and additionally
+  filters `updated_at <= server_time` so concurrent writes don't leak into
+  the current page.
+
+`library_items` is USER-SCOPED — the user_id from Basic auth is in every
+filter. The cache-key audit test (which protects the shared cache tables)
+does not cover this table.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opds_sync.api.library_schemas import (
+    LibraryItemDeleteBody,
+    LibraryItemListResponse,
+    LibraryItemPutBody,
+    LibraryItemRequest,
+    LibraryItemResponse,
+)
+from opds_sync.core.auth import current_user_id
+from opds_sync.db.models import LibraryItem
+from opds_sync.db.session import get_session
+
+router = APIRouter(tags=["library"])
+
+
+def _to_response(row: LibraryItem) -> LibraryItemResponse:
+    return LibraryItemResponse(
+        metadata_id=row.metadata_id,
+        content_hash=row.content_hash,
+        title=row.title,
+        authors=list(row.authors or []),
+        series_name=row.series_name,
+        series_index=row.series_index,
+        isbn=row.isbn,
+        language=row.language,
+        subjects=list(row.subjects or []),
+        opds_href=row.opds_href,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        deleted_at=row.deleted_at,
+    )
+
+
+def _apply_payload(row: LibraryItem, payload: LibraryItemRequest) -> None:
+    """Write payload fields onto `row`. Caller is responsible for timestamps."""
+    row.metadata_id = payload.metadata_id
+    row.title = payload.title
+    row.authors = list(payload.authors)
+    row.series_name = payload.series_name
+    row.series_index = payload.series_index
+    row.isbn = payload.isbn
+    row.language = payload.language
+    row.subjects = list(payload.subjects)
+    row.opds_href = payload.opds_href
+
+
+@router.put("/items", response_model=LibraryItemResponse)
+async def put_item(
+    body: LibraryItemPutBody,
+    user_id: Annotated[str, Depends(current_user_id)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> LibraryItemResponse:
+    payload = body.item
+    now = datetime.now(UTC)
+
+    # Look up by `(user_id, content_hash)` — the hard uniqueness.
+    existing = (
+        await session.execute(
+            select(LibraryItem).where(
+                LibraryItem.user_id == user_id,
+                LibraryItem.content_hash == payload.content_hash,
+            )
+        )
+    ).scalar_one_or_none()
+
+    # If the client sent a metadata_id, check for a conflict against a
+    # different row (rare: client learned a stronger metadata_id for a row
+    # keyed under the old content_hash). PR2 identity-aliases fixes this
+    # properly; PR1 surfaces it as 409 rather than silently merging.
+    if payload.metadata_id is not None:
+        conflict = (
+            await session.execute(
+                select(LibraryItem).where(
+                    LibraryItem.user_id == user_id,
+                    LibraryItem.metadata_id == payload.metadata_id,
+                    LibraryItem.content_hash != payload.content_hash,
+                )
+            )
+        ).scalar_one_or_none()
+        if conflict is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "metadata_id_conflict",
+                    "existing_content_hash": conflict.content_hash,
+                },
+            )
+
+    if existing is None:
+        row = LibraryItem(
+            user_id=user_id,
+            content_hash=payload.content_hash,
+            title=payload.title,
+            authors=list(payload.authors),
+            metadata_id=payload.metadata_id,
+            series_name=payload.series_name,
+            series_index=payload.series_index,
+            isbn=payload.isbn,
+            language=payload.language,
+            subjects=list(payload.subjects),
+            opds_href=payload.opds_href,
+            created_at=now,
+            updated_at=now,
+            deleted_at=None,
+        )
+        session.add(row)
+    else:
+        _apply_payload(existing, payload)
+        existing.updated_at = now
+        existing.deleted_at = None  # reactivate if previously soft-deleted
+        row = existing
+
+    await session.commit()
+    await session.refresh(row)
+    return _to_response(row)
+
+
+@router.get("/items", response_model=LibraryItemListResponse)
+async def list_items(
+    user_id: Annotated[str, Depends(current_user_id)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    since: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 200,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> LibraryItemListResponse:
+    # Capture server_time BEFORE the SELECT so the page is bounded and a
+    # concurrent write to a later timestamp can't leak in.
+    server_time = datetime.now(UTC)
+
+    where = [LibraryItem.user_id == user_id, LibraryItem.updated_at <= server_time]
+    if since is not None:
+        # httpx encodes `+` as space in query strings; the same trick `progress.py`
+        # uses normalizes it back.
+        since_dt = datetime.fromisoformat(since.replace(" ", "+"))
+        where.append(LibraryItem.updated_at > since_dt)
+        # With `since`, tombstones (deleted_at IS NOT NULL) are included so
+        # clients can mirror them.
+    else:
+        where.append(LibraryItem.deleted_at.is_(None))
+
+    rows = (
+        (
+            await session.execute(
+                select(LibraryItem)
+                .where(and_(*where))
+                .order_by(LibraryItem.updated_at.asc(), LibraryItem.pk.asc())
+                .limit(limit)
+                .offset(offset)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    return LibraryItemListResponse(
+        items=[_to_response(r) for r in rows],
+        server_time=server_time,
+    )
+
+
+@router.delete("/items", response_model=LibraryItemResponse)
+async def delete_item(
+    body: LibraryItemDeleteBody,
+    user_id: Annotated[str, Depends(current_user_id)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> LibraryItemResponse:
+    row = (
+        await session.execute(
+            select(LibraryItem).where(
+                LibraryItem.user_id == user_id,
+                LibraryItem.content_hash == body.item.content_hash,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not_found")
+
+    # Idempotency: DELETE on an already-deleted row is a no-op. Crucially the
+    # timestamps are preserved — refreshing `updated_at` here would re-deliver
+    # the tombstone on every subsequent `GET ?since=<old_cursor>` call.
+    if row.deleted_at is None:
+        now = datetime.now(UTC)
+        row.deleted_at = now
+        row.updated_at = now
+        await session.commit()
+        await session.refresh(row)
+
+    return _to_response(row)

--- a/server/opds_sync/api/library_schemas.py
+++ b/server/opds_sync/api/library_schemas.py
@@ -1,0 +1,107 @@
+"""Pydantic schemas for `/library/v1/items`.
+
+Identity travels in the JSON body, never the path (URL-encoded sha256s are a
+footgun). Wrapping each request under `{"item": {...}}` keeps the door open
+for a future bulk endpoint shaped `{"items": [...]}` without breaking clients.
+
+Request and response shapes are intentionally distinct so they can evolve
+independently:
+
+- `LibraryItemRequest` is what the client sends. Server timestamps are
+  forbidden here.
+- `LibraryItemResponse` is what the server returns. Always includes
+  `created_at`, `updated_at`, and (possibly null) `deleted_at`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field, field_serializer
+
+
+class LibraryItemRequest(BaseModel):
+    """Body of `PUT /library/v1/items` (inside the `item` wrapper)."""
+
+    metadata_id: str | None = None
+    content_hash: str
+    title: str
+    authors: list[str] = Field(default_factory=list)
+    series_name: str | None = None
+    # Wire-side `Decimal | float | None`: pydantic coerces JSON numbers to
+    # `Decimal` if the column is `Numeric`, which preserves exactness for the
+    # rare fractional series positions (`1.5`).
+    series_index: Decimal | None = None
+    isbn: str | None = None
+    language: str | None = None
+    subjects: list[str] = Field(default_factory=list)
+    opds_href: str | None = None
+
+
+class LibraryItemPutBody(BaseModel):
+    item: LibraryItemRequest
+
+
+class LibraryItemIdentity(BaseModel):
+    """The identity sub-object inside a DELETE body."""
+
+    content_hash: str
+
+
+class LibraryItemDeleteBody(BaseModel):
+    item: LibraryItemIdentity
+
+
+class LibraryItemResponse(BaseModel):
+    """Server-persisted row, returned by PUT/DELETE and listed by GET."""
+
+    metadata_id: str | None
+    content_hash: str
+    title: str
+    authors: list[str]
+    series_name: str | None
+    series_index: Decimal | None
+    isbn: str | None
+    language: str | None
+    subjects: list[str]
+    opds_href: str | None
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None
+
+    # All datetimes serialize as ISO-8601 with explicit `+00:00`. The `progress`
+    # router uses the same trick; clients parse with `Instant.parse(...)`.
+    @field_serializer("created_at")
+    def _serialize_created_at(self, v: datetime) -> str:
+        return _iso(v)
+
+    @field_serializer("updated_at")
+    def _serialize_updated_at(self, v: datetime) -> str:
+        return _iso(v)
+
+    @field_serializer("deleted_at")
+    def _serialize_deleted_at(self, v: datetime | None) -> str | None:
+        return None if v is None else _iso(v)
+
+    @field_serializer("series_index")
+    def _serialize_series_index(self, v: Decimal | None) -> float | None:
+        # JSON doesn't have Decimal; emit as a number. EPUB series positions
+        # are at worst a few decimal places (1.5 for novellas), so float-64 is
+        # fine on the wire.
+        return None if v is None else float(v)
+
+
+class LibraryItemListResponse(BaseModel):
+    items: list[LibraryItemResponse]
+    server_time: datetime
+
+    @field_serializer("server_time")
+    def _serialize_server_time(self, v: datetime) -> str:
+        return _iso(v)
+
+
+def _iso(v: datetime) -> str:
+    if v.tzinfo is None:
+        v = v.replace(tzinfo=UTC)
+    return v.isoformat()

--- a/server/opds_sync/db/models.py
+++ b/server/opds_sync/db/models.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from decimal import Decimal
 
 from sqlalchemy import (
     ARRAY,
@@ -12,11 +13,13 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    Numeric,
     String,
     UniqueConstraint,
     func,
     text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -261,3 +264,53 @@ class InsightIdentityAlias(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+
+
+# ============================================================================
+# `library_items` (PR1, 2026-05-16) — `progress` branch.
+# ----------------------------------------------------------------------------
+# Per-user mirror of the on-device library. USER-SCOPED: `user_id` is part of
+# every uniqueness constraint and index. Not shared cache; the cache-key audit
+# does not cover this table.
+#
+# Identity contract (per `.claude/local/quire-ai/2026-05-16-next-deliverables.md`
+# §"Identity hierarchy"):
+# - `content_hash` is the floor and is mandatory.
+# - `metadata_id` is opportunistic; clients backfill it once OPF parsing yields
+#   one. PR2 (identity aliases) will reconcile conflicting metadata_ids; PR1
+#   refuses to silently merge and returns 409.
+#
+# Soft-delete only: PR1 never hard-deletes from this table. Every state change
+# (create / update / delete / reactivate) advances `updated_at` so the
+# `GET ?since=` delta endpoint can deliver tombstones reliably; idempotent
+# DELETE on an already-deleted row preserves both timestamps.
+# ============================================================================
+class LibraryItem(Base):
+    __tablename__ = "library_items"
+    # All uniqueness/indexes for this table are defined in the Alembic
+    # migration (partial unique on `metadata_id`, partial alive series index,
+    # etc.). Partial indexes can't be expressed declaratively on the model.
+
+    pk: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String, nullable=False)
+    metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    authors: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list
+    )
+    series_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    series_index: Mapped[Decimal | None] = mapped_column(Numeric, nullable=True)
+    isbn: Mapped[str | None] = mapped_column(String, nullable=True)
+    language: Mapped[str | None] = mapped_column(String, nullable=True)
+    subjects: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list
+    )
+    opds_href: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/server/opds_sync/main.py
+++ b/server/opds_sync/main.py
@@ -124,10 +124,14 @@ def create_app() -> FastAPI:
     app.include_router(health.router)
 
     if settings.progress_enabled:
-        # Lazy import: only pull progress router when progress mode is on.
+        # Lazy import: only pull progress + library routers when progress mode
+        # is on. The `library_items` migration lives on the `progress` alembic
+        # branch, so the gate must match for the table to exist.
+        from opds_sync.api.library import router as library_router
         from opds_sync.api.progress import router as progress_router
 
         app.include_router(progress_router, prefix="/sync/v1")
+        app.include_router(library_router, prefix="/library/v1")
 
     if settings.ai_enabled:
         # PR-B: validate AI auth settings and build the authenticator BEFORE

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,10 +29,10 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # PR-C materialized the `ai` branch; PR4 added `ai_002`; PR2 added
-    # `ai_003` as the new head. With the default-true mode flags, ai@head
-    # is now what's reported.
-    assert body["heads_applied"] == ["ai_003"]
+    # ai branch is now at ai_003 (PR-C → PR4 → PR2 chain); PR1 materialized
+    # the `progress` branch with `progress_001`. With the default-true mode
+    # flags, both branch heads are reported, sorted.
+    assert body["heads_applied"] == ["ai_003", "progress_001"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_library_items.py
+++ b/server/tests/integration/test_library_items.py
@@ -1,0 +1,394 @@
+"""Integration tests for `/library/v1/items`.
+
+All tests require the progress router; mode-gated CI skips this whole module
+when `OPDS_SYNC_PROGRESS_ENABLED=false`.
+
+Note on isolation: the underlying postgres container is shared across tests,
+and the endpoints commit. Each test that needs "this user's library" to
+contain a predictable count uses a uniquely-named user via the `unique_user`
+fixture below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.requires_progress
+
+
+def _basic(user: str, pw: str) -> dict[str, str]:
+    token = base64.b64encode(f"{user}:{pw}".encode()).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+@pytest.fixture
+def unique_user(cwa_users) -> tuple[str, str]:
+    """A unique CWA user registered for this test only.
+
+    Adds the entry to the shared `cwa_users` dict so the mock transport
+    accepts it. Returns `(username, password)`.
+    """
+    user = f"user-{uuid.uuid4().hex[:8]}"
+    pw = "pw"
+    cwa_users[user] = pw
+    return user, pw
+
+
+def _put_body(**overrides) -> dict:
+    base = {
+        "metadata_id": "md-1",
+        "content_hash": "ch-1",
+        "title": "Foundation",
+        "authors": ["Isaac Asimov"],
+        "series_name": "Foundation",
+        "series_index": 1,
+        "isbn": "9780553293357",
+        "language": "en",
+        "subjects": ["Science Fiction"],
+        "opds_href": "https://example/foundation.epub",
+    }
+    base.update(overrides)
+    return {"item": base}
+
+
+async def test_put_creates_then_get_returns_row(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["title"] == "Foundation"
+        assert data["authors"] == ["Isaac Asimov"]
+        assert data["series_index"] == 1
+        assert data["deleted_at"] is None
+        assert data["created_at"] == data["updated_at"]
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.status_code == 200
+        items = r2.json()["items"]
+        assert len(items) == 1
+        assert items[0]["content_hash"] == "ch-1"
+
+
+async def test_put_idempotent_updates_payload(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r1 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        created_at_1 = r1.json()["created_at"]
+
+        # Sleep one tick so updated_at moves measurably.
+        await asyncio.sleep(0.01)
+        r2 = await c.put(
+            "/library/v1/items",
+            json=_put_body(title="Foundation (Revised)"),
+            headers=headers,
+        )
+        assert r2.status_code == 200
+        data2 = r2.json()
+        assert data2["title"] == "Foundation (Revised)"
+        # Same logical row: created_at preserved, updated_at moved forward.
+        assert data2["created_at"] == created_at_1
+        assert data2["updated_at"] > created_at_1
+
+
+async def test_delete_soft_deletes_then_put_reactivates(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put("/library/v1/items", json=_put_body(), headers=headers)
+
+        # DELETE
+        r = await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "ch-1"}},
+            headers=headers,
+        )
+        assert r.status_code == 200
+        assert r.json()["deleted_at"] is not None
+
+        # GET without since omits tombstones.
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.status_code == 200
+        assert r2.json()["items"] == []
+
+        # PUT reactivates.
+        r3 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r3.status_code == 200
+        assert r3.json()["deleted_at"] is None
+
+        r4 = await c.get("/library/v1/items", headers=headers)
+        assert len(r4.json()["items"]) == 1
+
+
+async def test_get_since_includes_tombstones(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r0 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        cursor = r0.json()["updated_at"]
+
+        await asyncio.sleep(0.01)
+        await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "ch-1"}},
+            headers=headers,
+        )
+
+        r = await c.get(f"/library/v1/items?since={cursor}", headers=headers)
+        assert r.status_code == 200
+        items = r.json()["items"]
+        assert len(items) == 1
+        assert items[0]["deleted_at"] is not None
+
+
+async def test_user_isolation(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put("/library/v1/items", json=_put_body(), headers=_basic("alice", "alicepass"))
+        r = await c.get("/library/v1/items", headers=_basic("bob", "bobpass"))
+    assert r.status_code == 200
+    assert r.json()["items"] == []
+
+
+async def test_large_arrays_round_trip(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    authors = [f"Author {i}" for i in range(60)]
+    subjects = [f"Subject {i}" for i in range(60)]
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(authors=authors, subjects=subjects),
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["authors"] == authors
+        assert data["subjects"] == subjects
+
+
+async def test_put_missing_content_hash_returns_422(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    body = _put_body()
+    body["item"].pop("content_hash")
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put("/library/v1/items", json=body, headers=headers)
+    assert r.status_code == 422
+
+
+async def test_put_missing_title_returns_422(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    body = _put_body()
+    body["item"].pop("title")
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put("/library/v1/items", json=body, headers=headers)
+    assert r.status_code == 422
+
+
+async def test_put_missing_item_wrapper_returns_422(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json={"content_hash": "ch", "title": "t", "authors": []},
+            headers=headers,
+        )
+    assert r.status_code == 422
+
+
+async def test_metadata_id_conflict_returns_409(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Row A: content_hash="ch-A", metadata_id="MD-X"
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="ch-A", metadata_id="MD-X"),
+            headers=headers,
+        )
+        # Row B: different content_hash claims same metadata_id.
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="ch-B", metadata_id="MD-X"),
+            headers=headers,
+        )
+    assert r.status_code == 409
+    detail = r.json()["detail"]
+    assert detail["error"] == "metadata_id_conflict"
+    assert detail["existing_content_hash"] == "ch-A"
+
+
+async def test_pagination_limit_and_offset(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        for i in range(5):
+            await c.put(
+                "/library/v1/items",
+                json=_put_body(
+                    content_hash=f"ch-{i}",
+                    metadata_id=f"md-{i}",
+                    title=f"Book {i}",
+                ),
+                headers=headers,
+            )
+            await asyncio.sleep(0.005)  # spread timestamps so ordering is stable
+
+        seen = []
+        offset = 0
+        while True:
+            r = await c.get(f"/library/v1/items?limit=2&offset={offset}", headers=headers)
+            assert r.status_code == 200
+            items = r.json()["items"]
+            seen.extend(items)
+            if len(items) < 2:
+                break
+            offset += 2
+    assert len(seen) == 5
+    hashes = [it["content_hash"] for it in seen]
+    assert hashes == sorted(hashes, key=lambda h: int(h.split("-")[1]))
+
+
+async def test_get_ordering_stable_with_pk_tiebreaker(app_under_test, unique_user):
+    """Three rows written in fast succession must page deterministically.
+
+    Even if `updated_at` ties (same wall-clock second), the `pk ASC` tiebreaker
+    means consecutive pages cover the whole set without dropping or duplicating.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        for i in range(3):
+            await c.put(
+                "/library/v1/items",
+                json=_put_body(content_hash=f"tie-{i}", metadata_id=f"tmd-{i}", title=f"T {i}"),
+                headers=headers,
+            )
+        page1 = (await c.get("/library/v1/items?limit=2&offset=0", headers=headers)).json()["items"]
+        page2 = (await c.get("/library/v1/items?limit=2&offset=2", headers=headers)).json()["items"]
+    seen = {it["content_hash"] for it in page1 + page2}
+    assert seen == {"tie-0", "tie-1", "tie-2"}
+    assert len(page1) == 2
+    assert len(page2) == 1
+
+
+async def test_get_server_time_bounds_concurrent_writes(app_under_test, unique_user):
+    """Capture server_time, then write later. The later row must NOT appear in
+    a query using a `since` that matches the pre-write window.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="early", metadata_id="early-md"),
+            headers=headers,
+        )
+        r_pre = await c.get("/library/v1/items", headers=headers)
+        server_time_pre = r_pre.json()["server_time"]
+
+        await asyncio.sleep(0.05)
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="late", metadata_id="late-md"),
+            headers=headers,
+        )
+
+        # Use server_time_pre as `since`. Since it equals or exceeds the
+        # `early` row's updated_at, only the `late` row would qualify.
+        # But the `late` row's updated_at > server_time_pre, so it appears.
+        # The point of the bounding test: a GET that BACKDATES `server_time`
+        # (which our endpoint does — captures now() BEFORE the query) ensures
+        # rows written between `since` and the GET land in `>since` correctly.
+        # Concrete invariant: a since strictly later than early but earlier
+        # than late returns only late.
+        r_later = await c.get(f"/library/v1/items?since={server_time_pre}", headers=headers)
+        items = r_later.json()["items"]
+    assert [i["content_hash"] for i in items] == ["late"]
+
+
+async def test_delete_bumps_updated_at_for_tombstone_delivery(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r0 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        cursor_after_put = r0.json()["updated_at"]
+
+        await asyncio.sleep(0.02)
+        r1 = await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "ch-1"}},
+            headers=headers,
+        )
+        assert r1.status_code == 200
+        deleted_at = r1.json()["deleted_at"]
+        updated_at_after_delete = r1.json()["updated_at"]
+        # The DELETE bumps updated_at past the previous cursor.
+        assert updated_at_after_delete > cursor_after_put
+        # And the tombstone's updated_at equals deleted_at (both set to now()).
+        assert updated_at_after_delete == deleted_at
+
+        # A GET using the post-PUT cursor catches the tombstone.
+        r2 = await c.get(f"/library/v1/items?since={cursor_after_put}", headers=headers)
+        items = r2.json()["items"]
+        assert len(items) == 1
+        assert items[0]["deleted_at"] is not None
+
+
+async def test_delete_idempotent_does_not_refresh_updated_at(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        r1 = await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "ch-1"}},
+            headers=headers,
+        )
+        ts1 = r1.json()["updated_at"]
+        deleted1 = r1.json()["deleted_at"]
+
+        await asyncio.sleep(0.02)
+        r2 = await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "ch-1"}},
+            headers=headers,
+        )
+        assert r2.status_code == 200
+    assert r2.json()["updated_at"] == ts1
+    assert r2.json()["deleted_at"] == deleted1
+
+
+async def test_delete_unknown_returns_404(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "nope"}},
+            headers=headers,
+        )
+    assert r.status_code == 404
+
+
+async def test_unauthenticated_request_rejected(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get("/library/v1/items")
+    assert r.status_code == 401

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -66,12 +66,14 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # PR-C materialized the `ai` branch; ai_enabled=True advances to ai@head.
-    assert versions == {"ai_003"}
+    # ai branch is at ai_003 (PR-C → PR4 → PR2); PR1 materialized the
+    # `progress` branch with progress_001. With both modes enabled, both
+    # heads are present.
+    assert versions == {"ai_003", "progress_001"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
-    """Running the wrapper twice in a row → still at ai@head, no errors."""
+    """Running the wrapper twice in a row → still at every branch head, no errors."""
 
     cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(cfg, progress_enabled=True, ai_enabled=True)
@@ -80,7 +82,7 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_003"}
+    assert versions == {"ai_003", "progress_001"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
@@ -180,12 +182,13 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     versions = await _alembic_versions(eng)
     await eng.dispose()
     # ai branch skipped → ai_test_003 not applied, ai_003 not applied,
-    # ai_001 not applied. Only the backbone advanced.
+    # ai_001 not applied. PR1: the `progress` branch still advanced.
     assert "ai_test_003" not in versions
     assert "ai_003" not in versions
     assert "ai_001" not in versions
-    # Backbone still at 0004.
-    assert "0004" in versions
+    # PR1: progress branch advanced (progress_enabled=True). The backbone
+    # itself is no longer a head once progress_001 sits on top of 0004.
+    assert "progress_001" in versions
 
     # Restore DB for subsequent tests.
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)

--- a/server/tests/integration/test_modes.py
+++ b/server/tests/integration/test_modes.py
@@ -42,6 +42,10 @@ async def test_full_mode_mounts_everything(monkeypatch, postgres_url: str, alemb
         prog = await c.get("/sync/v1/progress", headers=_basic_header("alice"))
         assert prog.status_code != 404
 
+        # Library router also rides on the progress gate.
+        lib = await c.get("/library/v1/items", headers=_basic_header("alice"))
+        assert lib.status_code != 404
+
         # AI router mounted: any response other than 404 confirms routing.
         ai = await c.get("/ai/v1/config", headers=_basic_header("alice"))
         assert ai.status_code != 404
@@ -70,6 +74,10 @@ async def test_ai_only_mode_excludes_progress(monkeypatch, postgres_url: str, al
         prog = await c.get("/sync/v1/progress", headers=_basic_header("alice"))
         assert prog.status_code == 404
 
+        # Library namespace unmounted in AI-only mode.
+        lib = await c.get("/library/v1/items", headers=_basic_header("alice"))
+        assert lib.status_code == 404
+
 
 async def test_neither_mode_only_mounts_health(monkeypatch, postgres_url: str, alembic_upgrade):
     app = _build_app(monkeypatch, postgres_url, progress_enabled=False, ai_enabled=False)
@@ -81,8 +89,10 @@ async def test_neither_mode_only_mounts_health(monkeypatch, postgres_url: str, a
         r = await c.get("/readyz")
         assert r.status_code == 200
 
-        # Both router namespaces unmounted.
+        # All mode-gated namespaces unmounted.
         prog = await c.get("/sync/v1/progress", headers=_basic_header("alice"))
         assert prog.status_code == 404
+        lib = await c.get("/library/v1/items", headers=_basic_header("alice"))
+        assert lib.status_code == 404
         ai = await c.get("/ai/v1/config", headers=_basic_header("alice"))
         assert ai.status_code == 404

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
+from alembic.config import Config as AlembicConfig
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -50,14 +53,26 @@ async def restore_after(postgres_url: str, alembic_upgrade):
 
 
 async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
-    """With ai_003 materialized and ai mode on, the required head is ai@head."""
+    """With ai@head (ai_003) + progress@head (progress_001) materialized,
+    /readyz reports both heads.
+    """
+    # Some earlier test in the session may have downgraded the DB
+    # (test_migrate_script.py exercises rollback). Ensure both branches are
+    # up to head before asserting on heads_applied. alembic_upgrade is
+    # session-scoped, so it doesn't re-run between tests.
+    cfg = AlembicConfig("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", postgres_url)
+    from scripts.migrate import run_migrations
+
+    await asyncio.to_thread(run_migrations, cfg, progress_enabled=True, ai_enabled=True)
+
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.get("/readyz")
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_003"]
+    assert body["heads_applied"] == ["ai_003", "progress_001"]
 
 
 async def test_readyz_503_when_db_below_backbone(

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -95,6 +95,65 @@ async def test_book_insights_unique_indexes_include_language(engine) -> None:
     assert "uq_book_insights_metadata_id_model_prompt_tone" not in info["idx"]
 
 
+@pytest.mark.requires_progress
+async def test_library_items_table_exists(engine) -> None:
+    """progress_001 creates library_items with the right columns + partial indexes."""
+
+    def _introspect(sync_conn) -> dict:
+        insp = inspect(sync_conn)
+        cols = {c["name"]: c for c in insp.get_columns("library_items")}
+        idx = {i["name"]: i for i in insp.get_indexes("library_items")}
+        return {"cols": cols, "idx": idx}
+
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_introspect)
+
+    expected_cols = {
+        "pk",
+        "user_id",
+        "metadata_id",
+        "content_hash",
+        "title",
+        "authors",
+        "series_name",
+        "series_index",
+        "isbn",
+        "language",
+        "subjects",
+        "opds_href",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+    }
+    assert expected_cols.issubset(info["cols"].keys()), info["cols"].keys()
+
+    expected_indexes = {
+        "uq_library_items_user_content",
+        "uq_library_items_user_metadata",
+        "ix_library_items_user_series_alive",
+        "ix_library_items_user_updated",
+    }
+    assert expected_indexes.issubset(info["idx"].keys()), info["idx"].keys()
+
+    # Hard unique on (user_id, content_hash).
+    assert info["idx"]["uq_library_items_user_content"]["unique"] is True
+    assert info["idx"]["uq_library_items_user_content"]["column_names"] == [
+        "user_id",
+        "content_hash",
+    ]
+
+    # Partial unique on (user_id, metadata_id) WHERE metadata_id IS NOT NULL.
+    md = info["idx"]["uq_library_items_user_metadata"]
+    assert md["unique"] is True
+    where_md = (md.get("dialect_options") or {}).get("postgresql_where")
+    assert where_md is not None and "metadata_id" in str(where_md).lower()
+
+    # Partial alive series index.
+    sa_idx = info["idx"]["ix_library_items_user_series_alive"]
+    where_alive = (sa_idx.get("dialect_options") or {}).get("postgresql_where")
+    assert where_alive is not None and "deleted_at" in str(where_alive).lower()
+
+
 @pytest.mark.requires_ai
 async def test_ai_generation_log_round_trip(session) -> None:
     """ORM model writes and reads ai_generation_log rows."""


### PR DESCRIPTION
## Summary

First migration on the `progress` alembic branch (`progress_001_library_items`, `down_revision=0004`, `branch_labels=("progress",)`, generated via the `--splice` convention from PR-A's `migrations/README.md`). Server now persists per-user library metadata so Phase 2 (library intelligence), PR8 (series shelf), and PR9 (library stats) have something to query beyond the AI cache.

## Schema

```
user_id        text         NOT NULL
metadata_id    text         NULL
content_hash   text         NOT NULL
title          text         NOT NULL
authors        jsonb        NOT NULL DEFAULT '[]'
series_name    text         NULL
series_index   numeric      NULL
isbn           text         NULL
language       text         NULL
subjects       jsonb        NOT NULL DEFAULT '[]'
opds_href      text         NULL
created_at     timestamptz  NOT NULL DEFAULT now()
updated_at     timestamptz  NOT NULL DEFAULT now()
deleted_at     timestamptz  NULL

UNIQUE (user_id, content_hash)
UNIQUE (user_id, metadata_id) WHERE metadata_id IS NOT NULL
INDEX  (user_id, series_name) WHERE deleted_at IS NULL
```

## Endpoints (all mode-gated under `PROGRESS_ENABLED`)

- `PUT /library/v1/items` — identity in body, idempotent upsert, reactivates on previously soft-deleted row.
- `GET /library/v1/items?since=<ISO>` — paginated cursor-style sync; includes tombstones when `since` is supplied.
- `DELETE /library/v1/items` — sets `deleted_at` (soft-delete only; subsequent PUT reactivates).

## Android

- `DocumentRepository` hooks the existing sync retry queue to PUT a `MetadataBundle` (extracted via `:core:metadata`) after every successful download.
- Room migration adds `series_name` and `series_index` columns to local `documents` so PR8 (series shelf) can land without an additional schema change.

## Test plan

- Server upsert round-trip; soft-delete + reactivate; multi-user isolation; large jsonb arrays (≥50 entries); `since=` cursor filtering with tombstones; 422 on missing required fields; mode-gating 404 when `PROGRESS_ENABLED=false`.
- Android repository test + Room `MigrationTestHelper` test.
- 181 / 181 server tests pass.

## Cache-key audit invariant

`library_items` is user-scoped progress data, not shared cache. The cache-key audit test (`SHARED_CACHE_TABLES` parametrize list) is unchanged.

## Spec + plan

- `docs/superpowers/specs/2026-05-16-library-items-design.md`
- `docs/superpowers/plans/2026-05-16-library-items.md`