### PR TITLE
feat(server): structured themes v3 + book_themes

### DIFF
--- a/docs/superpowers/plans/2026-05-17-themes-v3.md
+++ b/docs/superpowers/plans/2026-05-17-themes-v3.md
@@ -1,0 +1,206 @@
+# Plan — Structured themes v3 + `book_themes` (PR3)
+
+**Spec:** `docs/superpowers/specs/2026-05-17-themes-v3-design.md`
+**Branch:** `feat/themes-v3`
+**Worktree:** `.claude/worktrees/pr3-themes-v3`
+**Status:** Architect-reviewed (APPROVE-WITH-CHANGES 2026-05-17); implementing.
+
+## Atomic tasks
+
+### 1. Controlled vocabulary module
+
+- New file: `server/opds_sync/core/ai/themes.py`.
+- Export `CONTROLLED_THEMES: frozenset[str]` per spec §3.3 (~57 entries). Vocab does NOT include `other` — that token is reserved for the empty-input fallback and is written at low confidence.
+- Export `VOCAB_CONFIDENCE = 1.0` and `OTHER_CONFIDENCE = 0.5` constants.
+- Export `normalize_theme(raw: str) -> tuple[str, float]`:
+  - `stripped = raw.strip().lower()`.
+  - `candidate = stripped.replace(" ", "_").replace("-", "_")`.
+  - If `candidate in CONTROLLED_THEMES`: return `(candidate, VOCAB_CONFIDENCE)`.
+  - If `not stripped`: return `("other", OTHER_CONFIDENCE)` (empty input collapses).
+  - Else: return `(stripped, OTHER_CONFIDENCE)` (raw passthrough, spaces preserved).
+
+**Verify:** add a unit test `server/tests/unit/test_themes_vocab.py` covering normalization branches AND that the literal token `"other"` from the model returns `("other", OTHER_CONFIDENCE)`.
+
+### 2. Migration `ai_004_themes`
+
+- File: `server/migrations/versions/ai_004_themes.py`.
+- `revision = "ai_004"`, `down_revision = "ai_003"`, `branch_labels = None`, `depends_on = None`.
+- Upgrade:
+  ```python
+  op.create_table(
+      "book_themes",
+      sa.Column("book_insight_id", sa.BigInteger(), nullable=False),
+      sa.Column("theme", sa.String(), nullable=False),
+      sa.Column("confidence", sa.Float(), nullable=False, server_default=sa.text("1.0")),
+      sa.PrimaryKeyConstraint("book_insight_id", "theme", name="pk_book_themes"),
+      sa.ForeignKeyConstraint(
+          ["book_insight_id"],
+          ["book_insights.id"],
+          ondelete="CASCADE",
+          name="fk_book_themes_insight",
+      ),
+  )
+  op.create_index("ix_book_themes_theme", "book_themes", ["theme"])
+  ```
+- Downgrade: drop index then table.
+- Docstring at top of the migration explains the spec link, the cascade rationale, and that the composite PK gives uniqueness for free.
+
+**Verify:**
+1. From the worktree: `cd server && uv run alembic upgrade ai@head` against a fresh testcontainers Postgres applies cleanly.
+2. `uv run alembic downgrade -1` on a fresh DB drops cleanly.
+3. `alembic heads --verbose` reports `ai_004` as the head of the `ai` branch.
+
+### 3. ORM model `BookTheme`
+
+- Add to `server/opds_sync/db/models.py` immediately after `InsightIdentityAlias`.
+- Composite primary key on `(book_insight_id, theme)` (declarative via `primary_key=True` on both columns).
+- `book_insight_id` is a `ForeignKey("book_insights.id", ondelete="CASCADE")`.
+- `confidence` is `Float`, `nullable=False`, `server_default=text("1.0")`, `default=1.0`.
+- `__table_args__` declares `Index("ix_book_themes_theme", "theme")`. The composite PK `(book_insight_id, theme)` already covers parent-delete queries (its left-most column is `book_insight_id`), so we do NOT need a separate index on `book_insight_id`. (Postgres does NOT automatically index FKs — the PK gives us the leftmost-prefix lookup for free.)
+- Block comment above the class: SHARED CACHE table, NO user_id, points to the cache-integrity invariant at top of `BookInsight`.
+
+### 4. Schema bump + RE-ADD `themes` field
+
+The architect review caught that `themes` is NOT present on the current `BookInsightPayload`; it was stripped in the v2 cleanup and `test_payload_dropped_v1_fields_rejected` actively rejects it. PR3 RE-ADDS it as a first-class output.
+
+- In `server/opds_sync/api/ai_schemas.py`:
+  - ADD `themes: list[str] | None = None` to `BookInsightPayload`, positioned BETWEEN `content_warnings` and `confidence` (so the model's generation order keeps safety tags before topic tags before the meta confidence field).
+  - `schema_version: int = 3` (was 2).
+- In `server/tests/unit/test_ai_schemas.py`:
+  - Remove `"themes"` from the `test_payload_dropped_v1_fields_rejected` for-loop.
+  - Update `test_payload_round_trip_minimal`: assert `again.schema_version == 3` (was 2).
+  - Update `test_payload_key_order_matches_reading_order`: expected list inserts `"themes"` after `"content_warnings"` and before `"confidence"`.
+
+### 5. Prompt bump
+
+- In `server/opds_sync/core/ai/prompts.py`:
+  - `PROMPT_VERSION = "4"` (was "3").
+  - Update the JSON key-order line in `SYSTEM_PROMPT` to be: `intro, author, series, analysis, content_warnings, themes, confidence`.
+  - Add a rule (after the `content_warnings` rule, before the `confidence` rule):
+    > `- "themes": pick 1-5 tags from the controlled vocabulary listed at the end of this prompt. Prefer the listed names exactly. If a clearly-applicable concept is missing, you MAY emit your own short snake_case string; the server preserves it with reduced confidence. Do NOT emit the literal string "other".`
+  - Append at the end of `SYSTEM_PROMPT`:
+    ```
+    "\n\nControlled themes vocabulary:\n" + ", ".join(sorted(CONTROLLED_THEMES))
+    ```
+- Decision: vocab list lives in the system prompt because it's identity-agnostic and lets future SDK-level prompt caching work. ~150 extra tokens against the existing ~600-token system prompt is fine.
+
+### 6. Orchestrator: pin schema_version + write theme rows on insight write
+
+- In `server/opds_sync/core/ai/service.py::_do_generate`:
+  1. RIGHT AFTER `payload = await self.ai.chat_structured(...)` succeeds (after the health-state success record), force the schema version:
+     ```python
+     # PR3: pin schema_version server-side. The model may emit 2 by mistake;
+     # the cache row must always reflect the schema we generated under.
+     payload.schema_version = 3
+     ```
+  2. After `await session.flush()` (which populates `row.id`) and BEFORE the existing `await self._log_generation(...)` call:
+     ```python
+     # PR3: persist themes as side-table rows. FK + ON DELETE CASCADE means
+     # we never need to clean these up explicitly — invalidate deletes the
+     # parent insight and Postgres drops the children. Regenerate marks the
+     # old row superseded (not deleted), so its theme rows survive for audit.
+     if payload.themes:
+         seen: set[str] = set()
+         for raw in payload.themes:
+             if not isinstance(raw, str):
+                 continue
+             normalized, conf = normalize_theme(raw)
+             if normalized in seen:
+                 continue
+             seen.add(normalized)
+             session.add(BookTheme(
+                 book_insight_id=row.id,
+                 theme=normalized,
+                 confidence=conf,
+             ))
+     ```
+- Imports `BookTheme` and `normalize_theme` go to the top of the file with the other imports.
+- The theme rows commit atomically with the insight row + alias reconciliation in the existing `await session.commit()` at the end of `_do_generate`.
+
+### 7. Cache-key audit list
+
+- In `server/tests/integration/test_cache_key_audit.py`:
+  - Import `BookTheme` from `opds_sync.db.models`.
+  - Uncomment / add the parametrize entry: `pytest.param(BookTheme, id="book_themes"),`.
+- The existing parametrized `test_shared_cache_table_has_no_tenant_columns` test now also covers `book_themes`. No new test needed.
+
+### 8. New tests
+
+All in `server/tests/integration/test_book_themes.py` (new file). Use existing fixtures (`engine`, `session`) from `conftest.py`.
+
+8a. `test_book_themes_persisted_on_generate`
+- Set up a fake AI client whose `chat_structured` returns a payload with `themes=["mystery", "noir"]`.
+- Run `orchestrator.generate(session, ident, bundle, user_id="alice")`.
+- Query `SELECT theme, confidence FROM book_themes WHERE book_insight_id = ?` — expect two rows, both confidence=1.0.
+
+8b. `test_book_themes_non_vocab_falls_to_other_confidence`
+- Fake `chat_structured` returns `themes=["dystopia", "noir western", "Cyberpunk"]`.
+- Expect rows: `("dystopia", 1.0)`, `("cyberpunk", 1.0)`, `("noir western", 0.5)`.
+
+8c. `test_book_themes_cascade_on_insight_delete`
+- Generate. Verify themes exist. `await orchestrator.invalidate(session, ident, user_id="alice")`. Verify no `book_themes` rows for that id.
+
+8d. `test_book_themes_dedup_on_model_duplicate`
+- Fake returns `themes=["Mystery", "mystery", "MYSTERY"]` → exactly one row.
+
+8e. `test_book_themes_regenerate_keeps_superseded_themes`
+- Generate (themes A). Regenerate with reason="redo" (themes B). Both insight rows live; old has `superseded_at` non-null, new has `superseded_at` IS NULL. Their `book_themes` rowsets are independent.
+
+8f. `test_old_schema_version_2_payload_deserializes`
+- Construct a raw dict `{"intro": "...", "confidence": "low", "schema_version": 2}` (no `themes` key, matching real v2 rows) and call `BookInsightPayload.model_validate(d)` → succeeds, schema_version reads back as 2, themes is None.
+- Also test that a `BookInsightPayload(...)` constructed with no args defaults `schema_version` to 3 and `themes` to None.
+
+8g. `test_book_themes_shared_cache_no_user_id`
+- Inspect `book_themes` columns via SQLAlchemy `inspect()` and assert `user_id` not in column names. (Already covered by `test_cache_key_audit.py`; this is a belt-and-braces local check inside the themes test file.)
+
+8h. `test_book_themes_literal_other_low_confidence`
+- Fake `chat_structured` returns `themes=["", "  ", "other"]` → expect a single row `(insight_id, "other", 0.5)`. Empties collapse onto the literal `"other"` sentinel via `normalize_theme`; the model emitting the literal `"other"` itself ALSO falls into the OTHER_CONFIDENCE band (because `"other"` is not in `CONTROLLED_THEMES`).
+
+8i. `test_schema_version_pinned_to_3_server_side`
+- Fake `chat_structured` returns `BookInsightPayload(confidence="low", schema_version=2)` → after `generate`, query `book_insights.payload` directly and assert `payload["schema_version"] == 3`.
+
+8j. (in `tests/unit/test_themes_vocab.py`) — unit tests for `normalize_theme`:
+- Vocab hit: `normalize_theme("mystery") == ("mystery", 1.0)`.
+- Case-insensitive vocab: `normalize_theme("Mystery") == ("mystery", 1.0)`.
+- Hyphen → underscore: `normalize_theme("coming-of-age") == ("coming_of_age", 1.0)`.
+- Space → underscore + vocab: `normalize_theme("coming of age") == ("coming_of_age", 1.0)`.
+- Free-text passthrough: `normalize_theme("interstellar politics") == ("interstellar politics", 0.5)` — spaces preserved for non-vocab passthroughs.
+- Literal `"other"` from model: `normalize_theme("other") == ("other", 0.5)` — it's not in the vocab, so it goes to the OTHER band; this keeps PR9's `WHERE confidence >= 1.0` query clean.
+- Empty input: `normalize_theme("") == ("other", 0.5)` and `normalize_theme("   ") == ("other", 0.5)`.
+- Leading/trailing whitespace: `normalize_theme("  Mystery  ") == ("mystery", 1.0)`.
+
+### 9. Update sync-api.md
+
+- Bump the `schema_version` example from `2` to `3` in the `BookInsightPayload` JSON block.
+- After the JSON block, add a short paragraph:
+  > Themes are also persisted to a side table `book_themes(book_insight_id, theme, confidence)` for queryability (PR9 library stats). The model is instructed to pick from a controlled vocabulary of ~50 entries; non-vocab strings are preserved with `confidence < 1.0` instead of being dropped.
+- In the AiStyle cache-key table, change the PROMPT_VERSION reference (if present) — grep first.
+
+### 10. Pre-commit + test loop
+
+- `cd server && uv run pre-commit run --all-files` (or `ruff check`, `ruff format`).
+- `cd server && uv run pytest -q` (full stack mode — default env vars).
+- `cd server && OPDS_SYNC_PROGRESS_ENABLED=false OPDS_SYNC_AI_ENABLED=true uv run pytest -q` (AI-only mode: progress tests skip).
+- `cd server && OPDS_SYNC_PROGRESS_ENABLED=true OPDS_SYNC_AI_ENABLED=false uv run pytest -q` (sync-only mode: AI tests skip; book_themes never gets migrated; the cache-key audit test for book_themes correctly skips via `requires_ai`).
+
+Skip the 3-mode loop only if the testcontainers cycle is prohibitively slow; minimum: full-stack mode green.
+
+### 11. Commit + push + PR
+
+- Commit message: `:sparkles: feat(server): structured themes v3 + book_themes table`.
+- NO `Co-Authored-By: Claude` trailer.
+- Push with `-u origin feat/themes-v3`.
+- `gh pr create --base main --head feat/themes-v3 --title 'feat(server): structured themes v3' --body <body>`.
+- PR body: summary, schema diagram, vocab size + first/last entries, migration revision id (`ai_004`, down_revision `ai_003`), test plan, cache-version checklist (all checked), GPT architect verdict (verbatim or synthesized), downstream notes for PR9 / PR7.
+
+## Verification checklist
+
+- [ ] `cd server && uv run alembic upgrade ai@head` from a fresh DB succeeds.
+- [ ] `cd server && uv run pytest -q tests/integration/test_book_themes.py` green.
+- [ ] `cd server && uv run pytest -q tests/integration/test_cache_key_audit.py` green (now includes `book_themes`).
+- [ ] `cd server && uv run pytest -q tests/unit/test_themes_vocab.py` green.
+- [ ] `cd server && uv run pytest -q` green (whole suite).
+- [ ] `cd server && uv run ruff check && uv run ruff format --check` clean.
+- [ ] `cd server && uv run alembic downgrade -1` on a fresh upgrade-then-downgrade cycle succeeds (migration is reversible).
+- [ ] Manually verify `payload.themes` survives a generate→get roundtrip without modification (themes are duplicated in the payload AND in the side table for v3 — payload is the source-of-truth for the client; side table is the SQL surface).
+- [ ] PR opened on GitHub against `main`.

--- a/docs/superpowers/specs/2026-05-17-themes-v3-design.md
+++ b/docs/superpowers/specs/2026-05-17-themes-v3-design.md
@@ -1,0 +1,288 @@
+# Spec — Structured themes v3 + `book_themes` (PR3)
+
+**Date:** 2026-05-17
+**Branch:** `feat/themes-v3` (from `main` after PR-A / PR-C / PR4 / PR-B / PR5 / PR1 / PR2 all merged)
+**Roadmap reference:** `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §PR3
+**Status:** Architect-reviewed (APPROVE-WITH-CHANGES, 2026-05-17); incorporating findings.
+
+## 1. Motivation
+
+`BookInsightPayload.themes` does NOT exist on the current `main` (it was removed in the schema v2 cleanup; `test_payload_dropped_v1_fields_rejected` actively rejects payloads carrying a `themes` key). PR3 RE-INTRODUCES `themes` as a first-class structured output rooted in a controlled vocabulary, and at the same time normalizes it into a side table.
+
+Previously (pre-v2) the field existed as an unconstrained `list[str] | None`. The problems it had then were:
+
+- **Free-text.** The model emits whatever genre/topic phrases it likes (`"dystopia"`, `"a dystopian future"`, `"dystopia and surveillance"`). No vocabulary, no normalization, so aggregation across books is impossible.
+- **Buried.** Themes live inside the JSON payload only; there is no SQL-queryable surface. `top_themes` for PR9 library stats can't be expressed without scanning every payload row in Python.
+- **Tone-conflated.** Because themes live in the per-(tone, language) cache row, the same book ends up with subtly different theme lists under each style. There's no canonical "what is this book about" anchored to the identity.
+
+PR3 splits themes off the payload into a normalized side table `book_themes(book_insight_id, theme, confidence)`, hanging off `book_insights.id` (not raw identity). This:
+
+- Lets PR9 (`/library/v1/stats` top_themes) query `book_themes` directly with a `GROUP BY theme`.
+- Lets the model output a controlled vocabulary so cross-book aggregation is meaningful.
+- Preserves the "free-text raw value" escape hatch via an `other` bucket with `confidence < 1.0` — non-vocab themes still get persisted, just with lower confidence, so vocab evolution doesn't lose data.
+- Stays per-cache-row (FK to `book_insights.id`) so tone/language/model variants stay independently queryable. Different tones for the same book produce different theme rows; PR9's `top_themes` query can either dedup by `(metadata_id, content_hash, theme)` later, or just count rows — both are valid v0 choices.
+
+## 2. Identity hierarchy (unchanged)
+
+PR3 introduces no new identity surface. The FK to `book_insights.id` inherits whatever canonical/alias resolution PR2 produces upstream.
+
+## 3. Server changes
+
+### 3.1 Migration `ai_004_themes`
+
+Fourth migration on the `ai` branch. Per `server/migrations/README.md`:
+
+```python
+revision = "ai_004"
+down_revision = "ai_003"
+branch_labels = None     # PR-C owns the "ai" label on ai_001
+depends_on = None
+```
+
+Upgrade creates the table:
+
+```sql
+CREATE TABLE book_themes (
+    book_insight_id  bigint   NOT NULL,
+    theme            text     NOT NULL,
+    confidence       real     NOT NULL DEFAULT 1.0,
+
+    PRIMARY KEY (book_insight_id, theme),
+    FOREIGN KEY (book_insight_id) REFERENCES book_insights(id) ON DELETE CASCADE
+);
+
+CREATE INDEX ix_book_themes_theme ON book_themes (theme);
+```
+
+The PK is composite `(book_insight_id, theme)` — one row per (insight, theme) pair, no duplicates. The single-column `theme` index covers PR9's `GROUP BY theme` / `WHERE theme = ?` query paths without a join (the FK is already an implicit index in Postgres).
+
+`ON DELETE CASCADE` means invalidating an insight automatically drops its theme rows. The orchestrator's existing `invalidate` does a bare `DELETE FROM book_insights`; the FK cascade picks up the side table for free.
+
+Downgrade drops the index and the table.
+
+### 3.2 ORM model `BookTheme`
+
+In `server/opds_sync/db/models.py`:
+
+```python
+class BookTheme(Base):
+    __tablename__ = "book_themes"
+    __table_args__ = (
+        Index("ix_book_themes_theme", "theme"),
+    )
+
+    book_insight_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("book_insights.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    theme: Mapped[str] = mapped_column(String, primary_key=True)
+    confidence: Mapped[float] = mapped_column(
+        Float, nullable=False, server_default=text("1.0"), default=1.0
+    )
+```
+
+Block comment immediately above the class points to the cache-integrity invariant: `book_themes` is SHARED cache (no `user_id`), per the same rule as `book_insights`.
+
+### 3.3 Controlled vocabulary `opds_sync/core/ai/themes.py`
+
+Per architect feedback (2026-05-17), the vocabulary expands to cover broad library-shelf buckets (`science_fiction`, `fantasy`, `young_adult`, `middle_grade`, `poetry`, `drama`, `short_stories`, `graphic_novel`, `western`, `contemporary_fiction`, `crime`, `health`) and merges `science` + `popular_science` to avoid hairline splits. `other` is REMOVED from the model-visible vocab — non-vocab passthroughs still go to the side table at confidence 0.5, but the model is never instructed to emit the literal token `"other"` (which would otherwise pollute PR9's controlled-vocab top-N query). The full list lives in code; the count target is ~55 entries.
+
+New module exports:
+
+```python
+CONTROLLED_THEMES: frozenset[str] = frozenset({
+    # Fiction — broad buckets
+    "science_fiction", "fantasy", "literary_fiction", "contemporary_fiction",
+    "historical_fiction", "young_adult", "middle_grade", "children",
+    "poetry", "drama", "short_stories", "graphic_novel",
+    # Fiction — speculative subgenres
+    "dystopia", "post_apocalyptic", "cyberpunk", "space_opera",
+    "first_contact", "time_travel", "alternate_history", "magical_realism",
+    "epic_fantasy", "urban_fantasy", "mythology", "superheroes",
+    # Fiction — genre
+    "mystery", "thriller", "noir", "horror", "romance", "crime",
+    "coming_of_age", "war_fiction", "adventure", "satire", "western",
+    # Nonfiction
+    "biography", "memoir", "history", "science", "philosophy",
+    "essays", "journalism", "business", "economics", "psychology",
+    "self_help", "travel", "cooking", "politics", "religion",
+    "true_crime", "nature", "art", "music", "sports", "education",
+    "technology", "medicine", "health",
+})  # ~57 entries; deliberately no `other` sentinel.
+
+VOCAB_CONFIDENCE = 1.0
+OTHER_CONFIDENCE = 0.5
+
+
+def normalize_theme(raw: str) -> tuple[str, float]:
+    """Map a raw model-emitted theme to (canonical_theme, confidence).
+
+    Rules:
+      - Strip whitespace; lowercase.
+      - Compute a candidate by additionally replacing spaces/hyphens with
+        underscores.
+      - If the candidate is in CONTROLLED_THEMES, return
+        (candidate, VOCAB_CONFIDENCE).
+      - If the raw input (post-strip) is empty, return
+        ("other", OTHER_CONFIDENCE).
+      - Otherwise return (lowercased_stripped, OTHER_CONFIDENCE) —
+        preserving spaces so the human-readable raw token survives the
+        round trip.
+
+    The literal token `"other"` is reserved for empty/null inputs and is
+    written at 0.5 confidence so it falls out of PR9's `WHERE confidence
+    >= 1.0` controlled-vocab queries cleanly. Real raw passthroughs (like
+    `"noir western"`) survive in the index at 0.5 confidence with their
+    spaces intact.
+    """
+```
+
+Decision (locked):
+- Confidence is a NORMALIZATION BAND, not epistemic confidence. `1.0` means "the model picked a vocab term"; `0.5` means "the model emitted something off-vocab and we preserved it".
+- Literal `"other"` exists ONLY as the empty-input fallback at 0.5 confidence. The model never sees `"other"` in the vocab list, so it has no reason to emit it.
+- Raw passthroughs keep their spaces (`"noir western"`) rather than collapsing onto the `"other"` sentinel — strictly more information, and PR9 filters by confidence band anyway.
+
+### 3.4 Re-introduce `themes` and bump `BookInsightPayload.schema_version` to 3
+
+In `opds_sync/api/ai_schemas.py`:
+
+- ADD `themes: list[str] | None = None` to `BookInsightPayload` (the field does not exist on the current `main`; it was stripped in the schema v2 cleanup and `test_payload_dropped_v1_fields_rejected` actively rejects it as a stale v1 field).
+- Update `test_payload_dropped_v1_fields_rejected` to remove `themes` from the rejected-fields list.
+- Update `test_payload_key_order_matches_reading_order` to include `themes` immediately after `content_warnings` (themes are reader-facing topic tags, naturally grouped with safety tags in the reading order).
+- `schema_version: int = 3` (was 2).
+- Old (cached) v2 payloads deserialize cleanly because v2 had no `themes` (the field defaults to `None`) and `extra="forbid"` does not catch missing fields.
+- IMPORTANT (per architect feedback): `_do_generate` MUST force `payload.schema_version = 3` after the model returns, before `model_dump()`. The schema has `schema_version: int = 3` as the default, but the model can still produce `2` by mistake — we don't want pre-bumped values winning by accident. This is a server-side normalization; the model's free choice of `schema_version` is irrelevant.
+
+### 3.5 Bump `PROMPT_VERSION` to "4"
+
+In `opds_sync/core/ai/prompts.py`:
+
+- `PROMPT_VERSION = "4"` (was "3").
+- Prompt body gets a new section under "Rules":
+  - `- "themes": pick 1-5 tags from the controlled vocabulary below. If a clearly-applicable concept is missing from the vocab, you may emit your own short snake_case string; the server will preserve it with reduced confidence."`
+  - The vocab list is inlined as a comma-separated string for the model. (~50 strings = ~150 tokens; negligible against the prompt body.)
+
+Existing cache rows at `prompt_version="3"` are not deleted; they simply stop being returned because every new lookup runs at version "4". Old rows are still queryable by audit tooling. No backfill in this PR.
+
+### 3.6 Orchestrator: write `book_themes` rows on insight write
+
+In `service.py::_do_generate`, after `payload = await self.ai.chat_structured(...)` and BEFORE `session.add(row)`, force the schema version:
+
+```python
+# PR3: server-side schema_version pin. The model may emit `2` by mistake;
+# the cache row must always reflect the server-side schema we generated under.
+payload.schema_version = 3
+```
+
+After `session.add(row)` and `session.flush()` (which populates `row.id`) and BEFORE `await self._log_generation(...)`:
+
+```python
+# PR3: persist themes as side-table rows. The FK + ON DELETE CASCADE means we
+# never need to clean these up explicitly — invalidate deletes the parent
+# insight and Postgres drops the children. Regenerate marks the old row as
+# superseded (not deleted), so its theme rows survive for audit alongside the
+# new row's themes.
+if payload.themes:
+    seen: set[str] = set()
+    for raw in payload.themes:
+        if not isinstance(raw, str):
+            continue
+        normalized, conf = normalize_theme(raw)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        session.add(BookTheme(
+            book_insight_id=row.id,
+            theme=normalized,
+            confidence=conf,
+        ))
+```
+
+The `seen` set guards against the model emitting duplicates (`["mystery", "Mystery"]` → both normalize to `mystery`). The PK constraint would catch this too, but explicit dedup avoids integrity-error rollbacks for model quirks.
+
+`regenerate` reuses `_do_generate`: the old live row is marked `superseded_at` (not deleted), so its `book_themes` children survive for audit history. The new live row gets its own fresh theme set. PR9 (top_themes) MUST filter for `superseded_at IS NULL` on the join to avoid double-counting regenerated insights.
+
+### 3.7 Cache-key audit: add `BookTheme` to SHARED list
+
+In `server/tests/integration/test_cache_key_audit.py`:
+
+```python
+SHARED_CACHE_TABLES = [
+    pytest.param(BookInsight, id="book_insights"),
+    pytest.param(ExternalSourceCacheEntry, id="external_source_cache"),
+    pytest.param(BookTheme, id="book_themes"),  # PR3
+]
+```
+
+`book_themes` carries no `user_id` / `tenant_id` / `subject` / `principal_id`. The existing parametrized test covers it without other changes.
+
+### 3.8 Docs
+
+- `docs/sync-api.md` AiStyle table footnote: bump `PROMPT_VERSION` to `"4"`, bump `schema_version` example to `3`, mention the controlled vocab. Add a short note explaining that themes now also live in `book_themes`.
+
+## 4. Cache-version checklist
+
+- [x] `PROMPT_VERSION` → `"4"`.
+- [x] `BookInsightPayload.schema_version` → `3` (payload shape changed: `themes: list[str] | None` ADDED back as a first-class output — it did not exist in v2).
+- [x] `_do_generate` pins `payload.schema_version = 3` server-side after model return.
+- [x] `book_insights` unique indexes unchanged (themes go to a side table, not new cache-key dimensions).
+- [x] Lock key in `service.py` unchanged (no new cache-key dimension).
+- [x] Android `:data:ai` DTOs already handle `themes: List<String>?`; no change.
+- [x] Invalidate-by-cache-key still works: FK cascade deletes side rows automatically.
+- [x] Tests cover: new insight populates `book_themes`; non-vocab → `other` confidence band; cascade on delete; old v2 cache rows still deserialize; PR4-prompt-version-3 rows survive coexistence with v4 rows.
+- [x] Docs: `docs/sync-api.md` updated.
+
+## 5. Test plan
+
+All under `server/tests/integration/`.
+
+1. **`test_book_themes_persisted_on_generate`** — `generate(...)` for a fresh identity → assert one `BookTheme` row per payload theme, all with `confidence==1.0` (assuming vocab themes).
+2. **`test_book_themes_non_vocab_falls_to_other_confidence`** — fake `chat_structured` returns themes `["dystopia", "noir western", "Cyberpunk"]` → rows `dystopia` (1.0), `cyberpunk` (1.0, normalized), `noir western` (0.5).
+3. **`test_book_themes_cascade_on_insight_delete`** — generate → invalidate → assert no `BookTheme` rows survive (FK cascade).
+4. **`test_book_themes_cascade_on_regenerate_supersede`** — generate (5 themes), regenerate (3 different themes) → superseded row keeps its themes, new live row has the new themes; both row sets coexist because the original is superseded-not-deleted.
+5. **`test_book_themes_dedup_on_model_duplicate`** — model returns `["mystery", "Mystery", "MYSTERY"]` → exactly one row `(insight_id, "mystery", 1.0)`.
+6. **`test_old_prompt_version_3_rows_still_queryable`** — seed a row at `prompt_version="3"` with NO `book_themes` children → row remains readable by direct SQL (it's just not returned to clients whose lookup is at `prompt_version="4"`).
+7. **`test_old_schema_version_2_payload_deserializes`** — load a v2 payload (no `themes` field) into `BookInsightPayload.model_validate(...)` → succeeds; `themes` defaults to None; schema_version reads back as 2.
+8. **`test_book_themes_literal_other_low_confidence`** — fake model returns `themes=["", "  ", "other"]` → expect rows for `("other", 0.5)` only (empties collapse to literal "other"). Literal `"other"` from the model is NOT confidence-1.0; it survives at 0.5.
+9. **`test_schema_version_pinned_to_3_server_side`** — fake model returns a payload with `schema_version=2` → persisted row has `payload["schema_version"] == 3`.
+10. **Existing `test_cache_key_audit.py`** runs against `BookTheme` parametrize entry → green.
+
+Mode matrix:
+- `requires_ai` markers on all new tests → run in full-stack and AI-only modes, skip in sync-only mode (no AI tables migrated).
+
+## 6. Non-goals
+
+- **No backfill.** Pre-existing `book_insights` rows do NOT retroactively get `book_themes` populated. Their `payload.themes` (if any) stays inside the payload; PR9 stats will report 0 themes for them. A separate optional follow-up PR can backfill if it turns out users care.
+- **No `raw_string` column.** Spec explicitly says confidence band only. The raw string IS the `theme` column value for non-vocab entries.
+- **No Android changes.** The Android `:data:ai` layer already deserializes `themes: List<String>?`; the controlled vocab is server-internal.
+- **No PR9 work.** Library stats top_themes is a separate PR; PR3 just makes the SQL surface available.
+- **No vocabulary versioning column.** If the vocab evolves, old rows under the old vocab stay valid (they're just snake_case strings). A `vocab_version` column would be over-engineering for v0.
+
+## 7. Risks & mitigations
+
+- **Vocabulary lock-in.** Once `book_themes.theme` rows accumulate, renaming a vocab entry (e.g. `science_fiction` → `sf`) requires a data migration. Mitigation: pick names carefully now; if a rename happens later, it's a short follow-up migration. Document the vocab in `themes.py` with comments so renames are deliberate.
+- **`other` cardinality explosion.** If the model emits 10 distinct free-text strings per book, the `theme` index could bloat. Mitigation: low-confidence rows still cost only ~30 bytes apiece; ~10k books * 5 rows = 50k rows, trivial for Postgres. If it becomes a problem, a follow-up can collapse all `confidence < 1.0` rows into a single literal `"other"` row.
+- **Schema_version semantics (resolved).** PR3 actually ADDS the `themes` field (it does not exist on the current `main`; v2's payload had no themes). So this is a real shape change, not just a semantic one. Bumping to 3 is justified. `_do_generate` pins `payload.schema_version = 3` server-side after model return so cache rows can never be poisoned by a model emitting `2`.
+
+## 8. Downstream notes
+
+- **PR9 (library stats v0):** queries `book_themes` joined to `book_insights` filtered on the user's library items. Per architect feedback the query MUST filter `book_insights.superseded_at IS NULL` to avoid double-counting regenerated insights, AND should dedup per (book, theme) so a book with two tone variants doesn't count its themes twice. Suggested shape:
+  ```sql
+  SELECT theme, COUNT(DISTINCT li.pk) AS book_count
+  FROM book_themes bt
+  JOIN book_insights bi ON bi.id = bt.book_insight_id
+  JOIN library_items  li ON (
+        (bi.metadata_id  IS NOT NULL AND li.metadata_id  = bi.metadata_id)
+     OR (bi.content_hash IS NOT NULL AND li.content_hash = bi.content_hash))
+  WHERE li.user_id = :uid
+    AND li.deleted_at IS NULL
+    AND bi.superseded_at IS NULL
+    AND bt.confidence >= 1.0
+  GROUP BY theme
+  ORDER BY book_count DESC
+  LIMIT 10;
+  ```
+  Confidence-band filter (`>= 1.0`) restricts to controlled-vocab themes; PR9 can choose to also include lower-confidence raw passthroughs in a "raw themes" section if desired.
+- **PR7 (catalog detail screen):** no impact. Themes show up in `payload.themes` exactly as before, just now drawn from a controlled vocab. The pre-download catalog-preview flow generates an insight under a synthetic content_hash; that insight's `book_themes` children live alongside the post-download convergence.
+- **F-Droid posture:** untouched. Server-only PR.

--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -459,7 +459,7 @@ Response: a `BookInsight` with `payload`, `sources`, `model_id`,
 `prompt_version`, `generated_at`. See `opds_sync/api/ai_schemas.py` for
 the full payload schema.
 
-`payload` is the structured `BookInsightPayload` (schema v2, the model
+`payload` is the structured `BookInsightPayload` (schema v3, the model
 generates keys in this order):
 
 ```json
@@ -476,14 +476,46 @@ generates keys in this order):
   },
   "analysis": "One compact paragraph (~80–130 words) weaving synopsis, themes, tone, and reader fit.",
   "content_warnings": ["graphic violence", "sexual content"],
+  "themes": ["science_fiction", "epic"],
   "confidence": "high|medium|low",
-  "schema_version": 2
+  "schema_version": 3
 }
 ```
 
 `content_warnings` is scoped to concrete reader-safety concerns
 (violence, sexual content, abuse, self-harm, slurs, addiction, body horror) —
 **not** themes, genre, politics, or plot mechanics.
+
+`themes` (PR3, schema v3) is a list of 1-5 topic tags drawn from a controlled
+vocabulary (~57 entries — see `opds_sync/core/ai/themes.py::CONTROLLED_THEMES`,
+covering broad fiction buckets, speculative subgenres, genre fiction, and
+nonfiction categories). Vocab hits land in the side table `book_themes` at
+`confidence=1.0`; off-vocab strings are preserved verbatim at `confidence=0.5`
+so future vocabulary evolution doesn't lose data. The payload field is the
+source of truth for the client; `book_themes` is the SQL-queryable mirror
+that PR9 library stats reads. Old cached v2 payloads (no `themes` key)
+deserialize cleanly with `themes=null`; they contribute zero rows to
+`book_themes` until regenerated. The server pins `schema_version=3` after
+model return so cache rows never reflect a model's accidental version
+emission.
+
+Side-table schema:
+
+```sql
+CREATE TABLE book_themes (
+    book_insight_id  bigint  NOT NULL REFERENCES book_insights(id) ON DELETE CASCADE,
+    theme            text    NOT NULL,
+    confidence       real    NOT NULL DEFAULT 1.0,
+    PRIMARY KEY (book_insight_id, theme)
+);
+CREATE INDEX ix_book_themes_theme ON book_themes (theme);
+```
+
+`book_themes` is SHARED cache (no `user_id`/`tenant_id`); per-user filtering
+in PR9 happens by joining through `book_insights → library_items` on
+`metadata_id`/`content_hash`. PR9 MUST also filter
+`book_insights.superseded_at IS NULL` to avoid double-counting regenerated
+insights.
 
 ### `POST /ai/v1/insights/regenerate`
 

--- a/server/migrations/versions/ai_004_themes.py
+++ b/server/migrations/versions/ai_004_themes.py
@@ -1,0 +1,63 @@
+"""ai_004_themes: book_themes side table (PR3).
+
+Fourth migration on the `ai` branch. PR-C's `ai_001` owns the
+`branch_labels=("ai",)` claim; this revision sets `branch_labels = None`
+and chains off `ai_003` (the identity-aliases migration).
+
+Schema:
+- `book_themes(book_insight_id, theme, confidence)` with composite PK
+  `(book_insight_id, theme)` and a single-column `theme` index for PR9-style
+  GROUP BY queries. FK to `book_insights.id` with `ON DELETE CASCADE` so
+  invalidating an insight automatically drops its theme rows (regenerate
+  is a supersede-not-delete, so superseded rows KEEP their theme history
+  for audit; PR9 must filter `superseded_at IS NULL` on the join).
+
+The composite PK gives us free index coverage for parent-delete cascades
+(its leftmost column is `book_insight_id`), so no extra FK-side index is
+needed. The `theme` index covers the PR9 `WHERE theme = ?` / `GROUP BY
+theme` query paths.
+
+Cache-integrity invariant (see comment on BookInsight model): SHARED CACHE,
+no `user_id` / `tenant_id`. Per-tenant audit lives in `ai_generation_log`.
+
+Reference: docs/superpowers/specs/2026-05-17-themes-v3-design.md
+
+Revision ID: ai_004
+Revises: ai_003
+Create Date: 2026-05-17 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_004"
+down_revision = "ai_003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "book_themes",
+        sa.Column("book_insight_id", sa.BigInteger(), nullable=False),
+        sa.Column("theme", sa.String(), nullable=False),
+        sa.Column(
+            "confidence",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("1.0"),
+        ),
+        sa.PrimaryKeyConstraint("book_insight_id", "theme", name="pk_book_themes"),
+        sa.ForeignKeyConstraint(
+            ["book_insight_id"],
+            ["book_insights.id"],
+            ondelete="CASCADE",
+            name="fk_book_themes_insight",
+        ),
+    )
+    op.create_index("ix_book_themes_theme", "book_themes", ["theme"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_book_themes_theme", table_name="book_themes")
+    op.drop_table("book_themes")

--- a/server/opds_sync/api/ai_schemas.py
+++ b/server/opds_sync/api/ai_schemas.py
@@ -285,6 +285,13 @@ class BookInsightPayload(BaseModel):
     Field order is the reading order for BookDetailScreen — the model is
     instructed to generate keys in declared order, which keeps the streaming
     narrative coherent (intro before analysis, etc.).
+
+    `themes` (PR3, schema v3): controlled-vocabulary topic tags. The model
+    is instructed to pick from `opds_sync.core.ai.themes.CONTROLLED_THEMES`;
+    off-vocab strings are preserved verbatim and surface in `book_themes`
+    at confidence 0.5. The payload field is the source of truth for the
+    client; `book_themes` is the SQL-queryable mirror for aggregate stats.
+    Old v2 payloads (no `themes` key) deserialize cleanly with themes=None.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -294,8 +301,9 @@ class BookInsightPayload(BaseModel):
     series: SeriesInsight | None = None
     analysis: str | None = None
     content_warnings: list[str] | None = None
+    themes: list[str] | None = None
     confidence: Literal["high", "medium", "low"] = "low"
-    schema_version: int = 2
+    schema_version: int = 3
 
 
 class BookInsightResponse(BaseModel):

--- a/server/opds_sync/core/ai/prompts.py
+++ b/server/opds_sync/core/ai/prompts.py
@@ -8,8 +8,9 @@ output. Do NOT bump it for typo fixes or whitespace.
 from __future__ import annotations
 
 from opds_sync.api.ai_schemas import AiStyle, Citation, MetadataBundle
+from opds_sync.core.ai.themes import CONTROLLED_THEMES
 
-PROMPT_VERSION = "3"
+PROMPT_VERSION = "4"
 
 # `tone` and `language` (from AiStyle) participate in the cache key via the
 # `book_insights.tone` and `book_insights.language` columns, so emitting
@@ -18,11 +19,17 @@ PROMPT_VERSION = "3"
 # /insights/regenerate that produces a new row marked superseded against the
 # previous one.
 
+# Controlled themes vocabulary appended to SYSTEM_PROMPT so the model can
+# pick from it. Sorted for prompt stability across Python runs (frozenset
+# iteration order is otherwise hash-seed-dependent — would silently churn
+# every PROMPT_VERSION otherwise).
+_THEMES_VOCAB_BLOCK = "Controlled themes vocabulary:\n" + ", ".join(sorted(CONTROLLED_THEMES))
+
 SYSTEM_PROMPT = (
     "You write cached, user-agnostic book insights for Quire, a privacy-first reading app.\n"
     "\n"
     "JSON key order matters. Generate keys in this order: intro, author, series, analysis,"
-    " content_warnings, confidence.\n"
+    " content_warnings, themes, confidence.\n"
     "\n"
     "Rules:\n"
     "- Use the supplied EPUB metadata as the work's identity. If metadata names a series,"
@@ -40,11 +47,16 @@ SYSTEM_PROMPT = (
     "- `content_warnings`: only concrete reader-safety concerns — graphic violence, sexual"
     " content, abuse, self-harm, racism or slurs, addiction, body horror. Do NOT list themes,"
     " genre, politics, or plot mechanics here.\n"
+    "- `themes`: pick 1-5 tags from the controlled vocabulary listed at the end of this prompt."
+    " Prefer the listed names exactly. If a clearly-applicable concept is missing, you MAY emit"
+    " your own short snake_case string; the server preserves it with reduced confidence. Do NOT"
+    ' emit the literal string "other".\n'
     '- `confidence`: "high" only when at least one external citation grounds the central'
     ' book claims; "medium" when metadata plus reliable training knowledge is enough;'
     ' "low" otherwise.\n'
     "- Output strict JSON conforming exactly to the supplied JSON schema. No prose, no"
-    " markdown, no code fences."
+    " markdown, no code fences.\n"
+    "\n" + _THEMES_VOCAB_BLOCK
 )
 
 

--- a/server/opds_sync/core/ai/service.py
+++ b/server/opds_sync/core/ai/service.py
@@ -43,8 +43,9 @@ from opds_sync.core.ai.identity import (
     resolve_identity,
 )
 from opds_sync.core.ai.prompts import SYSTEM_PROMPT, compose_user_prompt
+from opds_sync.core.ai.themes import normalize_theme
 from opds_sync.core.logging_ctx import request_id_var
-from opds_sync.db.models import AIGenerationLog, AIUsageDaily, BookInsight
+from opds_sync.db.models import AIGenerationLog, AIUsageDaily, BookInsight, BookTheme
 
 logger = logging.getLogger(__name__)
 
@@ -418,6 +419,11 @@ class InsightOrchestrator:
             # PR5: chat_structured succeeded → provider is reachable now.
             if self._health is not None:
                 await self._health.record_provider_success(model_id=self.model_id)
+            # PR3: pin schema_version server-side. The model may emit `2` by
+            # mistake (or copy it from cached examples); the cache row must
+            # always reflect the schema we generated under, not whatever the
+            # model guessed.
+            payload.schema_version = 3
             latency_ms = int((time.monotonic() - t0) * 1000)
             logger.info(
                 "ai.generate content_hash=%s model=%s latency_ms=%d sources=%s regen=%s",
@@ -466,6 +472,31 @@ class InsightOrchestrator:
         )
         session.add(row)
         await session.flush()  # populate row.id before logging
+
+        # PR3: persist themes as side-table rows. FK + ON DELETE CASCADE means
+        # invalidate (DELETE on the parent) drops these for free. Regenerate is
+        # supersede-not-delete, so old theme rows survive for audit alongside
+        # the new row's themes; PR9's top_themes query must filter
+        # `book_insights.superseded_at IS NULL` on the join to avoid double-
+        # counting. Dedup via `seen` so model quirks like ["mystery", "Mystery"]
+        # don't trip the composite PK constraint with an IntegrityError.
+        if payload.themes:
+            seen: set[str] = set()
+            for raw in payload.themes:
+                if not isinstance(raw, str):
+                    continue
+                normalized, conf = normalize_theme(raw)
+                if normalized in seen:
+                    continue
+                seen.add(normalized)
+                session.add(
+                    BookTheme(
+                        book_insight_id=row.id,
+                        theme=normalized,
+                        confidence=conf,
+                    )
+                )
+
         await self._log_generation(
             session,
             book_insight_id=row.id,

--- a/server/opds_sync/core/ai/themes.py
+++ b/server/opds_sync/core/ai/themes.py
@@ -1,0 +1,122 @@
+"""Controlled vocabulary for `BookInsightPayload.themes` (PR3).
+
+The model is instructed (via PROMPT_VERSION="4") to pick 1-5 tags from the
+vocabulary below. Vocab hits are normalized snake_case and persisted to
+`book_themes` at confidence 1.0. Off-vocab strings are preserved verbatim
+(after lowercase/trim) at confidence 0.5 so PR9-style aggregation can
+either include or exclude them via the confidence band.
+
+Confidence here is a NORMALIZATION BAND, not epistemic certainty:
+  * 1.0 = "the model picked a controlled vocab term"
+  * 0.5 = "off-vocab raw passthrough (or empty input fallback)"
+
+The literal token "other" is NOT in the vocab (the model never sees it),
+so any "other" rows in `book_themes` come exclusively from the empty-input
+fallback or from a model deliberately ignoring the instruction. In both
+cases they land at 0.5 confidence — PR9's `WHERE confidence >= 1.0`
+top-themes query filters them out cleanly.
+
+Renames cost data migration: if a vocab entry is renamed later, an
+Alembic data migration must UPDATE existing `book_themes.theme` rows.
+Pick names carefully here.
+"""
+
+from __future__ import annotations
+
+CONTROLLED_THEMES: frozenset[str] = frozenset(
+    {
+        # Fiction — broad buckets
+        "science_fiction",
+        "fantasy",
+        "literary_fiction",
+        "contemporary_fiction",
+        "historical_fiction",
+        "young_adult",
+        "middle_grade",
+        "children",
+        "poetry",
+        "drama",
+        "short_stories",
+        "graphic_novel",
+        # Fiction — speculative subgenres
+        "dystopia",
+        "post_apocalyptic",
+        "cyberpunk",
+        "space_opera",
+        "first_contact",
+        "time_travel",
+        "alternate_history",
+        "magical_realism",
+        "epic_fantasy",
+        "urban_fantasy",
+        "mythology",
+        "superheroes",
+        # Fiction — genre
+        "mystery",
+        "thriller",
+        "noir",
+        "horror",
+        "romance",
+        "crime",
+        "coming_of_age",
+        "war_fiction",
+        "adventure",
+        "satire",
+        "western",
+        # Nonfiction
+        "biography",
+        "memoir",
+        "history",
+        "science",
+        "philosophy",
+        "essays",
+        "journalism",
+        "business",
+        "economics",
+        "psychology",
+        "self_help",
+        "travel",
+        "cooking",
+        "politics",
+        "religion",
+        "true_crime",
+        "nature",
+        "art",
+        "music",
+        "sports",
+        "education",
+        "technology",
+        "medicine",
+        "health",
+    }
+)
+
+VOCAB_CONFIDENCE: float = 1.0
+OTHER_CONFIDENCE: float = 0.5
+
+
+def normalize_theme(raw: str) -> tuple[str, float]:
+    """Map a model-emitted theme string to (canonical_theme, confidence).
+
+    Algorithm:
+      1. `stripped = raw.strip().lower()`.
+      2. `candidate = stripped.replace(" ", "_").replace("-", "_")`.
+      3. If `candidate in CONTROLLED_THEMES`: return (candidate, 1.0).
+      4. If `not stripped` (empty after strip): return ("other", 0.5).
+      5. Otherwise: return (stripped, 0.5) — passthrough with spaces preserved.
+
+    Examples:
+      `"Mystery"`          -> `("mystery", 1.0)`
+      `"coming-of-age"`    -> `("coming_of_age", 1.0)`
+      `"coming of age"`    -> `("coming_of_age", 1.0)`
+      `"interstellar war"` -> `("interstellar war", 0.5)` (off-vocab passthrough)
+      `"other"`            -> `("other", 0.5)` (model ignored the instruction; lands in OTHER band)
+      `""`                 -> `("other", 0.5)` (empty fallback)
+    """
+    stripped = raw.strip().lower()
+    candidate = stripped.replace(" ", "_").replace("-", "_")
+    if candidate in CONTROLLED_THEMES:
+        return candidate, VOCAB_CONFIDENCE
+    if not stripped:
+        return "other", OTHER_CONFIDENCE
+    return stripped, OTHER_CONFIDENCE

--- a/server/opds_sync/db/models.py
+++ b/server/opds_sync/db/models.py
@@ -314,3 +314,43 @@ class LibraryItem(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+# ============================================================================
+# `book_themes` (PR3, 2026-05-17) — `ai` branch.
+# ----------------------------------------------------------------------------
+# SHARED CACHE side-table for `book_insights`. Per the cache-integrity
+# invariant (see the BookInsight block comment): NO `user_id`, NO
+# `tenant_id`, NO `subject`. Per-tenant audit lives in
+# `ai_generation_log`; per-user library filtering happens via the join to
+# `library_items` in PR9.
+#
+# Cascade: `ON DELETE CASCADE` on the FK to `book_insights.id` means
+# `invalidate` (which DELETEs the parent) drops the children for free.
+# `regenerate` is supersede-not-delete, so old theme rows survive for
+# audit history alongside the new live row's themes. PR9 MUST filter
+# `book_insights.superseded_at IS NULL` on the join to avoid
+# double-counting regenerated insights.
+#
+# Composite PK `(book_insight_id, theme)`: one row per (insight, theme)
+# pair, no duplicates. The PK's leftmost column covers the FK cascade
+# lookup, so we do NOT need a separate index on `book_insight_id`. The
+# `theme` index covers PR9-style `GROUP BY theme` queries.
+#
+# Confidence band semantics (see opds_sync.core.ai.themes.normalize_theme):
+#   * 1.0 — the model picked a controlled-vocab term
+#   * 0.5 — off-vocab raw passthrough (or empty-input fallback to "other")
+# ============================================================================
+class BookTheme(Base):
+    __tablename__ = "book_themes"
+    __table_args__ = (Index("ix_book_themes_theme", "theme"),)
+
+    book_insight_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("book_insights.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    theme: Mapped[str] = mapped_column(String, primary_key=True)
+    confidence: Mapped[float] = mapped_column(
+        Float, nullable=False, server_default=text("1.0"), default=1.0
+    )

--- a/server/tests/integration/test_book_themes.py
+++ b/server/tests/integration/test_book_themes.py
@@ -1,0 +1,300 @@
+"""Integration tests for `book_themes` side-table writes + cascade (PR3).
+
+Covers:
+- Vocab and off-vocab themes persist with correct confidence bands.
+- Empty / literal-"other" inputs fold into the OTHER band.
+- Model duplicates dedup before hitting the composite PK.
+- Cascade-on-delete drops theme rows when the insight is invalidated.
+- Regenerate is supersede-not-delete: old theme rows survive.
+- `_do_generate` pins `schema_version=3` server-side over whatever the
+  model returned.
+- Cache-key audit (no `user_id`) at the table inspection level.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy import inspect, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from opds_sync.api.ai_schemas import DocumentIdentity, MetadataBundle
+from opds_sync.core.ai.service import InsightOrchestrator
+from opds_sync.db.models import BookInsight, BookTheme
+
+
+class _FakeAIClient:
+    """Returns a configurable themes payload on each `chat_structured` call."""
+
+    def __init__(self, themes: list[str] | None = None, schema_version: int = 3) -> None:
+        self.calls: list[dict] = []
+        self.themes = themes
+        self.schema_version = schema_version
+
+    async def chat_structured(self, *, system, user, schema, timeout_s):
+        self.calls.append({"system": system, "user": user})
+        return schema.model_validate(
+            {
+                "schema_version": self.schema_version,
+                "intro": "Fake insight for themes test.",
+                "confidence": "high",
+                "themes": self.themes,
+            }
+        )
+
+
+class _FakeRetriever:
+    async def lookup_wikipedia(self, **kw):
+        return []
+
+    async def lookup_openlibrary(self, **kw):
+        return []
+
+
+@pytest.fixture
+async def session_factory(engine) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    yield async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+async def _wipe(session_factory) -> None:
+    """Truncate the AI-side tables so each test starts clean.
+
+    `book_themes` is cascade-truncated by the `book_insights` CASCADE
+    chain (FK ON DELETE CASCADE + TRUNCATE CASCADE).
+    """
+    async with session_factory() as cleanup:
+        await cleanup.execute(
+            text(
+                "TRUNCATE TABLE ai_generation_log, external_source_cache, "
+                "book_insights, book_themes, ai_usage_daily CASCADE"
+            )
+        )
+        await cleanup.commit()
+
+
+def _orchestrator(ai: _FakeAIClient, *, prompt_version: str = "4") -> InsightOrchestrator:
+    return InsightOrchestrator(
+        ai=ai,
+        retriever_factory=lambda s: _FakeRetriever(),
+        sources_enabled=(),
+        model_id="themes-test-model",
+        prompt_version=prompt_version,
+        max_concurrency=2,
+        ai_timeout_s=5.0,
+    )
+
+
+async def _themes_for(session: AsyncSession, insight_id: int) -> list[tuple[str, float]]:
+    rows = (
+        await session.execute(
+            select(BookTheme.theme, BookTheme.confidence).where(
+                BookTheme.book_insight_id == insight_id
+            )
+        )
+    ).all()
+    return sorted((r[0], float(r[1])) for r in rows)
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_book_themes_persisted_on_generate(session_factory):
+    await _wipe(session_factory)
+    ai = _FakeAIClient(themes=["mystery", "noir"])
+    orch = _orchestrator(ai)
+    ident = DocumentIdentity(metadata_id="t-vocab", content_hash="ch-vocab")
+    bundle = MetadataBundle(title="Vocab Themes")
+
+    async with session_factory() as s:
+        await orch.generate(s, ident, bundle, user_id="alice", tenant_id="local")
+
+    async with session_factory() as s:
+        insight = (
+            await s.execute(select(BookInsight).where(BookInsight.content_hash == "ch-vocab"))
+        ).scalar_one()
+        themes = await _themes_for(s, insight.id)
+    assert themes == [("mystery", 1.0), ("noir", 1.0)]
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_book_themes_non_vocab_falls_to_other_confidence(session_factory):
+    await _wipe(session_factory)
+    ai = _FakeAIClient(themes=["dystopia", "noir western", "Cyberpunk"])
+    orch = _orchestrator(ai)
+    ident = DocumentIdentity(metadata_id="t-mixed", content_hash="ch-mixed")
+    bundle = MetadataBundle(title="Mixed Themes")
+
+    async with session_factory() as s:
+        await orch.generate(s, ident, bundle, user_id="alice", tenant_id="local")
+
+    async with session_factory() as s:
+        insight = (
+            await s.execute(select(BookInsight).where(BookInsight.content_hash == "ch-mixed"))
+        ).scalar_one()
+        themes = await _themes_for(s, insight.id)
+    assert themes == [
+        ("cyberpunk", 1.0),
+        ("dystopia", 1.0),
+        ("noir western", 0.5),  # off-vocab passthrough, spaces preserved
+    ]
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_book_themes_dedup_on_model_duplicate(session_factory):
+    await _wipe(session_factory)
+    ai = _FakeAIClient(themes=["Mystery", "mystery", "MYSTERY"])
+    orch = _orchestrator(ai)
+    ident = DocumentIdentity(metadata_id="t-dup", content_hash="ch-dup")
+    bundle = MetadataBundle(title="Dup Themes")
+
+    async with session_factory() as s:
+        await orch.generate(s, ident, bundle, user_id="alice", tenant_id="local")
+
+    async with session_factory() as s:
+        insight = (
+            await s.execute(select(BookInsight).where(BookInsight.content_hash == "ch-dup"))
+        ).scalar_one()
+        themes = await _themes_for(s, insight.id)
+    assert themes == [("mystery", 1.0)]
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_book_themes_literal_other_low_confidence(session_factory):
+    """Empty inputs collapse to literal "other"; literal "other" from the
+    model lands at OTHER_CONFIDENCE (not VOCAB) so PR9's confidence filter
+    excludes it from the controlled-vocab top-N query.
+    """
+    await _wipe(session_factory)
+    ai = _FakeAIClient(themes=["", "  ", "other"])
+    orch = _orchestrator(ai)
+    ident = DocumentIdentity(metadata_id="t-other", content_hash="ch-other")
+    bundle = MetadataBundle(title="Other Themes")
+
+    async with session_factory() as s:
+        await orch.generate(s, ident, bundle, user_id="alice", tenant_id="local")
+
+    async with session_factory() as s:
+        insight = (
+            await s.execute(select(BookInsight).where(BookInsight.content_hash == "ch-other"))
+        ).scalar_one()
+        themes = await _themes_for(s, insight.id)
+    # All three inputs deduped onto a single ("other", 0.5) row.
+    assert themes == [("other", 0.5)]
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_book_themes_cascade_on_insight_delete(session_factory):
+    await _wipe(session_factory)
+    ai = _FakeAIClient(themes=["mystery", "noir"])
+    orch = _orchestrator(ai)
+    ident = DocumentIdentity(metadata_id="t-cascade", content_hash="ch-cascade")
+    bundle = MetadataBundle(title="Cascade Themes")
+
+    async with session_factory() as s:
+        await orch.generate(s, ident, bundle, user_id="alice", tenant_id="local")
+
+    # Verify themes exist
+    async with session_factory() as s:
+        insight = (
+            await s.execute(select(BookInsight).where(BookInsight.content_hash == "ch-cascade"))
+        ).scalar_one()
+        assert len(await _themes_for(s, insight.id)) == 2
+
+    # Invalidate (DELETE on the parent)
+    async with session_factory() as s:
+        n = await orch.invalidate(s, ident, user_id="alice")
+        assert n == 1
+
+    # FK cascade should have dropped the children
+    async with session_factory() as s:
+        remaining = (
+            (await s.execute(select(BookTheme).where(BookTheme.book_insight_id == insight.id)))
+            .scalars()
+            .all()
+        )
+    assert remaining == []
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_book_themes_regenerate_keeps_superseded_themes(session_factory):
+    """Regenerate is supersede-not-delete. Old theme rows survive for audit
+    alongside the new live row's themes. PR9 must filter superseded_at IS NULL
+    on the join to avoid double-counting.
+    """
+    await _wipe(session_factory)
+    ai = _FakeAIClient(themes=["mystery", "noir"])
+    orch = _orchestrator(ai)
+    ident = DocumentIdentity(metadata_id="t-regen", content_hash="ch-regen")
+    bundle = MetadataBundle(title="Regen Themes")
+
+    async with session_factory() as s:
+        await orch.generate(s, ident, bundle, user_id="alice", tenant_id="local")
+
+    # Reconfigure the fake to produce different themes on regen
+    ai.themes = ["thriller", "crime"]
+    async with session_factory() as s:
+        await orch.regenerate(s, ident, bundle, user_id="alice", reason="redo", tenant_id="local")
+
+    async with session_factory() as s:
+        insights = (
+            (await s.execute(select(BookInsight).where(BookInsight.content_hash == "ch-regen")))
+            .scalars()
+            .all()
+        )
+        assert len(insights) == 2
+        live = [i for i in insights if i.superseded_at is None]
+        old = [i for i in insights if i.superseded_at is not None]
+        assert len(live) == 1 and len(old) == 1
+
+        old_themes = await _themes_for(s, old[0].id)
+        live_themes = await _themes_for(s, live[0].id)
+
+    assert old_themes == [("mystery", 1.0), ("noir", 1.0)]
+    assert live_themes == [("crime", 1.0), ("thriller", 1.0)]
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_schema_version_pinned_to_3_server_side(session_factory):
+    """The model may emit schema_version=2 by mistake. _do_generate forces it
+    to 3 before model_dump() so the cache row reflects the real schema.
+    """
+    await _wipe(session_factory)
+    ai = _FakeAIClient(themes=["mystery"], schema_version=2)
+    orch = _orchestrator(ai)
+    ident = DocumentIdentity(metadata_id="t-sv", content_hash="ch-sv")
+    bundle = MetadataBundle(title="SV Themes")
+
+    async with session_factory() as s:
+        await orch.generate(s, ident, bundle, user_id="alice", tenant_id="local")
+
+    async with session_factory() as s:
+        insight = (
+            await s.execute(select(BookInsight).where(BookInsight.content_hash == "ch-sv"))
+        ).scalar_one()
+        # payload is JSON-stored; the dict's schema_version must be the
+        # server-pinned 3, not the model's emitted 2.
+        assert insight.payload["schema_version"] == 3
+
+
+@pytest.mark.requires_ai
+@pytest.mark.asyncio
+async def test_book_themes_table_has_no_user_id(engine):
+    """Belt-and-braces local check; the parametrized cache-key audit test
+    covers the same ground but this lives next to the feature for grep-ability.
+    """
+
+    def _columns(sync_conn) -> set[str]:
+        insp = inspect(sync_conn)
+        return {c["name"] for c in insp.get_columns("book_themes")}
+
+    async with engine.connect() as conn:
+        cols = await conn.run_sync(_columns)
+    assert {"book_insight_id", "theme", "confidence"} <= cols
+    assert "user_id" not in cols
+    assert "tenant_id" not in cols

--- a/server/tests/integration/test_cache_key_audit.py
+++ b/server/tests/integration/test_cache_key_audit.py
@@ -28,6 +28,7 @@ from sqlalchemy import inspect
 
 from opds_sync.db.models import (
     BookInsight,
+    BookTheme,
     ExternalSourceCacheEntry,
     InsightIdentityAlias,
 )
@@ -48,8 +49,7 @@ GRANDFATHERED: dict[str, frozenset[str]] = {
 SHARED_CACHE_TABLES = [
     pytest.param(BookInsight, id="book_insights"),
     pytest.param(ExternalSourceCacheEntry, id="external_source_cache"),
-    # Future entries (add when the model lands):
-    # pytest.param(BookTheme, id="book_themes"),           # PR3
+    pytest.param(BookTheme, id="book_themes"),  # PR3 (2026-05-17)
 ]
 
 # Tables where `user_id` is INTENTIONAL cache-key scoping, NOT a tenant-leak.

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,10 +29,10 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # ai branch is now at ai_003 (PR-C → PR4 → PR2 chain); PR1 materialized
-    # the `progress` branch with `progress_001`. With the default-true mode
-    # flags, both branch heads are reported, sorted.
-    assert body["heads_applied"] == ["ai_003", "progress_001"]
+    # ai branch is now at ai_004 (PR-C → PR4 → PR2 → PR3 chain); PR1
+    # materialized the `progress` branch with `progress_001`. With the
+    # default-true mode flags, both branch heads are reported, sorted.
+    assert body["heads_applied"] == ["ai_004", "progress_001"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -2,11 +2,11 @@
 
 Cases covered:
 1. Default state with real migrations: wrapper upgrades backbone + ai branch,
-   DB ends at ai@head (currently `ai_003`).
+   DB ends at ai@head (currently `ai_004`).
 2. Idempotent: running twice in a row is a no-op.
-3. Synthetic branched script directory (tmp copy of migrations + an ai_test_003
+3. Synthetic branched script directory (tmp copy of migrations + an ai_test_005
    revision chained off the current ai@head):
-   - ai_enabled=true → upgrades to ai_test_003.
+   - ai_enabled=true → upgrades to ai_test_005.
    - ai_enabled=false → stays at 0004 (no ai branch applied).
 """
 
@@ -53,7 +53,7 @@ async def _downgrade_in_thread(cfg, target: str) -> None:
 
 
 async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str):
-    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_001)."""
+    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_004)."""
 
     # Wipe DB to fresh state.
     eng = create_async_engine(postgres_url, future=True)
@@ -66,10 +66,10 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch is at ai_003 (PR-C → PR4 → PR2); PR1 materialized the
+    # ai branch is at ai_004 (PR-C → PR4 → PR2 → PR3); PR1 materialized the
     # `progress` branch with progress_001. With both modes enabled, both
     # heads are present.
-    assert versions == {"ai_003", "progress_001"}
+    assert versions == {"ai_004", "progress_001"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
@@ -82,14 +82,14 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_003", "progress_001"}
+    assert versions == {"ai_004", "progress_001"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
-    """Copy real migrations to tmp + add a synthetic ai_test_003 chained off
-    ai_003; verify enabled run advances to ai_test_003 (the new ai@head)."""
+    """Copy real migrations to tmp + add a synthetic ai_test_005 chained off
+    ai_004; verify enabled run advances to ai_test_005 (the new ai@head)."""
 
-    # First, ensure DB is at ai@head (real migrations include ai_001 + ai_003).
+    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_004).
     real_cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
 
@@ -97,23 +97,23 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
     versions_dir = synth_dir / "versions"
-    # Chain off ai_003 (the current ai@head) with branch_labels=None — the `ai`
+    # Chain off ai_004 (the current ai@head) with branch_labels=None — the `ai`
     # label is already claimed by ai_001.
-    (versions_dir / "ai_test_003.py").write_text(
+    (versions_dir / "ai_test_005.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration.
 
-            Revision ID: ai_test_003
-            Revises: ai_003
-            Create Date: 2026-05-16 00:00:00.000000
+            Revision ID: ai_test_005
+            Revises: ai_004
+            Create Date: 2026-05-17 00:00:00.000000
             """
 
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_003"
-            down_revision = "ai_003"
+            revision = "ai_test_005"
+            down_revision = "ai_004"
             branch_labels = None
             depends_on = None
 
@@ -134,18 +134,18 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     # ai branch advances to the new tip.
-    assert "ai_test_003" in versions, versions
+    assert "ai_test_005" in versions, versions
     await eng.dispose()
 
     # Cleanup: roll back the synthetic migration so other tests aren't affected.
-    await _downgrade_in_thread(cfg, "ai_003")
+    await _downgrade_in_thread(cfg, "ai_004")
 
 
 async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
     """With ai_enabled=False, the wrapper skips advancing the ai branch.
 
     Pre-condition: DB is rolled back to 0004 (no ai branch applied), then the
-    wrapper is invoked with ai_enabled=False. ai_test_003 (the synthetic head)
+    wrapper is invoked with ai_enabled=False. ai_test_005 (the synthetic head)
     must NOT be applied; the backbone stays at 0004.
     """
     # Stamp DB back to backbone (pre-ai-branch state) for this test.
@@ -154,15 +154,15 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
 
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
-    (synth_dir / "versions" / "ai_test_003.py").write_text(
+    (synth_dir / "versions" / "ai_test_005.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration."""
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_003"
-            down_revision = "ai_003"
+            revision = "ai_test_005"
+            down_revision = "ai_004"
             branch_labels = None
             depends_on = None
 
@@ -181,9 +181,10 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch skipped → ai_test_003 not applied, ai_003 not applied,
+    # ai branch skipped → ai_test_005 not applied, ai_004 not applied,
     # ai_001 not applied. PR1: the `progress` branch still advanced.
-    assert "ai_test_003" not in versions
+    assert "ai_test_005" not in versions
+    assert "ai_004" not in versions
     assert "ai_003" not in versions
     assert "ai_001" not in versions
     # PR1: progress branch advanced (progress_enabled=True). The backbone

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -53,7 +53,7 @@ async def restore_after(postgres_url: str, alembic_upgrade):
 
 
 async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
-    """With ai@head (ai_003) + progress@head (progress_001) materialized,
+    """With ai@head (ai_004) + progress@head (progress_001) materialized,
     /readyz reports both heads.
     """
     # Some earlier test in the session may have downgraded the DB
@@ -72,14 +72,14 @@ async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upg
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_003", "progress_001"]
+    assert body["heads_applied"] == ["ai_004", "progress_001"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
     """DB stamped below backbone; with both modes enabled, required head is
-    ai_003 (ai@head) — that's what should be reported missing."""
+    ai_004 (ai@head) — that's what should be reported missing."""
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -87,7 +87,7 @@ async def test_readyz_503_when_db_below_backbone(
     assert r.status_code == 503
     body = r.json()
     assert body["ready"] is False
-    assert "ai_003" in body["missing"]
+    assert "ai_004" in body["missing"]
 
 
 async def test_readyz_200_with_neither_mode_at_backbone(

--- a/server/tests/unit/test_ai_prompts.py
+++ b/server/tests/unit/test_ai_prompts.py
@@ -6,9 +6,27 @@ from opds_sync.core.ai.prompts import (
 )
 
 
-def test_prompt_version_is_v3():
-    """PR4 bumped from v2 to v3 because the prompt body now varies on `language`."""
-    assert PROMPT_VERSION == "3"
+def test_prompt_version_is_v4():
+    """PR3 (2026-05-17) bumped from v3 to v4 because the prompt body now
+    instructs the model to emit `themes` and includes the controlled vocabulary.
+    """
+    assert PROMPT_VERSION == "4"
+
+
+def test_system_prompt_includes_themes_vocab():
+    """PR3: the controlled vocabulary must be inlined in SYSTEM_PROMPT so the
+    model can pick from it. We don't pin the exact wording (avoids brittle
+    diff churn on vocab tweaks), but a sample of representative entries plus
+    the section header must be present.
+    """
+    low = SYSTEM_PROMPT.lower()
+    assert "controlled themes vocabulary" in low
+    # Sample a handful of stable vocab entries (renames cost data migration,
+    # so these should not move casually).
+    for entry in ("mystery", "science_fiction", "biography", "poetry"):
+        assert entry in low
+    # The model must NOT be told to emit the literal "other".
+    assert '"other"' in SYSTEM_PROMPT  # the "Do NOT emit ... other" line
 
 
 def test_user_prompt_includes_metadata_fields():

--- a/server/tests/unit/test_ai_schemas.py
+++ b/server/tests/unit/test_ai_schemas.py
@@ -14,21 +14,40 @@ def test_payload_round_trip_minimal():
     p = BookInsightPayload(confidence="high")
     again = BookInsightPayload.model_validate_json(p.model_dump_json())
     assert again.confidence == "high"
-    assert again.schema_version == 2
+    assert again.schema_version == 3
     assert again.intro is None
     assert again.analysis is None
+    assert again.themes is None
 
 
 def test_payload_extra_fields_rejected():
     with pytest.raises(ValidationError):
-        BookInsightPayload.model_validate({"schema_version": 2, "fictional_field": "no"})
+        BookInsightPayload.model_validate({"schema_version": 3, "fictional_field": "no"})
 
 
 def test_payload_dropped_v1_fields_rejected():
-    # v1 had summary/themes/tone/suggested_for/notes — none should validate under v2.
-    for stale in ("summary", "themes", "tone", "suggested_for", "notes", "content_advisory"):
+    # v1 had summary/tone/suggested_for/notes — none should validate under v3.
+    # `themes` was re-introduced in PR3 (v3) and is intentionally NOT in this list.
+    for stale in ("summary", "tone", "suggested_for", "notes", "content_advisory"):
         with pytest.raises(ValidationError):
             BookInsightPayload.model_validate({stale: "x"})
+
+
+def test_payload_accepts_themes_field():
+    """PR3 (v3) re-introduces `themes` as a first-class output."""
+    p = BookInsightPayload.model_validate({"themes": ["mystery", "noir"], "confidence": "low"})
+    assert p.themes == ["mystery", "noir"]
+    assert p.schema_version == 3
+
+
+def test_payload_v2_no_themes_still_deserializes():
+    """Old cached v2 payloads (no `themes` key, `schema_version=2`) must still
+    deserialize cleanly. `themes` defaults to None; `schema_version` reads back
+    as 2 because the model honors the supplied value over the default.
+    """
+    p = BookInsightPayload.model_validate({"schema_version": 2, "confidence": "low"})
+    assert p.schema_version == 2
+    assert p.themes is None
 
 
 def test_payload_key_order_matches_reading_order():
@@ -40,6 +59,7 @@ def test_payload_key_order_matches_reading_order():
         "series",
         "analysis",
         "content_warnings",
+        "themes",
         "confidence",
         "schema_version",
     ]

--- a/server/tests/unit/test_themes_vocab.py
+++ b/server/tests/unit/test_themes_vocab.py
@@ -1,0 +1,72 @@
+"""Unit tests for the controlled-vocabulary normalizer (PR3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from opds_sync.core.ai.themes import (
+    CONTROLLED_THEMES,
+    OTHER_CONFIDENCE,
+    VOCAB_CONFIDENCE,
+    normalize_theme,
+)
+
+
+def test_controlled_themes_is_a_nonempty_frozenset():
+    assert isinstance(CONTROLLED_THEMES, frozenset)
+    assert len(CONTROLLED_THEMES) >= 50
+    # Sanity: the literal "other" sentinel must NOT be in the vocab — it's
+    # reserved for the empty-input fallback and must NOT be model-visible.
+    assert "other" not in CONTROLLED_THEMES
+
+
+@pytest.mark.parametrize(
+    "raw,expected_theme",
+    [
+        ("mystery", "mystery"),
+        ("Mystery", "mystery"),
+        ("MYSTERY", "mystery"),
+        ("  Mystery  ", "mystery"),
+        ("coming-of-age", "coming_of_age"),
+        ("coming of age", "coming_of_age"),
+        ("Coming Of Age", "coming_of_age"),
+        ("science_fiction", "science_fiction"),
+        ("science fiction", "science_fiction"),
+        ("science-fiction", "science_fiction"),
+    ],
+)
+def test_vocab_hits_normalize_at_full_confidence(raw, expected_theme):
+    theme, conf = normalize_theme(raw)
+    assert theme == expected_theme
+    assert conf == VOCAB_CONFIDENCE
+
+
+@pytest.mark.parametrize(
+    "raw,expected_theme",
+    [
+        ("interstellar politics", "interstellar politics"),  # spaces preserved
+        ("Noir Western", "noir western"),  # lowercased, spaces kept
+        ("steampunk", "steampunk"),  # off-vocab single word
+    ],
+)
+def test_off_vocab_passthrough_at_other_confidence(raw, expected_theme):
+    theme, conf = normalize_theme(raw)
+    assert theme == expected_theme
+    assert conf == OTHER_CONFIDENCE
+
+
+@pytest.mark.parametrize("empty", ["", "   ", "\t", "\n", "  \n\t "])
+def test_empty_input_collapses_to_literal_other(empty):
+    theme, conf = normalize_theme(empty)
+    assert theme == "other"
+    assert conf == OTHER_CONFIDENCE
+
+
+def test_literal_other_from_model_lands_in_other_band():
+    """The model is instructed NOT to emit "other", but if it does anyway,
+    the row lands at OTHER_CONFIDENCE — NOT in the controlled-vocab band.
+    This keeps PR9's `WHERE confidence >= 1.0` top-themes query clean.
+    """
+    theme, conf = normalize_theme("other")
+    assert theme == "other"
+    assert conf == OTHER_CONFIDENCE


### PR DESCRIPTION
## Summary

PR3 re-introduces `themes` as a first-class output of `BookInsightPayload`
backed by a controlled vocabulary, and persists it to a normalized side
table `book_themes` so PR9 library stats can `GROUP BY theme` without
scanning every payload row.

- Server-only. Android `:data:ai` already deserializes `themes: List<String>?`.
- F-Droid posture unchanged.
- No backfill of existing rows (separate follow-up if needed).

## Schema

```sql
CREATE TABLE book_themes (
    book_insight_id  bigint NOT NULL,
    theme            text   NOT NULL,
    confidence       real   NOT NULL DEFAULT 1.0,
    PRIMARY KEY (book_insight_id, theme),
    FOREIGN KEY (book_insight_id) REFERENCES book_insights(id) ON DELETE CASCADE
);
CREATE INDEX ix_book_themes_theme ON book_themes (theme);
```

Composite PK gives free FK-cascade index coverage; the single-column
`theme` index covers PR9's `GROUP BY theme` / `WHERE theme = ?` paths.
`book_themes` is SHARED CACHE (no `user_id` / `tenant_id`) and is now
included in the parametrized `SHARED_CACHE_TABLES` audit.

## Migration

- Revision: `ai_004` (down_revision `ai_003`, `branch_labels=None`).
- Fourth migration on the `ai` branch (`ai_001` -> `ai_002` -> `ai_003` -> `ai_004`).
- `ON DELETE CASCADE` means `invalidate` drops the children for free.
- `regenerate` is supersede-not-delete: superseded rows keep their
  theme history for audit alongside the new live row.

## Controlled vocabulary

~57 snake_case entries in `opds_sync/core/ai/themes.py`. Sample:

`science_fiction, fantasy, literary_fiction, contemporary_fiction,
historical_fiction, young_adult, mystery, thriller, biography, memoir,
history, philosophy, self_help, true_crime, technology, health, …`

`"other"` is deliberately NOT in the vocab. It exists only as the
empty-input fallback at confidence 0.5 so PR9's
`WHERE confidence >= 1.0` query stays clean. Off-vocab passthroughs
preserve their spaces (`"noir western"`) so PR9 can still surface them
in a "raw themes" section if desired.

`normalize_theme(raw) -> (theme, confidence)`:
- Vocab hit (after lowercase + space/hyphen -> underscore) -> 1.0.
- Off-vocab passthrough (lowercased, spaces preserved) -> 0.5.
- Empty / whitespace -> `("other", 0.5)`.

## Schema + prompt bump

- `BookInsightPayload.schema_version` 2 -> 3; `themes: list[str] | None`
  re-added between `content_warnings` and `confidence`.
- `_do_generate` PINS `payload.schema_version = 3` after the model
  returns, before `model_dump()`. Prevents cache poisoning by models
  that under-report.
- `PROMPT_VERSION` "3" -> "4". The controlled vocabulary is inlined
  (sorted for hash-seed-stability) at the end of `SYSTEM_PROMPT` with
  an explicit "do NOT emit 'other'" instruction.

Old v2 payloads (no `themes` key) deserialize cleanly via the optional
field's `None` default.

## Test plan

- [x] `test_themes_vocab.py` (unit): `normalize_theme` branches incl.
      literal `"other"` from model, empty input, hyphen + space variants.
- [x] `test_ai_schemas.py` (unit): `themes` field accepted at v3,
      `schema_version` defaults to 3, key order matches reading order,
      old v2 payload still deserializes.
- [x] `test_ai_prompts.py` (unit): `PROMPT_VERSION == "4"`, controlled
      vocab present in `SYSTEM_PROMPT`.
- [x] `test_book_themes.py` (integration): persisted on generate
      (vocab), non-vocab confidence band, dedup, cascade on invalidate,
      regenerate keeps superseded themes, literal-"other" collapse,
      schema_version pinned server-side, table has no `user_id`.
- [x] `test_cache_key_audit.py` (integration): `BookTheme` added to
      `SHARED_CACHE_TABLES`; parametrized audit confirms no tenant
      columns.
- [x] Migration head bump (`ai_004`) propagated to `test_migrate_script`,
      `test_health`, `test_readyz_migration_state`.

Mode matrix (run locally):
- `pytest -q` (full-stack, AI+progress): 334 passed
- `OPDS_SYNC_PROGRESS_ENABLED=false OPDS_SYNC_AI_ENABLED=true`: 309 passed, 25 skipped
- `OPDS_SYNC_PROGRESS_ENABLED=true OPDS_SYNC_AI_ENABLED=false`: 281 passed, 53 skipped

## Cache-version checklist

- [x] `PROMPT_VERSION` bumped to `"4"`.
- [x] `BookInsightPayload.schema_version` bumped to `3` (real shape change:
      `themes` field added back).
- [x] `_do_generate` pins `schema_version = 3` server-side.
- [x] `book_insights` unique indexes unchanged (themes go to a side table).
- [x] Lock key in `service.py` unchanged.
- [x] Android `:data:ai` DTOs already handle `themes: List<String>?`.
- [x] Invalidate-by-cache-key still works (FK cascade drops side rows).
- [x] Tests cover new insight, non-vocab confidence band, cascade on
      delete, old v2 deserialization, prompt v3 coexistence.
- [x] `docs/sync-api.md` updated (schema example, vocab note).

## Downstream notes (PR9)

`top_themes` query MUST filter `book_insights.superseded_at IS NULL` on
the join to avoid double-counting regenerated insights; should also
dedup per `(book, theme)` so two tone variants don't count themes twice.
Suggested shape (also in the spec):

```sql
SELECT theme, COUNT(DISTINCT li.pk) AS book_count
FROM book_themes bt
JOIN book_insights bi ON bi.id = bt.book_insight_id
JOIN library_items  li ON (
      (bi.metadata_id  IS NOT NULL AND li.metadata_id  = bi.metadata_id)
   OR (bi.content_hash IS NOT NULL AND li.content_hash = bi.content_hash))
WHERE li.user_id = :uid
  AND li.deleted_at IS NULL
  AND bi.superseded_at IS NULL
  AND bt.confidence >= 1.0
GROUP BY theme
ORDER BY book_count DESC
LIMIT 10;
```

The `confidence >= 1.0` filter restricts to controlled-vocab themes;
PR9 can choose to surface lower-confidence raw passthroughs in a
separate "raw themes" section.