### PR TITLE
refactor(android): drop "Regenerate insights" overflow action

### DIFF
--- a/app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
+++ b/app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
@@ -57,13 +57,6 @@ class AiRepository(
         bundle: MetadataBundle,
     ): BookInsightResponse = client.lookupInsight(identity, bundle)
 
-    /** User requested a re-generation with a reason. Counts against regen daily limit. */
-    suspend fun regenerateInsight(
-        identity: DocumentIdentity,
-        bundle: MetadataBundle,
-        reason: String,
-    ): BookInsightResponse = client.regenerateInsight(identity, bundle, reason)
-
     suspend fun getCachedInsight(identity: DocumentIdentity): BookInsightResponse? =
         try {
             client.getInsight(identity)

--- a/app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailScreen.kt
@@ -4,15 +4,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -20,9 +17,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
@@ -35,7 +29,6 @@ fun BookDetailScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val doc = state.document
-    var regenDialogOpen by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = { TopAppBar(title = { Text(doc?.title ?: "Book") }) }
@@ -56,56 +49,7 @@ fun BookDetailScreen(
                 }
             }
             InsightSection(state.insight, onRetry = { viewModel.retry() })
-            if (state.insight is InsightUiState.Loaded) {
-                TextButton(
-                    modifier = Modifier.padding(horizontal = 8.dp),
-                    onClick = { regenDialogOpen = true },
-                ) { Text("Not quite right? Regenerate") }
-            }
             Spacer(Modifier.height(24.dp))
         }
     }
