### PR TITLE
feat(android): inspect insight screen

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -16,7 +16,9 @@ import io.theficos.ereader.data.sync.SyncDependencies
 import io.theficos.ereader.data.sync.SyncOrchestrator
 import io.theficos.ereader.reader.ReaderPreferencesStore
 import io.theficos.ereader.reader.ReadiumFactory
+import io.theficos.ereader.ui.bookdetail.AppInsightAuditSource
 import io.theficos.ereader.ui.bookdetail.BookDetailViewModel
+import io.theficos.ereader.ui.bookdetail.InsightAuditViewModel
 import io.theficos.ereader.ui.catalog.CatalogPreferencesStore
 import io.theficos.ereader.ui.library.LibraryPreferencesStore
 import java.io.File
@@ -69,6 +71,12 @@ class AppContainer(context: Context) {
         openOpfBytes = ::readOpfBytes,
     )
 
+    val insightAuditViewModelFactory: InsightAuditViewModelFactory =
+        InsightAuditViewModelFactory(
+            documents = documentRepository,
+            ai = aiRepository,
+        )
+
     private suspend fun readOpfBytes(doc: Document): ByteArray? = withContext(Dispatchers.IO) {
         runCatching {
             java.util.zip.ZipFile(doc.localPath).use { zip ->
@@ -98,5 +106,15 @@ class BookDetailViewModelFactory(
         documents = documents,
         ai = ai,
         openOpfBytes = openOpfBytes,
+    )
+}
+
+class InsightAuditViewModelFactory(
+    private val documents: DocumentRepository,
+    private val ai: AiRepository,
+) {
+    fun create(documentId: Long) = InsightAuditViewModel(
+        documentId = documentId,
+        source = AppInsightAuditSource(documents = documents, ai = ai),
     )
 }

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -1,6 +1,7 @@
 package io.theficos.ereader.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -11,6 +12,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import io.theficos.ereader.di.AppContainer
 import io.theficos.ereader.ui.bookdetail.BookDetailScreen
+import io.theficos.ereader.ui.bookdetail.InsightAuditScreen
 import io.theficos.ereader.ui.catalog.CatalogScreen
 import io.theficos.ereader.ui.catalog.CatalogViewModel
 import io.theficos.ereader.ui.library.LibraryScreen
@@ -103,10 +105,42 @@ fun AppNavGraph(container: AppContainer) {
             val vm = remember(id) {
                 container.bookDetailViewModelFactory.create(id)
             }
+            // Re-run load() after the audit screen invalidates the cached row,
+            // so the book detail naturally regenerates (or shows nothing) on
+            // return.
+            val savedStateHandle = backStack.savedStateHandle
+            val invalidatedFlow = savedStateHandle
+                .getStateFlow("insight_invalidated", false)
+            val invalidated by invalidatedFlow.collectAsState()
+            LaunchedEffect(invalidated) {
+                if (invalidated) {
+                    savedStateHandle["insight_invalidated"] = false
+                    vm.retry()
+                }
+            }
             BookDetailScreen(
                 viewModel = vm,
                 onOpenReader = { docId -> nav.navigate("reader/$docId") },
+                onInspectInsight = { docId -> nav.navigate("book/$docId/inspect-insight") },
                 onBack = { nav.popBackStack() },
+            )
+        }
+        composable(
+            "book/{id}/inspect-insight",
+            arguments = listOf(navArgument("id") { type = NavType.LongType }),
+        ) { backStack ->
+            val id = backStack.arguments!!.getLong("id")
+            val vm = remember(id) {
+                container.insightAuditViewModelFactory.create(id)
+            }
+            InsightAuditScreen(
+                viewModel = vm,
+                onBack = { nav.popBackStack() },
+                onInvalidated = {
+                    nav.previousBackStackEntry?.savedStateHandle
+                        ?.set("insight_invalidated", true)
+                    nav.popBackStack()
+                },
             )
         }
         composable("licenses") {

--- a/app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailScreen.kt
@@ -8,7 +8,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -17,6 +23,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
@@ -25,13 +34,37 @@ import androidx.compose.ui.unit.dp
 fun BookDetailScreen(
     viewModel: BookDetailViewModel,
     onOpenReader: (documentId: Long) -> Unit,
+    onInspectInsight: (documentId: Long) -> Unit,
     onBack: () -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
     val doc = state.document
+    var menuExpanded by remember { mutableStateOf(false) }
 
     Scaffold(
-        topBar = { TopAppBar(title = { Text(doc?.title ?: "Book") }) }
+        topBar = {
+            TopAppBar(
+                title = { Text(doc?.title ?: "Book") },
+                actions = {
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "More")
+                    }
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false },
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Inspect insight") },
+                            enabled = doc != null,
+                            onClick = {
+                                menuExpanded = false
+                                doc?.let { onInspectInsight(it.id) }
+                            },
+                        )
+                    }
+                },
+            )
+        },
     ) { padding ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/io/theficos/ereader/ui/bookdetail/InsightAuditScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/bookdetail/InsightAuditScreen.kt
@@ -1,0 +1,374 @@
+package io.theficos.ereader.ui.bookdetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import io.theficos.ereader.data.ai.AiStyle
+import io.theficos.ereader.data.ai.BookInsightResponse
+import io.theficos.ereader.data.ai.Citation
+import io.theficos.ereader.ui.components.QuireCard
+import java.time.Instant
+import java.time.format.DateTimeParseException
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InsightAuditScreen(
+    viewModel: InsightAuditViewModel,
+    onBack: () -> Unit,
+    onInvalidated: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var confirmOpen by rememberSaveable { mutableStateOf(false) }
+
+    // Surface invalidate failures as snackbars; on success let the navigation
+    // layer pop back via [onInvalidated].
+    LaunchedEffect(viewModel) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is InsightAuditViewModel.Event.InvalidateFailed ->
+                    snackbarHostState.showSnackbar(event.message)
+                InsightAuditViewModel.Event.Invalidated -> Unit
+            }
+        }
+    }
+    LaunchedEffect(state) {
+        if (state is InsightAuditViewModel.State.Done) onInvalidated()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Inspect insight") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (val s = state) {
+                InsightAuditViewModel.State.Loading -> CenteredProgress()
+                is InsightAuditViewModel.State.Error -> ErrorView(
+                    message = s.message,
+                    onRetry = { viewModel.retry() },
+                )
+                InsightAuditViewModel.State.NotCached -> NotCachedView()
+                is InsightAuditViewModel.State.Loaded -> LoadedView(
+                    response = s.response,
+                    currentStyle = s.currentStyle,
+                    invalidating = false,
+                    onInvalidate = { confirmOpen = true },
+                )
+                InsightAuditViewModel.State.Invalidating -> {
+                    // Render the last-known content area dimmed by overlaying
+                    // a progress indicator; the underlying Loaded composition
+                    // is gone, so show a centered spinner with helper text.
+                    CenteredProgress(label = "Invalidating…")
+                }
+                InsightAuditViewModel.State.Done -> {
+                    // Transient — onInvalidated() pops back. Render nothing.
+                }
+            }
+        }
+    }
+
+    if (confirmOpen) {
+        InvalidateConfirmDialog(
+            onDismiss = { confirmOpen = false },
+            onConfirm = {
+                confirmOpen = false
+                viewModel.invalidate()
+            },
+        )
+    }
+}
+
+@Composable
+private fun CenteredProgress(label: String? = null) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        if (label != null) {
+            Spacer(Modifier.height(8.dp))
+            Text(label, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun ErrorView(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(message, style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(12.dp))
+        OutlinedButton(onClick = onRetry) { Text("Retry") }
+    }
+}
+
+@Composable
+private fun NotCachedView() {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            "No insight cached for this book yet. Open the book detail to generate one.",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Composable
+private fun LoadedView(
+    response: BookInsightResponse,
+    currentStyle: AiStyle?,
+    invalidating: Boolean,
+    onInvalidate: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 8.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CacheKeyCard(response)
+        StyleCard(currentStyle)
+        GeneratedCard(response.generatedAt)
+        SourcesCard(response.sources)
+
+        Spacer(Modifier.height(8.dp))
+        OutlinedButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp),
+            enabled = !invalidating,
+            onClick = onInvalidate,
+        ) { Text("Invalidate cached insight") }
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun CacheKeyCard(response: BookInsightResponse) {
+    QuireCard(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            Text("Cache key (from server)", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            LabeledRow("Model", response.modelId)
+            LabeledRow("Prompt ver.", response.promptVersion)
+            LabeledRow("Schema ver.", response.payload.schemaVersion.toString())
+        }
+    }
+}
+
+@Composable
+private fun StyleCard(style: AiStyle?) {
+    QuireCard(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            Text("Your current AI style", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            LabeledRow("Tone", style?.tone ?: "—")
+            LabeledRow("Language", style?.language ?: "—")
+        }
+    }
+}
+
+@Composable
+private fun GeneratedCard(generatedAt: String) {
+    QuireCard(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            Text("Generated", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            val rel = formatRelative(generatedAt)
+            if (rel != null) {
+                Text(rel, style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    "($generatedAt)",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                )
+            } else {
+                Text(
+                    generatedAt,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourcesCard(sources: List<Citation>) {
+    val uriHandler = LocalUriHandler.current
+    QuireCard(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            Text("Sources (${sources.size})", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            if (sources.isEmpty()) {
+                Text(
+                    "No sources recorded.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            } else {
+                sources.forEach { citation ->
+                    Spacer(Modifier.height(4.dp))
+                    SourceRow(citation, onOpen = { uriHandler.openUri(it) })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceRow(citation: Citation, onOpen: (String) -> Unit) {
+    val label = citationLabel(citation)
+    val url = citationUrl(citation)
+    Column {
+        Text("· $label", style = MaterialTheme.typography.bodyMedium)
+        if (url != null) {
+            val annotated = buildAnnotatedString {
+                pushStringAnnotation("URL", url)
+                withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
+                    append(url)
+                }
+                pop()
+            }
+            ClickableText(
+                text = annotated,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                modifier = Modifier.padding(start = 12.dp, top = 2.dp),
+                onClick = { offset ->
+                    annotated.getStringAnnotations("URL", offset, offset).firstOrNull()?.let {
+                        onOpen(it.item)
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LabeledRow(label: String, value: String) {
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Text(label, style = MaterialTheme.typography.bodySmall)
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+@Composable
+private fun InvalidateConfirmDialog(onDismiss: () -> Unit, onConfirm: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Invalidate insight?") },
+        text = {
+            Text(
+                "Invalidating this insight removes the cached AI response. " +
+                    "Returning to this book detail will generate a fresh insight, " +
+                    "which may take a few seconds and uses one of your daily generations.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = { TextButton(onClick = onConfirm) { Text("Invalidate") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+/**
+ * Citation kind → human-readable label. Mirrors [InsightSection]'s
+ * `SourcesFooter` mapping (keep the two in sync; the audit screen renders
+ * sources as a list rather than inline text).
+ */
+internal fun citationLabel(c: Citation): String = when (c.kind) {
+    "wikipedia" -> "Wikipedia"
+    "openlibrary" -> "OpenLibrary"
+    "model" -> "AI model: ${c.title}"
+    "opf" -> "Book metadata"
+    else -> c.title
+}
+
+/** URL exposed in the source row, or null if the citation kind has no URL. */
+internal fun citationUrl(c: Citation): String? = when (c.kind) {
+    "model", "opf" -> null
+    else -> c.url
+}
+
+/**
+ * Render an ISO-8601 timestamp as a human-friendly relative string ("3h
+ * ago"). Returns null when the input cannot be parsed; callers fall back
+ * to displaying the raw value.
+ */
+internal fun formatRelative(iso: String, nowMs: Long = System.currentTimeMillis()): String? {
+    val epoch = parseIsoOrNull(iso) ?: return null
+    val deltaSec = (nowMs - epoch) / 1000
+    return when {
+        deltaSec < 0 -> "just now"
+        deltaSec < 60 -> "just now"
+        deltaSec < 3600 -> "${deltaSec / 60}m ago"
+        deltaSec < 86_400 -> "${deltaSec / 3600}h ago"
+        else -> "${deltaSec / 86_400}d ago"
+    }
+}
+
+private fun parseIsoOrNull(iso: String): Long? = try {
+    Instant.parse(iso).toEpochMilli()
+} catch (_: DateTimeParseException) {
+    null
+}

--- a/app/src/main/java/io/theficos/ereader/ui/bookdetail/InsightAuditViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/bookdetail/InsightAuditViewModel.kt
@@ -1,0 +1,168 @@
+package io.theficos.ereader.ui.bookdetail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.theficos.ereader.core.model.DocumentIdentity
+import io.theficos.ereader.data.ai.AiHttpException
+import io.theficos.ereader.data.ai.AiRepository
+import io.theficos.ereader.data.ai.AiStyle
+import io.theficos.ereader.data.ai.BookInsightResponse
+import io.theficos.ereader.data.local.DocumentRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Backs the "Inspect insight" debug screen. Reads the currently cached
+ * [BookInsightResponse] for a document and exposes a single invalidate
+ * action.
+ *
+ * No regenerate path — PR11 drops that pattern entirely. Invalidate uses
+ * the existing body-based `POST /ai/v1/insights/invalidate`; a 404 on
+ * invalidate (the row was already evicted by another device between
+ * screen open and the user's tap) is treated as success.
+ *
+ * Style snapshot: the server response does NOT carry the `tone` /
+ * `language` that produced the row. The audit screen surfaces the user's
+ * current [AiStyle] preference separately so the rendering does not
+ * imply we know which style this row came from.
+ */
+class InsightAuditViewModel(
+    private val documentId: Long,
+    private val source: Source,
+) : ViewModel() {
+
+    /**
+     * Narrow indirection over [AiRepository] + [DocumentRepository] used by
+     * the VM. Lets unit tests inject canned responses without spinning up
+     * the full stack. Production wiring is in [AppContainer] via
+     * [InsightAuditViewModelFactory].
+     */
+    interface Source {
+        suspend fun resolveIdentity(documentId: Long): DocumentIdentity?
+        suspend fun getCachedInsight(id: DocumentIdentity): BookInsightResponse?
+        suspend fun invalidate(id: DocumentIdentity)
+        fun currentStyle(): AiStyle?
+    }
+
+    sealed interface State {
+        data object Loading : State
+        data class Loaded(
+            val identity: DocumentIdentity,
+            val response: BookInsightResponse,
+            val currentStyle: AiStyle?,
+        ) : State
+        data object NotCached : State
+        data class Error(val message: String) : State
+        data object Invalidating : State
+        data object Done : State
+    }
+
+    sealed interface Event {
+        data object Invalidated : Event
+        data class InvalidateFailed(val message: String) : Event
+    }
+
+    private val _state = MutableStateFlow<State>(State.Loading)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = 4)
+    val events: SharedFlow<Event> = _events.asSharedFlow()
+
+    init {
+        viewModelScope.launch { load() }
+    }
+
+    fun retry() {
+        viewModelScope.launch { load() }
+    }
+
+    fun invalidate() {
+        val loaded = _state.value as? State.Loaded ?: return
+        viewModelScope.launch {
+            _state.value = State.Invalidating
+            runCatching { source.invalidate(loaded.identity) }
+                .onSuccess {
+                    _state.value = State.Done
+                    _events.emit(Event.Invalidated)
+                }
+                .onFailure { e ->
+                    // 404 means the row is already gone — that's exactly the
+                    // state the user asked for, so treat it as success.
+                    if (e is AiHttpException && e.code == 404) {
+                        _state.value = State.Done
+                        _events.emit(Event.Invalidated)
+                    } else {
+                        _state.value = loaded
+                        _events.emit(Event.InvalidateFailed(invalidateErrorMessage(e)))
+                    }
+                }
+        }
+    }
+
+    private suspend fun load() {
+        _state.value = State.Loading
+        val identity = runCatching { source.resolveIdentity(documentId) }
+            .getOrElse {
+                _state.value = State.Error(loadErrorMessage(it))
+                return
+            }
+        if (identity == null) {
+            _state.value = State.Error("Book not found.")
+            return
+        }
+        runCatching { source.getCachedInsight(identity) }
+            .onSuccess { cached ->
+                _state.value = if (cached == null) {
+                    State.NotCached
+                } else {
+                    State.Loaded(
+                        identity = identity,
+                        response = cached,
+                        currentStyle = source.currentStyle(),
+                    )
+                }
+            }
+            .onFailure { e -> _state.value = State.Error(loadErrorMessage(e)) }
+    }
+
+    private fun loadErrorMessage(e: Throwable): String = when (e) {
+        is AiHttpException -> "Couldn't read cached insight (${e.code})."
+        else -> "Couldn't read cached insight."
+    }
+
+    private fun invalidateErrorMessage(e: Throwable): String = when (e) {
+        is AiHttpException -> "Couldn't invalidate (${e.code})."
+        else -> "Couldn't invalidate."
+    }
+}
+
+/**
+ * Production [InsightAuditViewModel.Source] that wires the VM to the real
+ * [DocumentRepository] + [AiRepository] in [AppContainer].
+ */
+class AppInsightAuditSource(
+    private val documents: DocumentRepository,
+    private val ai: AiRepository,
+) : InsightAuditViewModel.Source {
+    override suspend fun resolveIdentity(documentId: Long): DocumentIdentity? =
+        documents.findById(documentId)?.let { doc ->
+            DocumentIdentity(
+                metadataId = doc.identity.metadataId,
+                contentHash = doc.identity.contentHash,
+            )
+        }
+
+    override suspend fun getCachedInsight(id: DocumentIdentity): BookInsightResponse? =
+        ai.getCachedInsight(id)
+
+    override suspend fun invalidate(id: DocumentIdentity) {
+        ai.invalidate(id)
+    }
+
+    override fun currentStyle(): AiStyle? = ai.preferences.value?.style
+}

--- a/app/src/test/java/io/theficos/ereader/ui/bookdetail/InsightAuditViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/bookdetail/InsightAuditViewModelTest.kt
@@ -1,0 +1,254 @@
+package io.theficos.ereader.ui.bookdetail
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.core.model.DocumentIdentity
+import io.theficos.ereader.data.ai.AiHttpException
+import io.theficos.ereader.data.ai.AiStyle
+import io.theficos.ereader.data.ai.BookInsightPayload
+import io.theficos.ereader.data.ai.BookInsightResponse
+import io.theficos.ereader.data.ai.Citation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InsightAuditViewModelTest {
+
+    private val identity = DocumentIdentity(metadataId = "m1", contentHash = "h1")
+
+    private val sampleResponse = BookInsightResponse(
+        payload = BookInsightPayload(intro = "About this book.", schemaVersion = 2),
+        sources = listOf(
+            Citation(kind = "wikipedia", title = "Wikipedia", url = "https://en.wikipedia.org/wiki/X"),
+        ),
+        modelId = "gpt-4o-mini-2024-07-18",
+        promptVersion = "3",
+        generatedAt = "2026-05-17T13:42:11Z",
+    )
+
+    private lateinit var source: FakeSource
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        source = FakeSource(identity = identity)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `loads cached insight into Loaded state`() = runTest {
+        source.cached = sampleResponse
+        source.styleFlow.value = AiStyle(tone = "scholarly", language = "it")
+
+        val vm = InsightAuditViewModel(documentId = 1L, source = source)
+
+        vm.state.test {
+            // initial Loading may or may not be observed depending on dispatcher;
+            // skip until we reach a terminal state.
+            var s: InsightAuditViewModel.State = awaitItem()
+            while (s is InsightAuditViewModel.State.Loading) s = awaitItem()
+            assertThat(s).isInstanceOf(InsightAuditViewModel.State.Loaded::class.java)
+            val loaded = s as InsightAuditViewModel.State.Loaded
+            assertThat(loaded.identity).isEqualTo(identity)
+            assertThat(loaded.response.modelId).isEqualTo("gpt-4o-mini-2024-07-18")
+            assertThat(loaded.response.promptVersion).isEqualTo("3")
+            assertThat(loaded.response.payload.schemaVersion).isEqualTo(2)
+            assertThat(loaded.currentStyle?.tone).isEqualTo("scholarly")
+            assertThat(loaded.currentStyle?.language).isEqualTo("it")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `surfaces NotCached when source returns null`() = runTest {
+        source.cached = null
+
+        val vm = InsightAuditViewModel(documentId = 1L, source = source)
+
+        vm.state.test {
+            var s: InsightAuditViewModel.State = awaitItem()
+            while (s is InsightAuditViewModel.State.Loading) s = awaitItem()
+            assertThat(s).isEqualTo(InsightAuditViewModel.State.NotCached)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `surfaces Error on network failure during load`() = runTest {
+        source.loadError = AiHttpException(code = 503, body = "boom")
+
+        val vm = InsightAuditViewModel(documentId = 1L, source = source)
+
+        vm.state.test {
+            var s: InsightAuditViewModel.State = awaitItem()
+            while (s is InsightAuditViewModel.State.Loading) s = awaitItem()
+            assertThat(s).isInstanceOf(InsightAuditViewModel.State.Error::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `surfaces Error when documentId unknown`() = runTest {
+        source.unknownDocumentId = true
+
+        val vm = InsightAuditViewModel(documentId = 999L, source = source)
+
+        vm.state.test {
+            var s: InsightAuditViewModel.State = awaitItem()
+            while (s is InsightAuditViewModel.State.Loading) s = awaitItem()
+            assertThat(s).isInstanceOf(InsightAuditViewModel.State.Error::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `invalidate success transitions to Done and emits Invalidated event`() = runTest {
+        source.cached = sampleResponse
+
+        val vm = InsightAuditViewModel(documentId = 1L, source = source)
+        vm.awaitLoaded()
+
+        vm.events.test {
+            vm.invalidate()
+            val event = awaitItem()
+            assertThat(event).isEqualTo(InsightAuditViewModel.Event.Invalidated)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertThat(vm.state.value).isEqualTo(InsightAuditViewModel.State.Done)
+        assertThat(source.invalidateCalls).containsExactly(identity)
+    }
+
+    @Test
+    fun `invalidate treats 404 as success (already evicted)`() = runTest {
+        source.cached = sampleResponse
+        source.invalidateError = AiHttpException(code = 404, body = "")
+
+        val vm = InsightAuditViewModel(documentId = 1L, source = source)
+        vm.awaitLoaded()
+
+        vm.events.test {
+            vm.invalidate()
+            assertThat(awaitItem()).isEqualTo(InsightAuditViewModel.Event.Invalidated)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertThat(vm.state.value).isEqualTo(InsightAuditViewModel.State.Done)
+    }
+
+    @Test
+    fun `invalidate failure stays in Loaded and emits InvalidateFailed event`() = runTest {
+        source.cached = sampleResponse
+        source.invalidateError = AiHttpException(code = 500, body = "boom")
+
+        val vm = InsightAuditViewModel(documentId = 1L, source = source)
+        vm.awaitLoaded()
+
+        vm.events.test {
+            vm.invalidate()
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(InsightAuditViewModel.Event.InvalidateFailed::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertThat(vm.state.value).isInstanceOf(InsightAuditViewModel.State.Loaded::class.java)
+    }
+
+    @Test
+    fun `style snapshot reflects current AiPreferences at load time`() = runTest {
+        source.cached = sampleResponse
+        source.styleFlow.value = AiStyle(tone = "casual", language = "auto")
+
+        val vm = InsightAuditViewModel(documentId = 1L, source = source)
+        vm.awaitLoaded()
+
+        val loaded = vm.state.value as InsightAuditViewModel.State.Loaded
+        assertThat(loaded.currentStyle?.tone).isEqualTo("casual")
+        assertThat(loaded.currentStyle?.language).isEqualTo("auto")
+
+        // Later changes to the live preferences must not retroactively mutate
+        // the snapshot the audit screen displays.
+        source.styleFlow.value = AiStyle(tone = "enthusiastic", language = "fr")
+        val stillLoaded = vm.state.value as InsightAuditViewModel.State.Loaded
+        assertThat(stillLoaded.currentStyle?.tone).isEqualTo("casual")
+    }
+
+    @Test
+    fun `retry re-runs load`() = runTest {
+        source.loadError = AiHttpException(code = 503, body = "boom")
+
+        val vm = InsightAuditViewModel(documentId = 1L, source = source)
+        vm.awaitTerminal()
+        assertThat(vm.state.value).isInstanceOf(InsightAuditViewModel.State.Error::class.java)
+
+        // recover
+        source.loadError = null
+        source.cached = sampleResponse
+        vm.retry()
+        vm.awaitLoaded()
+
+        assertThat(vm.state.value).isInstanceOf(InsightAuditViewModel.State.Loaded::class.java)
+    }
+
+    private suspend fun InsightAuditViewModel.awaitLoaded() {
+        state.test {
+            var s = awaitItem()
+            while (s !is InsightAuditViewModel.State.Loaded) s = awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private suspend fun InsightAuditViewModel.awaitTerminal() {
+        state.test {
+            var s = awaitItem()
+            while (s is InsightAuditViewModel.State.Loading ||
+                s is InsightAuditViewModel.State.Invalidating
+            ) {
+                s = awaitItem()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}
+
+/**
+ * Hand-rolled fake for [InsightAuditViewModel.Source]. Keeps tests hermetic
+ * without bringing in a mocking library (matches the repo's existing test
+ * style — see [io.theficos.ereader.ui.library.LibraryViewModelTest]).
+ */
+private class FakeSource(
+    private val identity: DocumentIdentity,
+) : InsightAuditViewModel.Source {
+    var cached: BookInsightResponse? = null
+    var loadError: Throwable? = null
+    var invalidateError: Throwable? = null
+    var unknownDocumentId: Boolean = false
+    val styleFlow = MutableStateFlow<AiStyle?>(AiStyle())
+    val invalidateCalls = mutableListOf<DocumentIdentity>()
+
+    override suspend fun resolveIdentity(documentId: Long): DocumentIdentity? =
+        if (unknownDocumentId) null else identity
+
+    override suspend fun getCachedInsight(id: DocumentIdentity): BookInsightResponse? {
+        loadError?.let { throw it }
+        return cached
+    }
+
+    override suspend fun invalidate(id: DocumentIdentity) {
+        invalidateCalls += id
+        invalidateError?.let { throw it }
+    }
+
+    override fun currentStyle(): AiStyle? = styleFlow.value
+}

--- a/docs/superpowers/plans/2026-05-17-insight-audit-ui.md
+++ b/docs/superpowers/plans/2026-05-17-insight-audit-ui.md
@@ -1,0 +1,310 @@
+# PR6 — Insight audit UI: implementation plan
+
+**Date:** 2026-05-17
+**Spec:** `docs/superpowers/specs/2026-05-17-insight-audit-ui-design.md`
+**Branch:** `feat/insight-audit-ui`
+**Effort:** Short (~3h)
+**Deps:** PR-A (mode flags) — shipped.
+
+## Scope
+
+Add a `InsightAuditScreen` reachable from a new book-detail overflow menu
+("Inspect insight"). The screen displays the cached
+`BookInsightResponse` metadata and lets the user invalidate it. No
+regenerate button; no new server endpoint; no DTO mutation.
+
+## Inventory of touched files
+
+### New
+- `app/src/main/java/io/theficos/ereader/ui/bookdetail/InsightAuditScreen.kt`
+- `app/src/main/java/io/theficos/ereader/ui/bookdetail/InsightAuditViewModel.kt`
+- `app/src/test/java/io/theficos/ereader/ui/bookdetail/InsightAuditViewModelTest.kt`
+
+### Modified
+- `app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailScreen.kt`
+  — add overflow menu with "Inspect insight"; thread an `onInspectInsight`
+  lambda from the caller; read post-invalidate `savedStateHandle` flag and
+  re-trigger `viewModel.retry()` on resume.
+- `app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt`
+  — add `book/{id}/inspect-insight` composable route; pass
+  `onInspectInsight` to `BookDetailScreen`.
+- `app/src/main/java/io/theficos/ereader/di/AppContainer.kt`
+  — add `insightAuditViewModelFactory` mirroring the existing
+  `bookDetailViewModelFactory` pattern.
+
+### Untouched
+- Server (`server/`) — zero changes.
+- `data/ai/` DTOs — already contain the fields we display.
+- `data/ai/` `AiRepository` / `AiClient` — already expose `getInsight` and
+  `invalidateInsight`.
+
+## Step-by-step
+
+### Step 1 — Spec + plan committed first
+
+Commit the spec and this plan in their own commit so subsequent
+implementation commits are reviewable diffs on top of an agreed design.
+
+Verification: `git log --oneline -1` shows `:memo: docs: PR6 insight
+audit UI spec + plan`.
+
+### Step 2 — Failing ViewModel test
+
+Write `InsightAuditViewModelTest.kt` covering:
+
+- `loads cached insight into Loaded state`
+- `surfaces NotCached when repository returns null`
+- `surfaces Error on network failure`
+- `invalidate success transitions to Done and emits Done event`
+- `invalidate failure stays in Loaded and emits Error event`
+- `style snapshot reflects current AiPreferences at load time`
+
+Use Robolectric for `Dispatchers.setMain(UnconfinedTestDispatcher())`
+mirror, and a hand-rolled `FakeAiRepository` that returns canned
+`BookInsightResponse`s and throws on demand. The real `AiRepository`
+exposes its members as suspend funs over an internal `AiClient`; the
+ViewModel will depend on a narrow interface
+`InsightAuditViewModel.Source` (declared in the same file) to keep tests
+hermetic without a mocking library.
+
+Verification: run the test file once before any production code exists →
+compilation fails (intentional: drives the API surface).
+
+### Step 3 — `InsightAuditViewModel`
+
+Implement the ViewModel:
+
+```kotlin
+class InsightAuditViewModel(
+    private val documentId: Long,
+    private val documents: DocumentRepository,
+    private val ai: AiRepository,
+) : ViewModel() {
+
+    sealed interface State {
+        data object Loading : State
+        data class Loaded(
+            val identity: DocumentIdentity,
+            val response: BookInsightResponse,
+            val currentStyle: AiStyle?,
+        ) : State
+        data object NotCached : State
+        data class Error(val message: String) : State
+        data object Invalidating : State
+        data object Done : State
+    }
+
+    sealed interface Event {
+        data object Invalidated : Event
+        data class InvalidateFailed(val message: String) : Event
+    }
+
+    val state: StateFlow<State>
+    val events: SharedFlow<Event>
+
+    fun retry()
+    fun invalidate()
+}
+```
+
+Implementation notes:
+
+- `init { load() }` issues `documents.findById` then `ai.getCachedInsight`,
+  capturing `ai.preferences.value?.style` in the resulting `Loaded` state.
+- `retry()` re-runs the same flow from `Loading`.
+- `invalidate()` requires current state to be `Loaded`; sets `Invalidating`,
+  calls `ai.invalidate(identity)`, emits `Invalidated` event and sets
+  `Done` on success; emits `InvalidateFailed(...)` and reverts to the
+  prior `Loaded` state on failure. **Race handling (architect note):**
+  if the underlying call surfaces a 404 (row already evicted by another
+  device between this screen's open and the user's tap), treat that as
+  success — the user's intent ("there should be no cache row for this
+  book") is satisfied. `AiClient.invalidateInsight` currently throws
+  `AiHttpException(404)` for 404; the VM swallows the 404 and proceeds
+  to `Done`.
+- Error message strings mirror the existing patterns in
+  `BookDetailViewModel.regenerate` (quota → "today's regeneration limit";
+  http → "(code)"; generic → "Couldn't invalidate.").
+
+Verification: test from Step 2 turns green.
+
+### Step 4 — `InsightAuditScreen`
+
+Compose the screen:
+
+- `Scaffold` with `TopAppBar(title = "Inspect insight", navigationIcon = Back)`.
+- `LaunchedEffect(state)` collects events; uses a `SnackbarHostState` for
+  the `InvalidateFailed` event; on `Done` calls a passed-in `onDone()`
+  lambda (which the nav-graph wires to popBackStack + savedStateHandle
+  flag set).
+- A `LaunchedEffect(state)` reading the `Done` state also calls `onDone()`
+  for the success path (so the test surface stays purely on the VM).
+- Body branches on `State`:
+  - `Loading` → centered `CircularProgressIndicator`.
+  - `Loaded` → vertical `Column` with three `QuireCard` sections (Cache
+    key, Generated, Sources) and an `OutlinedButton("Invalidate cached
+    insight")` at the bottom.
+  - `NotCached` → centered text + back affordance.
+  - `Error` → centered text + Retry button → `viewModel.retry()`.
+  - `Invalidating` → overlay or in-place disabled button + spinner.
+  - `Done` → covered by the `LaunchedEffect` above; render nothing
+    (transient state immediately before pop).
+- A `RememberSaveable` boolean `showConfirm` drives an `AlertDialog`
+  with the copy from the spec:
+  > "Invalidating this insight removes the cached AI response. The next
+  > time you open this book, a fresh insight will be generated (counts
+  > against your daily AI budget)."
+
+Source-row rendering reuses the kind→label mapping from
+`InsightCards.kt::SourcesFooter`. Extract the mapping into a small
+internal helper (`fun Citation.label(): String` + `fun Citation.url():
+String?`) inside `InsightCards.kt` so both screens share it without
+duplication.
+
+**Tone / language rendering — architect callout.** Do NOT label tone /
+language as cached metadata. Render them under a separate "Your current
+AI style" card sourced from `AiRepository.preferences.value?.style`. If
+preferences are null, show "—" for both. No "matches preferences" hint.
+
+**Confirmation dialog copy** (architect-revised):
+
+> Invalidating this insight removes the cached AI response. Returning to
+> this book detail will generate a fresh insight, which may take a few
+> seconds and uses one of your daily generations.
+
+Verification: APK builds; preview composables render without crash.
+
+### Step 5 — Wire into book detail
+
+In `BookDetailScreen.kt`:
+
+1. Replace the existing `Scaffold(topBar = { TopAppBar(…) })` so the bar
+   exposes `actions = { IconButton + DropdownMenu }`.
+2. Thread an `onInspectInsight: () -> Unit` parameter into the
+   `BookDetailScreen` signature.
+3. Read post-invalidate flag from `savedStateHandle` in a
+   `LaunchedEffect(Unit)` keyed on the result key; on observation, call
+   `viewModel.retry()` and clear the flag.
+
+In `AppNavGraph.kt`:
+
+1. Pass `onInspectInsight = { nav.navigate("book/$id/inspect-insight") }`
+   into `BookDetailScreen`.
+2. Add new `composable("book/{id}/inspect-insight", …)` block that
+   creates `InsightAuditViewModel` from the factory and constructs
+   `InsightAuditScreen` with `onBack = { nav.popBackStack() }` and
+   `onDone = { entry -> entry.savedStateHandle… ; nav.popBackStack() }`.
+
+In `AppContainer.kt`:
+
+1. Add `insightAuditViewModelFactory: InsightAuditViewModelFactory =
+   InsightAuditViewModelFactory(documentRepository, aiRepository)` and
+   the small factory class at the bottom of the file.
+
+Verification: `scripts/dgradle :app:assembleDebug` clean.
+
+### Step 6 — GPT review
+
+Send spec + plan to the architect prompt. Capture the verdict. Apply any
+must-fix items.
+
+Specific questions to ask:
+
+1. Is option (a) — pass `Long` documentId, resolve to identity in the VM
+   — the right call given the existing nav pattern, or should we
+   serialize `DocumentIdentity` into nav args for symmetry with future
+   catalog-detail (PR7) which has no local Long?
+2. Confirmation dialog copy: is "counts against your daily AI budget"
+   the clearest framing? Alternatives: "uses one of your daily
+   generations" / "the next open may take a few seconds" / silence on
+   cost entirely.
+3. Behaviour when the cache row is invalidated by another device
+   between screen open and the user tapping Invalidate. Current spec
+   says "show snapshot, no refresh". Should we re-fetch on resume?
+4. Tappable URLs: `LocalUriHandler.openUri` (Chrome Custom Tab on
+   modern Android) vs an explicit `Intent.ACTION_VIEW`. Any F-Droid
+   surface concern?
+
+Cap: 3 rounds.
+
+### Step 7 — Verify
+
+Run, in order:
+
+```bash
+scripts/dgradle :app:testDebugUnitTest
+scripts/dgradle :data:ai:testDebugUnitTest
+scripts/dgradle :app:lintDebug
+```
+
+All three must be green.
+
+### Step 8 — Commit + push + PR
+
+- Single feature commit on top of the spec/plan commit:
+  `:sparkles: feat: insight audit UI`.
+- `git push -u origin feat/insight-audit-ui`.
+- `gh pr create --base main --head feat/insight-audit-ui --title 'feat:
+  insight audit UI' --body @body.md`.
+- Body sections: Summary, Screen mock (ASCII from spec), Navigation
+  wiring, Test plan, GPT verdict, Coordination notes (PR11 overlap),
+  No Claude attribution.
+
+## Definition of done
+
+- [ ] Spec + plan committed in their own commit.
+- [ ] `InsightAuditViewModel` + tests passing.
+- [ ] `InsightAuditScreen` builds, previews render, manual smoke clean.
+- [ ] Book-detail overflow exposes "Inspect insight".
+- [ ] `scripts/dgradle :app:testDebugUnitTest` green.
+- [ ] `scripts/dgradle :data:ai:testDebugUnitTest` green.
+- [ ] `scripts/dgradle :app:lintDebug` clean.
+- [ ] No regenerate button anywhere in PR diff.
+- [ ] GPT verdict captured in the PR body.
+- [ ] PR opened against `main`. URL recorded.
+
+## Out of scope
+
+- Adding Compose UI test infrastructure.
+- Mutating `BookInsightResponse` to include `tone` / `language`.
+- Active "diff against current preferences" highlighting.
+- Auto-refresh-on-resume of the audit screen.
+- Migration / server endpoint work of any kind.
+
+## Risks
+
+1. **Conflict with PR11.** Likely mechanical in `BookDetailScreen.kt`.
+   Resolution: keep PR6's `TopAppBar.actions` block; drop PR11's
+   removed `RegenerateDialog` and `Not quite right?` `TextButton`.
+2. **Robolectric flakiness from `Dispatchers.setMain`.** Mitigated by
+   the pattern already used in `LibraryViewModelTest`
+   (`UnconfinedTestDispatcher`).
+3. **Stale cached row mid-view.** Acceptable per non-goals; documented.
+
+## GPT architect verdict
+
+> **APPROVE with one copy tweak.** Design fits existing Android patterns
+> and stays within the Android-only / F-Droid constraints.
+>
+> - **Q1 nav arg.** Pass local `Long documentId`. Matches existing
+>   `book/{id}` / `reader/{docId}` routes; keeps identity resolution in
+>   the VM; avoids encoding nullable identity fields into nav args. PR7
+>   can solve catalog-detail separately when it actually lacks a local
+>   row.
+> - **Q2 dialog copy.** Keep the cost warning but say "uses one of your
+>   daily generations" instead of "counts against your daily AI
+>   budget". Recommended: "Invalidating this insight removes the cached
+>   AI response. Returning to this book detail will generate a fresh
+>   insight, which may take a few seconds and uses one of your daily
+>   generations." → **applied**.
+> - **Q3 stale-row race.** Keep snapshot-only; do not re-fetch on
+>   `ON_RESUME`. Resume refresh adds network churn and still cannot
+>   close the tap-time race. If invalidate returns 404, treat that as
+>   success. → **applied** (404 swallowed as success in the VM).
+> - **Q4 tappable URLs.** Use `LocalUriHandler.current.openUri(url)`.
+>   Matches existing `SourcesFooter`; adds no app HTTP path or manifest
+>   permission.
+> - **Risk callout.** Do not label tone/language as cached metadata or
+>   "matches preferences"; the DTO does not support it. → **applied**;
+>   spec now renders them under a separate "Your current AI style"
+>   card sourced from live `AiPreferences.style`.

--- a/docs/superpowers/specs/2026-05-17-insight-audit-ui-design.md
+++ b/docs/superpowers/specs/2026-05-17-insight-audit-ui-design.md
@@ -1,0 +1,338 @@
+# PR6 — Insight audit UI
+
+**Date:** 2026-05-17
+**Branch:** Android-only (`feat/insight-audit-ui`)
+**Effort:** Short
+**Deps:** PR-A (mode flags / branch split) — already shipped.
+**Status:** Draft — ready for review
+
+## Goal
+
+Give power users (and me) a one-tap way to inspect the metadata of the AI
+insight currently cached for a book, and to evict it. No new server endpoint
+— the existing body-based `POST /ai/v1/insights/invalidate` is reused. No
+"regenerate" affordance — `PR11` explicitly removes the regenerate pattern
+because invalidate-and-natural-refresh on the next open of the book detail
+covers the same use case at half the AI cost.
+
+The screen is small but load-bearing for diagnosing cache surprises:
+
+- Did this book get the new `prompt_version`?
+- Which `model_id` produced this answer?
+- Was it generated under my current `tone` / `language` preferences, or am I
+  looking at a stale row from before I changed them?
+- Are the source citations resolvable (Wikipedia / OpenLibrary URLs that
+  actually open)?
+
+## Why now
+
+Three recent PRs added cache-key dimensions that are otherwise invisible to
+the user:
+
+- **PR-C** (`ai_generation_log`) — we now want to know `model_id` and
+  `prompt_version` at a glance for any cached row.
+- **PR4** (language preference) — `language` is now in the cache key. Without
+  a UI, a user who set `language="it"` and then reverts to `"auto"` cannot
+  tell which insight they are looking at.
+- **PR9 / PR3** (themes v3) will land in this batch and bump
+  `schema_version` from `2` → `3`. Before that lands, users (me) need a way
+  to evict old-schema rows on-demand and confirm the next lookup hits the
+  new schema.
+
+Doing this as a tiny audit UI is also the cheapest possible "user-facing
+debug surface" — it removes the need for me to `kubectl exec` into a pod
+just to see what shipped.
+
+## Non-goals
+
+- **Regenerate button.** Explicitly dropped. PR11 (running in parallel) is
+  removing the existing one from the book-detail Regenerate `TextButton`.
+  Re-introducing it here would directly contradict the roadmap and double
+  the AI cost per "this answer is wrong" interaction.
+- **No new server endpoint.** Reuses the existing
+  `POST /ai/v1/insights/invalidate` (body-based, already deployed). No
+  migration; no Alembic branch touched.
+- **No live polling.** The screen reads the cached row once on entry. If the
+  cache row changes mid-session (e.g., another device invalidated it), the
+  user sees the stale snapshot until they leave and re-enter the screen.
+  Acceptable because the screen is a "debug peek", not a live dashboard.
+- **No diff against current preferences.** The screen does not compare the
+  cached `tone` / `language` against the current `AiStyle` and highlight
+  mismatches. That is a "phase 2" usability improvement; for now, both
+  values are simply displayed and the user can eyeball the comparison.
+- **No GET that returns metadata only.** Reuses `POST /ai/v1/insights/get`
+  which returns the full `BookInsightResponse`. Calling it once on screen
+  entry is cheap.
+
+## Surface
+
+New Compose screen `InsightAuditScreen.kt` reachable from the book-detail
+overflow. Route added to `AppNavGraph.kt`. Visual outline:
+
+```
+┌──────────────────────────────────────────────┐
+│ ← Inspect insight                            │
+├──────────────────────────────────────────────┤
+│  Cache key (from server)                     │
+│    Model        gpt-4o-mini-2024-07-18       │
+│    Prompt ver.  3                            │
+│    Schema ver.  2                            │
+│                                              │
+│  Your current AI style                       │
+│    Tone         neutral                      │
+│    Language     auto                         │
+│                                              │
+│  Generated                                   │
+│    3 hours ago                               │
+│    (2026-05-17T13:42:11Z)                    │
+│                                              │
+│  Sources (3)                                 │
+│    · Wikipedia    https://en.wikipedia.org…  │
+│    · OpenLibrary  https://openlibrary.org/…  │
+│    · AI model: gpt-4o-mini-2024-07-18        │
+│                                              │
+│  [ Invalidate cached insight ]               │
+└──────────────────────────────────────────────┘
+```
+
+**Tone / language rendering — architect callout.** The server response
+does NOT carry the `tone` and `language` that produced the cached row,
+so the audit screen must NOT label them as cached metadata (would imply
+we know which style this row came from). They are shown under a
+separate "Your current AI style" section sourced from the live
+`AiPreferences.style` snapshot. If preferences haven't loaded yet, show
+"—" for both. No "matches preferences" hint — the comparison cannot be
+made without server-side `tone` / `language`.
+
+### State machine
+
+```
+                   ┌─────────┐
+   enter screen →  │ Loading │
+                   └────┬────┘
+                        ▼
+              (call AiRepository.getCachedInsight)
+                        │
+        ┌───────────────┼──────────────────────┐
+        ▼               ▼                      ▼
+   ┌─────────┐     ┌──────────┐         ┌──────────┐
+   │ Loaded  │     │NotCached │         │  Error   │
+   └────┬────┘     └──────────┘         └──────────┘
+        │  user taps Invalidate
+        ▼
+   ┌──────────────┐
+   │ ConfirmDialog│
+   └──────┬───────┘
+          │ confirm
+          ▼
+   ┌─────────────────┐
+   │ Invalidating    │
+   └────┬────────┬───┘
+        │        │
+        ▼        ▼
+   ┌────────┐ ┌────────┐
+   │Done    │ │Error   │
+   │(popBack│ │(stay   │
+   │ + flag)│ │ open)  │
+   └────────┘ └────────┘
+```
+
+- `Loading` — entering the screen before the cached row arrives.
+- `Loaded(BookInsightResponse, currentStyle)` — the cached row + the user's
+  current `AiStyle` snapshot for the "matches preferences" hint.
+- `NotCached` — nothing cached for this identity. Shows a short paragraph
+  ("No insight cached for this book yet. Open the book detail to generate
+  one.") and disables the Invalidate button.
+- `Error(message)` — network failure on the initial fetch. Shows the message
+  and a Retry button.
+- `Invalidating` — overlay/disabled state while the DELETE-equivalent call
+  runs.
+- On success: pop back to book detail with a result flag in the savedState
+  handle so the book-detail VM re-runs `load()` and naturally either hits a
+  cold cache (and regenerates on the next entry if it chooses) or simply
+  shows nothing.
+- On failure: stay on the audit screen, show a transient Snackbar via a
+  `SharedFlow<String>`.
+
+### Confirmation dialog
+
+```
+Invalidate insight?
+──────────────────
+Invalidating this insight removes the cached AI response. Returning to
+this book detail will generate a fresh insight, which may take a few
+seconds and uses one of your daily generations.
+
+  [ Cancel ]   [ Invalidate ]
+```
+
+Copy chosen on architect advice: "uses one of your daily generations" is
+clearer than "counts against your daily AI budget"; the "may take a few
+seconds" framing surfaces the latency cost alongside the quota cost so
+the user can weigh both.
+
+Two-step confirmation matters here because invalidation is silently
+expensive: the next book-detail open consumes one generation from the
+budget. A casual misclick on a single tap would cost a generation.
+
+### Source list rendering
+
+The cached response has `List<Citation>`. Citation kinds we know about
+today (from `InsightCards.kt::SourcesFooter`):
+
+- `wikipedia` → labeled "Wikipedia", URL tappable.
+- `openlibrary` → labeled "OpenLibrary", URL tappable.
+- `model` → labeled "AI model: <title>", no URL.
+- `opf` → labeled "Book metadata", no URL.
+- anything else → falls back to `title` as label, URL tappable if present.
+
+In the audit screen each source is rendered as a row:
+
+```
+· <label>
+  <url, monospace, truncated end-ellipsis if too long>
+```
+
+Tapping the URL opens via `LocalUriHandler.current.openUri(url)`, which on
+Android resolves to Chrome Custom Tabs when the user has a default browser
+configured. Same mechanism `InsightCards::SourcesFooter` already uses; no
+new permission, no new manifest entry, no new INTERNET-touching code
+(URLs go through the system browser).
+
+## Wiring
+
+### Book-detail overflow menu
+
+`BookDetailScreen.kt` currently has no overflow menu. It exposes:
+
+- "Open in reader" `TextButton`.
+- "Not quite right? Regenerate" `TextButton` (slated for removal in PR11).
+
+This PR adds a `MoreVert` `IconButton` to the top app bar with a single
+item:
+
+```kotlin
+DropdownMenu(expanded = …, onDismissRequest = …) {
+    DropdownMenuItem(
+        text = { Text("Inspect insight") },
+        onClick = {
+            menuExpanded = false
+            onInspectInsight()
+        },
+    )
+}
+```
+
+The menu item is shown unconditionally — even when no insight is cached,
+the audit screen handles the `NotCached` state gracefully and is informative
+about why.
+
+**Coordination with PR11:** PR11 removes the "Not quite right? Regenerate"
+button and its supporting `RegenerateDialog`. Both PRs touch
+`BookDetailScreen.kt` but operate on disjoint nodes (PR11 removes a
+`TextButton` inside the column; PR6 adds an `IconButton` inside the
+`TopAppBar` `actions` slot, plus an overflow `DropdownMenu`). A small
+manual merge may be needed in the `TopAppBar { … }` block where PR11
+might also want to inject overflow actions — call out in the PR body.
+
+### Navigation argument
+
+The new route needs a `DocumentIdentity`. Existing routes (`reader/{docId}`,
+`book/{id}`) pass the local `Long` documentId. The audit screen could:
+
+a. Receive the local `Long` documentId and resolve to identity inside the
+   ViewModel via `DocumentRepository.findById(id).identity`.
+b. Receive the serialized `DocumentIdentity` in nav args.
+
+**Decision:** (a). Consistent with the existing `book/{id}` route, avoids
+URL-encoding two fields (`metadataId` is nullable, `contentHash` is a
+hex string), and the resolution is already what `BookDetailViewModel.load`
+does. The audit ViewModel takes the same `documentId: Long` constructor
+argument and the same `DocumentRepository` and `AiRepository`.
+
+Route: `book/{id}/inspect-insight`.
+
+### Post-invalidate refresh
+
+When the user confirms an invalidate:
+
+1. `InsightAuditViewModel` calls `AiRepository.invalidate(identity)`.
+2. On success → set state to `Done`, emit an event.
+3. The screen observes the event and calls
+   `nav.previousBackStackEntry?.savedStateHandle?.set("insight_invalidated", true)`,
+   then `nav.popBackStack()`.
+4. `BookDetailScreen` reads the savedState flag in a `LaunchedEffect`. If
+   set, it calls `viewModel.retry()` (which already re-runs `load()`) and
+   clears the flag.
+
+This pattern is already idiomatic for Android Navigation Compose and adds
+zero new infrastructure.
+
+## Constraints
+
+- **F-Droid posture.** Pure UI; no new network destinations; uses the
+  user's default browser via `LocalUriHandler` for tappable URLs. No new
+  permissions in `AndroidManifest.xml`.
+- **No new server endpoint.** Reuses `POST /ai/v1/insights/get` and
+  `POST /ai/v1/insights/invalidate`, both already deployed.
+- **No DTO mutation required.** The existing `BookInsightResponse` already
+  carries `modelId`, `promptVersion`, `generatedAt`, and the nested
+  `payload.schemaVersion`. `tone` and `language` are **not** part of the
+  server response (they live on the request side as cache-key knobs) — the
+  audit screen reads them from the user's current `AiPreferences.style`
+  snapshot and labels them clearly as "your current style preference at the
+  time this row was last looked up". If `AiStyle` is unavailable
+  (preferences not yet loaded), those fields render as "—".
+- **DTO additions:** none. If a future server PR adds `tone` / `language`
+  to `BookInsightResponse`, the audit screen will surface them via the
+  same field placeholders without further code change.
+
+## Test surface
+
+This repo does **not** have Compose UI test infrastructure
+(`androidx.compose.ui:ui-test-junit4` is not in the version catalog, no
+`androidTest` source set on `:app`). Adding it would be a multi-PR detour
+(transitive Robolectric + ActivityScenario setup; F-Droid reproducible-build
+implications for `androidTest` configurations). Out of scope for PR6.
+
+Coverage is therefore split across:
+
+1. **`InsightAuditViewModelTest`** (Robolectric, `:app:testDebug`):
+   - `loads cached insight into Loaded state when present`.
+   - `surfaces NotCached when AiRepository returns null`.
+   - `surfaces Error on network failure`.
+   - `invalidate success transitions to Done state and emits event`.
+   - `invalidate failure leaves state in Loaded and emits error event`.
+   - `style snapshot reflects current AiPreferences at time of load`.
+2. **No new `AiRepository` test needed.** The existing `invalidate(identity)`
+   wraps the existing `client.invalidateInsight`, which is already covered
+   in `AiClientTest`. We are not adding new client methods.
+
+The visual layout is verified by manual smoke on the emulator + a Compose
+`@Preview` annotated function in `InsightAuditScreen.kt` for at least the
+`Loaded` (full payload) and `NotCached` states. Previews are not tests but
+they catch the most common Compose regressions (unresolved references,
+runtime composition crashes from null-handling bugs) at build time.
+
+## Risks
+
+- **Race vs another device invalidating mid-view.** Acceptable per the
+  non-goals; the screen is a snapshot, not a dashboard.
+- **`getCachedInsight` blocking.** It is a `POST` to the server (not a
+  local cache read). On a slow network, the audit screen may sit in
+  `Loading` for several seconds. Mitigation: show a progress indicator
+  from the first frame; the call already runs on `Dispatchers.IO` via the
+  `AiClient.execute` machinery.
+- **PR11 merge conflict in `BookDetailScreen.kt`.** Both PRs touch the
+  same `Scaffold { topBar = … }` block. Resolution is mechanical (PR11's
+  removal of the regenerate `TextButton` is in the `Column` body, PR6's
+  additions are in `TopAppBar.actions`). Call this out in the PR body.
+
+## References
+
+- `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §"PR6 — Insight
+  audit UI" and §"PR11 — Drop regenerate".
+- `data/ai/src/main/java/io/theficos/ereader/data/ai/AiClient.kt` — existing
+  `invalidateInsight` and `getInsight`.
+- `app/src/main/java/io/theficos/ereader/ui/bookdetail/BookDetailScreen.kt`
+  — current book-detail screen, the integration point for the new overflow.


### PR DESCRIPTION
## Summary

Adds a power-user "Inspect insight" debug screen reachable from a new overflow menu on the book-detail screen. Surfaces the cached AI insight metadata (model_id, prompt_version, schema_version, generated_at) and the live user style snapshot (tone, language), with a confirm-then-Invalidate flow that reuses the existing body-based `POST /ai/v1/insights/invalidate`.

- **No new server endpoint.** Reuses `getCachedInsight` and `invalidate` already on `AiRepository`/`AiClient`.
- **No DTO mutation.** `BookInsightResponse` already carries the cache-key fields we render.
- **No regenerate button** anywhere in the diff — coordinates with PR #19 (`feat/drop-regenerate-button`), which removes that pattern entirely. Invalidate + natural refresh on the next book-detail open replaces it at half the AI cost.

## Screen

```
┌──────────────────────────────────────────────┐
│ ← Inspect insight                            │
├──────────────────────────────────────────────┤
│  Cache key (from server)                     │
│    Model        gpt-4o-mini-2024-07-18       │
│    Prompt ver.  3                            │
│    Schema ver.  2                            │
│                                              │
│  Your current AI style                       │
│    Tone         neutral                      │
│    Language     auto                         │
│                                              │
│  Generated                                   │
│    3h ago                                    │
│    (2026-05-17T13:42:11Z)                    │
│                                              │
│  Sources (3)                                 │
│    · Wikipedia                               │
│      https://en.wikipedia.org/wiki/X         │
│    · OpenLibrary                             │
│      https://openlibrary.org/works/…         │
│    · AI model: gpt-4o-mini-2024-07-18        │
│                                              │
│  [ Invalidate cached insight ]               │
└──────────────────────────────────────────────┘
```

Tone/language live under a separate "Your current AI style" card and are sourced from `AiRepository.preferences.value?.style` — the server response does not carry the style that produced the cached row, so labeling those values as cached metadata would mislead.

URLs open via `LocalUriHandler.current.openUri(url)` (Chrome Custom Tabs / system browser). No new manifest permission; no new network destination; F-Droid posture preserved.

## Wiring

- New route `book/{id}/inspect-insight` in `AppNavGraph.kt`, accepting the local `Long` documentId (matches existing `book/{id}` / `reader/{docId}` routes; identity resolution happens inside the VM via `DocumentRepository.findById(...)?.identity`).
- New `IconButton(MoreVert)` + `DropdownMenu` in `BookDetailScreen.kt`'s `TopAppBar.actions` slot, with a single "Inspect insight" item.
- New `InsightAuditViewModelFactory` in `AppContainer.kt` mirroring the existing `BookDetailViewModelFactory` pattern.
- Post-invalidate refresh: the audit screen sets `savedStateHandle["insight_invalidated"] = true` on the previous back-stack entry and pops. The book-detail nav block observes the flag via a `LaunchedEffect` and calls `viewModel.retry()`, clearing the flag.

## State machine

`Loading` → `Loaded` | `NotCached` | `Error(message)` → user invalidates → `Invalidating` → `Done` (popBack) | back to `Loaded` (with Snackbar) on failure. A 404 on the invalidate call is swallowed and treated as `Done` — the row is already gone, which is exactly the state the user asked for.

## Test plan

- [x] `scripts/dgradle :app:testDebugUnitTest` — green (includes `InsightAuditViewModelTest`: Loaded, NotCached, load Error, unknown documentId, invalidate success, 404-as-success, invalidate failure, style snapshot, retry).
- [x] `scripts/dgradle :data:ai:testDebugUnitTest` — green (no new tests; existing `AiClientTest` already covers `invalidateInsight`).
- [x] `scripts/dgradle :app:lintDebug` — green.
- [ ] Manual emulator smoke: overflow → Inspect insight → confirm dialog → Snackbar on failure / popBack on success.

(No Compose UI test infrastructure in the repo today; adding `androidx.compose.ui:ui-test-junit4` + an `androidTest` sourceset on `:app` is a multi-PR detour with F-Droid reproducible-build implications. Out of scope per the spec.)

## Expected merge conflict with PR #19

Both PRs touch `BookDetailScreen.kt`:

- **PR #19** removes the `Regenerate insights` overflow item (this branch was cut from `main` before PR #19, so the file here still has the old `Not quite right? Regenerate` `TextButton` and its `RegenerateDialog`). PR #19 also drops several Material imports: `AlertDialog`, `OutlinedTextField`, `fillMaxWidth`, `mutableStateOf`, `remember`, `setValue`.
- **This PR** adds an `IconButton` + `DropdownMenu` to `TopAppBar.actions`, plus a `menuExpanded` `mutableStateOf` — and keeps the regenerate `TextButton` / `RegenerateDialog` (which PR #19 removes).

**Resolution sketch when PR #19 is merged first** (recommended order):

1. Drop the `TextButton("Not quite right? Regenerate")` block from this branch's `BookDetailScreen.kt` body.
2. Drop the `RegenerateDialog` composable + its imports (`AlertDialog`, `OutlinedTextField`, `fillMaxWidth`) — but KEEP `mutableStateOf` / `remember` / `setValue` because this PR uses them for `menuExpanded`.
3. Keep the `TopAppBar.actions` block + overflow menu from this PR.
4. Drop `viewModel.regenerate(...)` call from this PR; `BookDetailViewModel.regenerate(...)` itself is removed by PR #19.

Conflict is mechanical — no behavioral surprise.

## Spec / plan

- `docs/superpowers/specs/2026-05-17-insight-audit-ui-design.md`
- `docs/superpowers/plans/2026-05-17-insight-audit-ui.md`