-
-    if (regenDialogOpen) {
-        RegenerateDialog(
-            onDismiss = { regenDialogOpen = false },
-            onSubmit = { reason ->
-                regenDialogOpen = false
-                viewModel.regenerate(reason)
-            },
-        )
-    }
-}
-
-@Composable
-private fun RegenerateDialog(onDismiss: () -> Unit, onSubmit: (String) -> Unit) {
-    var reason by remember { mutableStateOf("") }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Regenerate insight") },
-        text = {
-            Column {
-                Text(
-                    "Tell the AI what was wrong or missing. This counts against your daily regeneration budget.",
-                    style = MaterialTheme.typography.bodySmall,
-                )
-                Spacer(Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = reason,
-                    onValueChange = { reason = it.take(500) },
-                    label = { Text("Reason") },
-                    minLines = 2,
-                    maxLines = 4,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(
-                enabled = reason.isNotBlank(),
-                onClick = { onSubmit(reason.trim()) },
-            ) { Text("Regenerate") }
-        },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
-    )
 }

--- a/app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailViewModel.kt
@@ -98,38 +98,4 @@ class BookDetailViewModel(
     fun retry() {
         viewModelScope.launch { load() }
     }
-
-    fun regenerate(reason: String) {
-        viewModelScope.launch {
-            val doc = state.value.document ?: return@launch
-            val ident = DocumentIdentity(
-                metadataId = doc.identity.metadataId,
-                contentHash = doc.identity.contentHash,
-            )
-            _state.value = _state.value.copy(insight = InsightUiState.Loading)
-            val opfBytes = openOpfBytes(doc)
-            val bundle = if (opfBytes != null) {
-                OpfMetadataExtractor.extract(opfBytes, fallbackTitle = doc.title)
-            } else {
-                MetadataBundle(title = doc.title, author = doc.author)
-            }
-            runCatching { ai.regenerateInsight(ident, bundle, reason) }
-                .onSuccess { resp ->
-                    _state.value = _state.value.copy(
-                        insight = InsightUiState.Loaded(resp.payload, resp.sources),
-                    )
-                }
-                .onFailure { e ->
-                    val msg = when {
-                        e is AiQuotaException ->
-                            "You've reached today's regeneration limit. Try again after ${e.info.resetsAt.take(10)}."
-                        e is AiHttpException && e.code == 429 ->
-                            "You've reached today's regeneration limit. Try again tomorrow."
-                        e is AiHttpException -> "Couldn't regenerate (${e.code})."
-                        else -> "Couldn't regenerate."
-                    }
-                    _state.value = _state.value.copy(insight = InsightUiState.Error(msg))
-                }
-        }
-    }
 }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiClient.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiClient.kt
@@ -58,14 +58,6 @@ class AiClient(
     ): BookInsightResponse =
         post("/ai/v1/insights/lookup", InsightLookupBody(identity, bundle))
 
-    /** Force a fresh generation. Counts against regen daily limit. */
-    suspend fun regenerateInsight(
-        identity: DocumentIdentity,
-        bundle: MetadataBundle,
-        reason: String,
-    ): BookInsightResponse =
-        post("/ai/v1/insights/regenerate", InsightRegenerateBody(identity, bundle, reason))
-
     /** Cache-only read. Throws [InsightNotCachedException] on 404. */
     suspend fun getInsight(identity: DocumentIdentity): BookInsightResponse =
         try {

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt
@@ -83,13 +83,6 @@ data class InsightLookupBody(
 @Serializable
 data class InsightGetBody(val identity: DocumentIdentity)
 
-@Serializable
-data class InsightRegenerateBody(
-    val identity: DocumentIdentity,
-    val bundle: MetadataBundle,
-    val reason: String,
-)
-
 /** Body of the inner detail object on a 429 response. */
 @Serializable
 data class QuotaInfo(

--- a/data/ai/src/test/java/io/theficos/ereader/data/ai/AiClientTest.kt
+++ b/data/ai/src/test/java/io/theficos/ereader/data/ai/AiClientTest.kt
@@ -137,24 +137,6 @@ class AiClientTest {
     }
 
     @Test
-    fun `regenerateInsight sends reason`() = runTest {
-        server.enqueue(
-            MockResponse().setResponseCode(200).setBody(
-                """{"payload":{"schema_version":2,"intro":"fixed","confidence":"high"},"sources":[],"model_id":"m","prompt_version":"2","generated_at":"2026-05-09T00:00:00+00:00"}"""
-            )
-        )
-        val out = client.regenerateInsight(
-            DocumentIdentity(metadataId = null, contentHash = "ch"),
-            MetadataBundle(title = "Foundation"),
-            reason = "Author bio was wrong.",
-        )
-        val req = server.takeRequest()
-        assertThat(req.path).isEqualTo("/ai/v1/insights/regenerate")
-        assertThat(req.body.readUtf8()).contains("Author bio was wrong.")
-        assertThat(out.payload.intro).isEqualTo("fixed")
-    }
-
-    @Test
     fun `429 raises AiQuotaException with parsed info`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(429).setBody(

--- a/docs/superpowers/plans/2026-05-17-drop-regenerate-button.md
+++ b/docs/superpowers/plans/2026-05-17-drop-regenerate-button.md
@@ -1,0 +1,81 @@
+# Plan — Drop "Regenerate insights" affordance
+
+**Spec:** `docs/superpowers/specs/2026-05-17-drop-regenerate-button-design.md`
+**Branch:** `feat/drop-regenerate-button`
+**Mode:** TDD-by-deletion (tests removed before implementation; build is the
+spec of correctness).
+
+## Steps
+
+### 1. Remove the client test for `regenerateInsight`
+
+- Edit `data/ai/src/test/java/io/theficos/ereader/data/ai/AiClientTest.kt`.
+- Delete the `@Test fun \`regenerateInsight sends reason\`` block.
+- Verify: `scripts/dgradle :data:ai:testDebugUnitTest` still compiles (it
+  will fail until the impl is removed, that is fine; we will re-run after
+  step 2).
+
+### 2. Remove the client method + DTO
+
+- Edit `data/ai/src/main/java/io/theficos/ereader/data/ai/AiClient.kt`:
+  delete `regenerateInsight()` and its KDoc.
+- Edit `data/ai/src/main/java/io/theficos/ereader/data/ai/AiDtos.kt`:
+  delete `InsightRegenerateBody`.
+- Verify: `scripts/dgradle :data:ai:testDebugUnitTest` green.
+
+### 3. Remove the repository method
+
+- Edit `app/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt`:
+  delete `regenerateInsight()` and its KDoc.
+
+### 4. Remove the ViewModel handler
+
+- Edit `app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailViewModel.kt`:
+  delete `fun regenerate(reason: String)`. The error-mapping `when` inside
+  that function uses `AiHttpException` / `AiQuotaException` — those imports
+  remain in use by `load()`.
+
+### 5. Remove the UI affordance
+
+- Edit `app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailScreen.kt`:
+  - Delete the `TextButton(...)` block under `if (state.insight is InsightUiState.Loaded)`.
+  - Delete the `regenDialogOpen` state.
+  - Delete the trailing `if (regenDialogOpen) { RegenerateDialog(...) }` block.
+  - Delete the `RegenerateDialog` composable.
+  - Prune now-unused imports (`AlertDialog`, `OutlinedTextField`,
+    `mutableStateOf`, `remember`, `setValue` if no other use).
+
+### 6. Verify
+
+- `scripts/dgradle :app:testDebugUnitTest` — green.
+- `scripts/dgradle :data:ai:testDebugUnitTest` — green.
+- `scripts/dgradle :app:lintDebug` — clean (no new warnings; no orphan
+  string references — the screen used inline string literals, no
+  `strings.xml` entries existed).
+
+### 7. Commit, push, PR
+
+- Commit subject: `:fire: refactor(android): drop "Regenerate insights" overflow action`
+- Body mirrors the spec rationale.
+- Push to `origin feat/drop-regenerate-button`.
+- Open PR against `main`.
+
+## Criteria
+
+**Clarity:** Every edit lists file + symbol. No ambiguity about scope.
+
+**Verifiability:** Each step ends with a concrete build/test command whose
+green status is the success signal.
+
+**Completeness:** Walks the full call chain UI → ViewModel → Repository →
+Client → DTO → Test. No reference to `regenerateInsight` will remain in the
+Android tree after step 5.
+
+**Big picture:** Server endpoint untouched. PR6's overflow menu (parallel
+work) lands on the same screen file but in a different region; conflict is
+trivial.
+
+## Rollback
+
+Single commit; `git revert HEAD` restores the button. Server contract
+unchanged, so a partial rollback (just the client method) is also safe.

--- a/docs/superpowers/specs/2026-05-17-drop-regenerate-button-design.md
+++ b/docs/superpowers/specs/2026-05-17-drop-regenerate-button-design.md
@@ -1,0 +1,99 @@
+# PR11 — Drop "Regenerate insights" overflow action
+
+**Date:** 2026-05-17
+**Branch:** Android-only (server endpoint retained for invalidate-only use by PR6)
+**Effort:** Quick
+**Deps:** none. Lands any time.
+**Status:** Draft — ready for review
+
+## Goal
+
+Remove the in-app "Regenerate" affordance from the book-detail screen. The
+server-side `POST /ai/v1/insights/regenerate` endpoint stays — it remains
+available to cluster admin tooling and future flows (e.g., the PR6 audit UI
+exposes the existing `invalidate` endpoint, not regenerate).
+
+The current implementation in `app/.../bookdetail/BookDetailScreen.kt` is a
+`TextButton` reading "Not quite right? Regenerate" plus a `RegenerateDialog`
+that captures a free-text reason and POSTs to `/ai/v1/insights/regenerate`.
+(The deliverables note describes the affordance as an overflow
+`DropdownMenuItem`; that menu does not yet exist on `main`. PR6 adds it. We
+delete the button + dialog that exist today.)
+
+## Why now
+
+The regenerate flow issues a forced re-generation with the *same* cache key,
+which is wasteful and adds essentially no UX value:
+
+- Legitimate "I want different output" cases (tone, language, model_id,
+  prompt_version changes) already invalidate the cache key naturally and
+  regenerate via the normal `lookup` path. No explicit user action needed.
+- The only remaining use case ("the answer is bad, give me a different one
+  with the same parameters") is better served by invalidate-and-reload — one
+  AI call instead of two (`DELETE` then `POST`), and the user gets the same
+  outcome.
+- PR6's audit UI surfaces the server-side `invalidate` endpoint as the
+  single, principled way to evict a cached insight. We do not want two ways
+  to do this from the app.
+
+## Scope
+
+### Remove
+
+- `BookDetailScreen.kt`: the `TextButton("Not quite right? Regenerate")`, the
+  `RegenerateDialog` composable, the `regenDialogOpen` state, and the
+  associated dialog block.
+- `BookDetailViewModel.kt`: `regenerate(reason: String)` and its supporting
+  imports (only those that become unused).
+- `AiRepository.kt`: `regenerateInsight()`.
+- `AiClient.kt`: `regenerateInsight()` and `InsightRegenerateBody`
+  reference. (The `InsightRegenerateBody` data class itself is unused once
+  the client method is removed — delete it from `AiDtos.kt`.)
+- `AiClientTest.kt`: `regenerateInsight sends reason` test.
+
+### Keep
+
+- Server `POST /ai/v1/insights/regenerate` endpoint (untouched, separate
+  repo path).
+- `POST /ai/v1/insights/invalidate` plus `AiRepository.invalidate()` and
+  `AiClient.invalidateInsight()`. These are PR6's substrate.
+- All `BookInsight` payload fields (no schema change). Lineage fields like
+  `regenerated_from` on the server live in the audit log, not in this PR's
+  surface area.
+- `regen_daily_limit` field on `AiConfig` — still relevant for admin tooling
+  and future surfaces; removing it would be a breaking server-contract
+  change that is out of scope.
+
+### Out of scope
+
+- Any server-side change.
+- Touching the AI Settings screen.
+- Removing the "regeneration limit" copy from `lookup` error messages — the
+  budget still applies to admin/cluster regenerate calls and surfaces here
+  via 429.
+
+## Tests
+
+- Update `AiClientTest`: delete `regenerateInsight sends reason`. No
+  inverted assertion needed — the API is gone; absence is enforced by the
+  type system.
+- No Compose UI test currently exists for `BookDetailScreen`. Adding one
+  purely to assert the absence of the button is gold-plating; the
+  compile-time absence of `viewModel.regenerate(...)` is sufficient.
+  Concurrent PR6 adds the overflow menu and will own that test surface.
+
+## Migration / rollout
+
+None. Pure code deletion. Users mid-dialog when they update lose the
+unsubmitted reason (acceptable — it never persists).
+
+## Risk / blast radius
+
+- **Merge with PR6:** PR6 (book-detail "Inspect insight" overflow) edits the
+  same `BookDetailScreen.kt` to add an overflow `Menu`. PR11 removes the
+  separate `TextButton` + dialog block. The two edits are in different
+  regions of the file — small conflict surface, mechanical to resolve.
+- **Other call sites:** none. Grep confirms `regenerateInsight` is only
+  referenced from the call chain listed above.
+- **Server endpoint:** unaffected. Calling it still works for anyone with
+  basic-auth credentials and a script.

--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -514,9 +514,13 @@ shared across users and remain readable by users who later opt out).
 
 ### `POST /ai/v1/insights/invalidate`
 
-Drops the cached row for the current `(model_id, prompt_version)`. Use this
-for admin-style cache busting; users hit `regenerate` instead, which is
-budgeted. Requires opt-in. Returns `{"deleted": <int>}`.
+Drops the cached row for the current `(model_id, prompt_version)`. Used by
+the app's "Invalidate insight" action (PR6 audit UI) and by admin-style cache
+busting. After invalidation the next `lookup` regenerates naturally, which is
+the user-facing path now that the in-app "Regenerate" affordance has been
+removed (PR11). The budgeted `POST /ai/v1/insights/regenerate` endpoint
+remains available for admin/cluster tooling. Requires opt-in. Returns
+`{"deleted": <int>}`.
 
 ### `GET /ai/v1/health`
 


### PR DESCRIPTION
## Summary

Removes the in-app "Not quite right? Regenerate" affordance (button + dialog) from the book-detail screen. The server-side `POST /ai/v1/insights/regenerate` endpoint stays in place for admin/cluster tooling.

## Rationale

The regenerate flow issued `DELETE` then `POST` against the same cache key — two AI calls where one suffices, and zero added UX value:

- **Parameter changes already regenerate naturally.** Tone, language, `model_id`, and `prompt_version` are part of the cache key. Any legitimate "I want different output" case invalidates the key automatically and falls through to a fresh `lookup`.
- **"Bad answer, try again" is better served by invalidate-and-reload.** One AI call (the new `lookup`) instead of two (the `regenerate` does both).
- **PR6 makes invalidate the principled path.** PR6's "Inspect insight" overflow surfaces the existing server `invalidate` endpoint as the single in-app way to evict a cached insight.

## What was removed (Android only)

- `BookDetailScreen.kt` — `TextButton` and `RegenerateDialog`.
- `BookDetailViewModel.kt` — `fun regenerate(reason: String)`.
- `AiRepository.kt` — `regenerateInsight()`.
- `AiClient.kt` — `regenerateInsight()` method.
- `AiDtos.kt` — `InsightRegenerateBody` data class.
- `AiClientTest.kt` — `regenerateInsight sends reason` test.

## What was preserved

- **Server `POST /ai/v1/insights/regenerate`** — untouched. Still available for admin tooling and any future flow that needs forced regeneration with the existing cache key.
- **`POST /ai/v1/insights/invalidate`** + `AiRepository.invalidate()` + `AiClient.invalidateInsight()` — this is the PR6 substrate.
- **`BookInsight` payload schema** — no lineage fields touched. PR6's audit-log surface depends on them.
- **`AiConfig.regen_daily_limit`** — still relevant for admin tooling and future surfaces.

## Docs

- `docs/sync-api.md` — rewrote the `/insights/invalidate` paragraph so it no longer claims "users hit `regenerate` instead".
- `docs/superpowers/specs/2026-05-17-drop-regenerate-button-design.md` and the matching plan capture the design and execution.

## GPT verdict

Architect (read-only, sandbox=read-only) returned **APPROVE WITH NOTES**. Notes acted on:

- No missed Android call sites (full grep clean).
- Doc stale reference in `docs/sync-api.md` was the one outside the listed deletion surface — fixed in this PR.
- Keep the server endpoint (consistent with the roadmap; avoids a breaking server-contract change).

## Test plan

- [x] `scripts/dgradle :data:ai:testDebugUnitTest` — green.
- [x] `scripts/dgradle :app:testDebugUnitTest` — green.
- [x] `scripts/dgradle :app:lintDebug` — clean.
- [x] Grep across `app/` and `data/`: no remaining references to `regenerate`, `regenDialog`, or `InsightRegenerateBody`.

## Coordination note

PR6 (book-detail "Inspect insight" overflow) edits the same `BookDetailScreen.kt`. A small conflict is expected on rebase: PR11 removes the standalone `TextButton` + `RegenerateDialog` block; PR6 adds an overflow `Menu` to the `Scaffold` top bar. The two regions are distinct; resolution is mechanical.

Diff: **187 insertions / 133 deletions** across 9 files (most of the insertions are the spec + plan).