### PR TITLE
feat: series continuity shelf

### DIFF
--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.theficos.ereader.auth.CalibreCredentialStore
 import io.theficos.ereader.core.identity.extractIdentity
+import io.theficos.ereader.core.metadata.readOpfBundle
 import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.db.SyncStateDao
 import io.theficos.ereader.data.opds.BookDownloader
@@ -139,6 +140,10 @@ class CatalogViewModel(
                 val identity = extractIdentity(file)
                 val existing = docs.findByIdentity(identity)
                 if (existing == null) {
+                    // Best-effort: read the OPF for series metadata so PR8's
+                    // continuity shelf can include this book the moment it lands.
+                    // Failures fall back to a title-only bundle (no series).
+                    val opf = readOpfBundle(file, fallbackTitle = pub.title)
                     docs.insert(
                         identity = identity,
                         title = pub.title,
@@ -147,6 +152,8 @@ class CatalogViewModel(
                         localPath = file.absolutePath,
                         coverPath = coverFile?.absolutePath,
                         downloadedAt = System.currentTimeMillis(),
+                        seriesName = opf.seriesName,
+                        seriesIndex = opf.seriesPosition?.toDouble(),
                     )
                 } else {
                     file.delete()

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
@@ -82,6 +82,7 @@ fun LibraryScreen(
 
     val items by viewModel.items.collectAsState()
     val cont by viewModel.continueReading.collectAsState()
+    val seriesCandidates by viewModel.seriesContinuationCandidates.collectAsState()
     var menuFor by remember { mutableStateOf<Document?>(null) }
     var pendingDelete by remember { mutableStateOf<Document?>(null) }
     var pendingRestart by remember { mutableStateOf<Document?>(null) }
@@ -154,6 +155,14 @@ fun LibraryScreen(
             cont?.let { row ->
                 item(span = { GridItemSpan(maxLineSpan) }) {
                     ContinueReadingCard(row = row, onClick = { onOpenBook(row.document.id) })
+                }
+            }
+            if (seriesCandidates.isNotEmpty()) {
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    SeriesContinuationShelf(
+                        books = seriesCandidates,
+                        onBookClick = { onOpenBook(it) },
+                    )
                 }
             }
             item(span = { GridItemSpan(maxLineSpan) }) {

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
@@ -85,6 +85,16 @@ class LibraryViewModel(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
+    /**
+     * "Continue your series" candidates for the library home shelf. Reactive —
+     * re-emits when any `documents` or `progress` row changes.
+     *
+     * Pure local Room query, no AI, no server call. See PR8.
+     */
+    val seriesContinuationCandidates: StateFlow<List<Document>> =
+        docs.observeSeriesContinuationCandidates()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
     private val _events = MutableSharedFlow<LibraryEvent>(extraBufferCapacity = 4)
     val events: SharedFlow<LibraryEvent> = _events.asSharedFlow()
 

--- a/app/src/main/java/io/theficos/ereader/ui/library/SeriesContinuationShelf.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/SeriesContinuationShelf.kt
@@ -1,0 +1,111 @@
+package io.theficos.ereader.ui.library
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.theficos.ereader.core.model.Document
+import io.theficos.ereader.ui.components.CoverImage
+import io.theficos.ereader.ui.components.SectionLabel
+
+/**
+ * Horizontal "Continue your series" shelf shown above the main library grid
+ * on the home screen.
+ *
+ * Renders nothing when [books] is empty — callers can include it unconditionally
+ * and it will simply disappear from layout.
+ */
+@Composable
+fun SeriesContinuationShelf(
+    books: List<Document>,
+    onBookClick: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (books.isEmpty()) return
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = SHELF_CONTENT_DESCRIPTION },
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        SectionLabel(SHELF_HEADER)
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(vertical = 4.dp),
+        ) {
+            items(items = books, key = { it.id }) { book ->
+                SeriesShelfItem(
+                    book = book,
+                    onClick = { onBookClick(book.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SeriesShelfItem(
+    book: Document,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .width(96.dp)
+            .clickable { onClick() },
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        CoverImage(
+            source = book.coverPath,
+            title = book.title,
+            author = book.author,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(2f / 3f),
+        )
+        Text(
+            text = book.title,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+        val seriesLabel = buildSeriesLabel(book.seriesName, book.seriesIndex)
+        if (seriesLabel != null) {
+            Text(
+                text = seriesLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+internal const val SHELF_HEADER: String = "Continue your series"
+internal const val SHELF_CONTENT_DESCRIPTION: String = "Continue your series shelf"
+
+internal fun buildSeriesLabel(seriesName: String?, seriesIndex: Double?): String? {
+    val name = seriesName?.takeIf { it.isNotBlank() } ?: return null
+    val bookN = seriesIndex?.let { idx ->
+        // Render whole numbers without ".0" (1.0 -> "1", 2.5 -> "2.5").
+        if (idx == idx.toLong().toDouble()) " · Book ${idx.toLong()}"
+        else " · Book $idx"
+    } ?: ""
+    return "$name$bookN"
+}

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
@@ -240,4 +240,59 @@ class LibraryViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    private suspend fun seedSeries(
+        contentHash: String,
+        title: String,
+        seriesName: String?,
+        seriesIndex: Double?,
+        percent: Double = 0.0,
+        finishedAt: Long? = null,
+        updatedAt: Long = 0L,
+    ): Long {
+        val docId = db.documentDao().insert(DocumentEntity(
+            metadataId = contentHash, contentHash = contentHash, title = title, author = null,
+            downloadUrl = "u", localPath = "p", coverPath = null, downloadedAt = 0,
+            seriesName = seriesName, seriesIndex = seriesIndex,
+        ))
+        if (percent > 0.0 || finishedAt != null) {
+            progress.save(DomainProgress(
+                documentId = docId, locator = "loc", percent = percent,
+                updatedAt = updatedAt, finishedAt = finishedAt,
+            ))
+        }
+        return docId
+    }
+
+    @Test fun `seriesContinuationCandidates emits the unread sibling-in-series`() = runTest {
+        seedSeries("h1", "Foundation 1", "Foundation", 1.0, percent = 1.0, finishedAt = 100L, updatedAt = 100L)
+        val candidateId = seedSeries("h2", "Foundation 2", "Foundation", 2.0)
+        vm.seriesContinuationCandidates.test {
+            var emission = awaitItem()
+            while (emission.size != 1) emission = awaitItem()
+            assertThat(emission.map { it.id }).containsExactly(candidateId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `seriesContinuationCandidates re-emits when a candidate is marked finished`() = runTest {
+        val sibling = seedSeries("h1", "Foundation 1", "Foundation", 1.0, percent = 1.0, finishedAt = 100L, updatedAt = 100L)
+        val candidate = seedSeries("h2", "Foundation 2", "Foundation", 2.0)
+        vm.seriesContinuationCandidates.test {
+            var emission = awaitItem()
+            while (emission.size != 1) emission = awaitItem()
+            assertThat(emission.map { it.id }).containsExactly(candidate)
+            // Mark the candidate finished; it should drop off the shelf.
+            progress.save(DomainProgress(
+                documentId = candidate, locator = "loc", percent = 1.0,
+                updatedAt = 999L, finishedAt = 999L,
+            ))
+            var next = awaitItem()
+            while (next.isNotEmpty()) next = awaitItem()
+            assertThat(next).isEmpty()
+            // Suppress unused-variable lint on `sibling` (kept for clarity).
+            assertThat(sibling).isGreaterThan(0L)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }

--- a/app/src/test/java/io/theficos/ereader/ui/library/SeriesContinuationShelfTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/SeriesContinuationShelfTest.kt
@@ -1,0 +1,40 @@
+package io.theficos.ereader.ui.library
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure-Kotlin tests for the label-builder helper. The composable's rendering
+ * behavior is exercised end-to-end by [LibraryViewModelTest] via the StateFlow
+ * it consumes; the on-empty "render nothing" branch is verified by inspection
+ * (single `if (books.isEmpty()) return`).
+ *
+ * A Robolectric Compose runner would be a nice-to-have, but adding the
+ * `androidx.compose.ui:ui-test-junit4` dependency is out of scope for PR8;
+ * none of the existing UI surfaces have Compose tests in this module yet.
+ */
+class SeriesContinuationShelfTest {
+
+    @Test fun `label is null when series name is null`() {
+        assertThat(buildSeriesLabel(null, null)).isNull()
+        assertThat(buildSeriesLabel(null, 2.0)).isNull()
+    }
+
+    @Test fun `label is null when series name is blank`() {
+        assertThat(buildSeriesLabel("", 2.0)).isNull()
+        assertThat(buildSeriesLabel("   ", 2.0)).isNull()
+    }
+
+    @Test fun `label shows series name only when index is null`() {
+        assertThat(buildSeriesLabel("Foundation", null)).isEqualTo("Foundation")
+    }
+
+    @Test fun `label drops trailing zero on whole-number index`() {
+        assertThat(buildSeriesLabel("Foundation", 1.0)).isEqualTo("Foundation · Book 1")
+        assertThat(buildSeriesLabel("Foundation", 12.0)).isEqualTo("Foundation · Book 12")
+    }
+
+    @Test fun `label preserves fractional index for half-book entries`() {
+        assertThat(buildSeriesLabel("Discworld", 2.5)).isEqualTo("Discworld · Book 2.5")
+    }
+}

--- a/core/metadata/src/main/java/io/theficos/ereader/core/metadata/EpubOpfReader.kt
+++ b/core/metadata/src/main/java/io/theficos/ereader/core/metadata/EpubOpfReader.kt
@@ -1,0 +1,31 @@
+package io.theficos.ereader.core.metadata
+
+import java.io.File
+import java.io.IOException
+import java.util.zip.ZipException
+import java.util.zip.ZipFile
+
+/**
+ * Reads the OPF document out of an EPUB file and returns a [MetadataBundle].
+ *
+ * Best-effort: any IO/zip/parse failure produces a [MetadataBundle] built from
+ * [fallbackTitle] alone, matching [OpfMetadataExtractor.extract]'s tolerance.
+ */
+fun readOpfBundle(epub: File, fallbackTitle: String): MetadataBundle {
+    val opfBytes = try {
+        ZipFile(epub).use { zip ->
+            val container = zip.getEntry("META-INF/container.xml") ?: return@use null
+            val containerXml = zip.getInputStream(container).use { it.readBytes() }.decodeToString()
+            val opfPath = Regex("""full-path="([^"]+)"""")
+                .find(containerXml)?.groupValues?.get(1)
+                ?: return@use null
+            val opfEntry = zip.getEntry(opfPath) ?: return@use null
+            zip.getInputStream(opfEntry).use { it.readBytes() }
+        }
+    } catch (_: ZipException) { null
+    } catch (_: IOException) { null
+    } catch (_: SecurityException) { null }
+    return opfBytes
+        ?.let { OpfMetadataExtractor.extract(it, fallbackTitle) }
+        ?: MetadataBundle(title = fallbackTitle)
+}

--- a/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
@@ -9,4 +9,6 @@ data class Document(
     val localPath: String,
     val coverPath: String?,
     val downloadedAt: Long,
+    val seriesName: String? = null,
+    val seriesIndex: Double? = null,
 )

--- a/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/5.json
+++ b/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/5.json
@@ -1,0 +1,233 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "b6e24b2882e14523dc5c419103669e50",
+    "entities": [
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `metadataId` TEXT, `contentHash` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `downloadUrl` TEXT NOT NULL, `localPath` TEXT NOT NULL, `coverPath` TEXT, `downloadedAt` INTEGER NOT NULL, `seriesName` TEXT, `seriesIndex` REAL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_documents_metadataId",
+            "unique": true,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_documents_contentHash",
+            "unique": true,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_documents_seriesName_seriesIndex",
+            "unique": false,
+            "columnNames": [
+              "seriesName",
+              "seriesIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_documents_seriesName_seriesIndex` ON `${TABLE_NAME}` (`seriesName`, `seriesIndex`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `documentId` INTEGER NOT NULL, `locator` TEXT NOT NULL, `percent` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `finishedAt` INTEGER, FOREIGN KEY(`documentId`) REFERENCES `documents`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locator",
+            "columnName": "locator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percent",
+            "columnName": "percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_documentId",
+            "unique": true,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_progress_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "documents",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `lastPulledAt` INTEGER NOT NULL, PRIMARY KEY(`tableName`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPulledAt",
+            "columnName": "lastPulledAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b6e24b2882e14523dc5c419103669e50')"
+    ]
+  }
+}

--- a/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
@@ -13,6 +13,20 @@ class DocumentRepository(private val dao: DocumentDao) {
     fun observeLibrary(): Flow<List<Document>> =
         dao.observeAll().map { rows -> rows.map { it.toDomain() } }
 
+    /**
+     * Books eligible for the library home "Continue your series" shelf: any book
+     * the user has not finished and barely (or not at all) started, where some
+     * other book in the same `seriesName` (case-insensitive) has a finish.
+     *
+     * Capped at [SERIES_CONTINUATION_MAX_ITEMS]; "barely started" is governed
+     * by [SERIES_CONTINUATION_STARTED_THRESHOLD] on `progress.percent`.
+     */
+    fun observeSeriesContinuationCandidates(): Flow<List<Document>> =
+        dao.observeSeriesContinuationCandidates(
+            startedThreshold = SERIES_CONTINUATION_STARTED_THRESHOLD,
+            maxItems = SERIES_CONTINUATION_MAX_ITEMS,
+        ).map { rows -> rows.map { it.toDomain() } }
+
     suspend fun findByIdentity(identity: DocumentIdentity): Document? {
         identity.metadataId?.let { dao.findByMetadataId(it)?.let { return it.toDomain() } }
         return dao.findByContentHash(identity.contentHash)?.toDomain()
@@ -49,6 +63,8 @@ class DocumentRepository(private val dao: DocumentDao) {
         localPath: String,
         coverPath: String?,
         downloadedAt: Long,
+        seriesName: String? = null,
+        seriesIndex: Double? = null,
     ): Long = dao.insert(DocumentEntity(
         metadataId = identity.metadataId,
         contentHash = identity.contentHash,
@@ -58,6 +74,8 @@ class DocumentRepository(private val dao: DocumentDao) {
         localPath = localPath,
         coverPath = coverPath,
         downloadedAt = downloadedAt,
+        seriesName = seriesName?.takeIf { it.isNotBlank() },
+        seriesIndex = seriesIndex,
     ))
 
     private fun DocumentEntity.toDomain(): Document = Document(
@@ -69,5 +87,19 @@ class DocumentRepository(private val dao: DocumentDao) {
         localPath = localPath,
         coverPath = coverPath,
         downloadedAt = downloadedAt,
+        seriesName = seriesName,
+        seriesIndex = seriesIndex,
     )
+
+    companion object {
+        /** Per-tile cap on the "Continue your series" shelf — keeps the LazyRow bounded. */
+        const val SERIES_CONTINUATION_MAX_ITEMS: Int = 12
+
+        /**
+         * Books with `progress.percent` below this threshold are treated as
+         * "not really started" and remain eligible for the continuation shelf.
+         * Tolerates an accidental open without burying the prompt.
+         */
+        const val SERIES_CONTINUATION_STARTED_THRESHOLD: Double = 0.05
+    }
 }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentDao.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentDao.kt
@@ -27,6 +27,57 @@ interface DocumentDao {
     @Query("SELECT * FROM documents ORDER BY downloadedAt DESC")
     fun observeAll(): Flow<List<DocumentEntity>>
 
+    /**
+     * "Continue your series" candidates for PR8's library-home shelf.
+     *
+     * A candidate is any book where:
+     *   - the book itself has a non-empty `seriesName`,
+     *   - the user has neither finished nor meaningfully started it
+     *     (no progress row, or `percent < startedThreshold` and `finishedAt IS NULL`),
+     *   - at least one other book in the same `seriesName` (case-insensitive)
+     *     has a `progress.finishedAt` set.
+     *
+     * Order: series whose latest finish is most recent first, then ascending
+     * `seriesIndex` within a series, with NULL indices pushed to the end and a
+     * stable title/id tiebreaker.
+     */
+    @Query(
+        """
+        WITH finished_series AS (
+            SELECT sibling.seriesName       AS seriesName,
+                   MAX(sp.finishedAt)       AS lastFinishedAt
+            FROM documents AS sibling
+            JOIN progress  AS sp ON sp.documentId = sibling.id
+            WHERE sibling.seriesName IS NOT NULL
+              AND sibling.seriesName != ''
+              AND sp.finishedAt IS NOT NULL
+            GROUP BY sibling.seriesName COLLATE NOCASE
+        )
+        SELECT d.*
+        FROM documents AS d
+        JOIN finished_series fs
+          ON fs.seriesName = d.seriesName COLLATE NOCASE
+        WHERE d.seriesName IS NOT NULL
+          AND d.seriesName != ''
+          AND NOT EXISTS (
+              SELECT 1 FROM progress AS p
+              WHERE p.documentId = d.id
+                AND (p.finishedAt IS NOT NULL OR p.percent >= :startedThreshold)
+          )
+        ORDER BY
+          fs.lastFinishedAt DESC,
+          (d.seriesIndex IS NULL) ASC,
+          d.seriesIndex ASC,
+          d.title COLLATE NOCASE ASC,
+          d.id ASC
+        LIMIT :maxItems
+        """
+    )
+    fun observeSeriesContinuationCandidates(
+        startedThreshold: Double,
+        maxItems: Int,
+    ): Flow<List<DocumentEntity>>
+
     @Query("DELETE FROM documents WHERE id = :id")
     suspend fun deleteById(id: Long): Int
 

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
@@ -9,6 +9,10 @@ import androidx.room.PrimaryKey
     indices = [
         Index(value = ["metadataId"], unique = true),
         Index(value = ["contentHash"], unique = true),
+        Index(
+            value = ["seriesName", "seriesIndex"],
+            name = "index_documents_seriesName_seriesIndex",
+        ),
     ],
 )
 data class DocumentEntity(
@@ -21,4 +25,6 @@ data class DocumentEntity(
     val localPath: String,
     val coverPath: String?,
     val downloadedAt: Long,
+    val seriesName: String? = null,
+    val seriesIndex: Double? = null,
 )

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [DocumentEntity::class, ProgressEntity::class, SyncStateEntity::class],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 abstract class EReaderDatabase : RoomDatabase() {
@@ -43,9 +43,29 @@ abstract class EReaderDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Adds seriesName + seriesIndex columns to local `documents` and the
+         * composite index that PR8's "Continue your series" shelf uses to find
+         * sibling-in-series candidates.
+         *
+         * Note: PR1 (server-side library_items) was supposed to ship the Android
+         * half of this change, but its diff only landed the server migration. PR8
+         * picks it up.
+         */
+        internal val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE documents ADD COLUMN seriesName TEXT")
+                db.execSQL("ALTER TABLE documents ADD COLUMN seriesIndex REAL")
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_documents_seriesName_seriesIndex " +
+                        "ON documents(seriesName, seriesIndex)"
+                )
+            }
+        }
+
         fun build(context: Context): EReaderDatabase =
             Room.databaseBuilder(context, EReaderDatabase::class.java, "ereader.db")
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                 .build()
     }
 }

--- a/data/local/src/test/java/io/theficos/ereader/data/local/db/DocumentDaoTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/db/DocumentDaoTest.kt
@@ -3,6 +3,7 @@ package io.theficos.ereader.data.local.db
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -16,12 +17,14 @@ import org.robolectric.annotation.Config
 class DocumentDaoTest {
     private lateinit var db: EReaderDatabase
     private lateinit var dao: DocumentDao
+    private lateinit var progressDao: ProgressDao
 
     @Before fun setUp() {
         db = Room.inMemoryDatabaseBuilder(
             ApplicationProvider.getApplicationContext(), EReaderDatabase::class.java
         ).allowMainThreadQueries().build()
         dao = db.documentDao()
+        progressDao = db.progressDao()
     }
 
     @After fun tearDown() { db.close() }
@@ -69,5 +72,161 @@ class DocumentDaoTest {
         val row = dao.findById(id)
         assertThat(row).isNotNull()
         assertThat(row!!.coverPath).isEqualTo("/tmp/y.jpg")
+    }
+
+    // ---- observeSeriesContinuationCandidates (PR8) ----
+
+    private suspend fun insertBook(
+        contentHash: String,
+        title: String,
+        seriesName: String? = null,
+        seriesIndex: Double? = null,
+    ): Long = dao.insert(DocumentEntity(
+        metadataId = contentHash,
+        contentHash = contentHash,
+        title = title,
+        author = null,
+        downloadUrl = "u",
+        localPath = "p",
+        coverPath = null,
+        downloadedAt = 0L,
+        seriesName = seriesName,
+        seriesIndex = seriesIndex,
+    ))
+
+    private suspend fun setProgress(
+        documentId: Long,
+        percent: Double = 0.0,
+        finishedAt: Long? = null,
+        updatedAt: Long = 0L,
+    ) {
+        progressDao.upsert(ProgressEntity(
+            documentId = documentId,
+            locator = "loc",
+            percent = percent,
+            updatedAt = updatedAt,
+            localUpdatedAt = updatedAt,
+            syncedAt = 0L,
+            finishedAt = finishedAt,
+        ))
+    }
+
+    private suspend fun shelf(): List<DocumentEntity> =
+        dao.observeSeriesContinuationCandidates(startedThreshold = 0.05, maxItems = 12).first()
+
+    @Test fun `shelf includes unread sibling when another book in the series is finished`() = runTest {
+        val finished = insertBook("h1", "Foundation", seriesName = "Foundation", seriesIndex = 1.0)
+        val candidate = insertBook("h2", "Foundation and Empire", seriesName = "Foundation", seriesIndex = 2.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+
+        val result = shelf()
+
+        assertThat(result.map { it.id }).containsExactly(candidate)
+    }
+
+    @Test fun `shelf is empty when nothing is finished`() = runTest {
+        insertBook("h1", "Foundation", seriesName = "Foundation", seriesIndex = 1.0)
+        insertBook("h2", "Foundation and Empire", seriesName = "Foundation", seriesIndex = 2.0)
+
+        assertThat(shelf()).isEmpty()
+    }
+
+    @Test fun `shelf excludes the candidate when the user already finished it`() = runTest {
+        val finished = insertBook("h1", "Foundation", seriesName = "Foundation", seriesIndex = 1.0)
+        val also = insertBook("h2", "Foundation and Empire", seriesName = "Foundation", seriesIndex = 2.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+        setProgress(also, percent = 1.0, finishedAt = 200L)
+
+        assertThat(shelf()).isEmpty()
+    }
+
+    @Test fun `shelf excludes the candidate when the user has started past the threshold`() = runTest {
+        val finished = insertBook("h1", "Foundation", seriesName = "Foundation", seriesIndex = 1.0)
+        val started = insertBook("h2", "Foundation and Empire", seriesName = "Foundation", seriesIndex = 2.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+        setProgress(started, percent = 0.5, updatedAt = 150L)
+
+        assertThat(shelf()).isEmpty()
+    }
+
+    @Test fun `shelf includes a candidate barely below the started threshold`() = runTest {
+        val finished = insertBook("h1", "Foundation", seriesName = "Foundation", seriesIndex = 1.0)
+        val barely = insertBook("h2", "Foundation and Empire", seriesName = "Foundation", seriesIndex = 2.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+        // Below the 5% threshold and not finished: still eligible.
+        setProgress(barely, percent = 0.02, updatedAt = 150L)
+
+        assertThat(shelf().map { it.id }).containsExactly(barely)
+    }
+
+    @Test fun `shelf matches series name case-insensitively`() = runTest {
+        val finished = insertBook("h1", "foundation v1", seriesName = "foundation", seriesIndex = 1.0)
+        val candidate = insertBook("h2", "Foundation v2", seriesName = "Foundation", seriesIndex = 2.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+
+        assertThat(shelf().map { it.id }).containsExactly(candidate)
+    }
+
+    @Test fun `shelf surfaces multiple series at once, ordered by most recently finished sibling`() = runTest {
+        val foundationA = insertBook("hf1", "Foundation 1", seriesName = "Foundation", seriesIndex = 1.0)
+        val foundationB = insertBook("hf2", "Foundation 2", seriesName = "Foundation", seriesIndex = 2.0)
+        val duneA = insertBook("hd1", "Dune 1", seriesName = "Dune", seriesIndex = 1.0)
+        val duneB = insertBook("hd2", "Dune 2", seriesName = "Dune", seriesIndex = 2.0)
+        setProgress(duneA, percent = 1.0, finishedAt = 100L)         // older finish
+        setProgress(foundationA, percent = 1.0, finishedAt = 500L)   // newer finish
+
+        val ids = shelf().map { it.id }
+        assertThat(ids).containsExactly(foundationB, duneB).inOrder()
+    }
+
+    @Test fun `shelf orders within a series by seriesIndex ASC`() = runTest {
+        val finished = insertBook("h0", "Foundation 0", seriesName = "Foundation", seriesIndex = 0.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+        val b3 = insertBook("h3", "Foundation 3", seriesName = "Foundation", seriesIndex = 3.0)
+        val b1 = insertBook("h1", "Foundation 1", seriesName = "Foundation", seriesIndex = 1.0)
+        val b2 = insertBook("h2", "Foundation 2", seriesName = "Foundation", seriesIndex = 2.0)
+
+        val ids = shelf().map { it.id }
+        assertThat(ids).containsExactly(b1, b2, b3).inOrder()
+    }
+
+    @Test fun `shelf pushes NULL seriesIndex to the end within a series`() = runTest {
+        val finished = insertBook("h0", "Foundation 0", seriesName = "Foundation", seriesIndex = 0.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+        val noIdx = insertBook("hnone", "Foundation Bonus", seriesName = "Foundation", seriesIndex = null)
+        val b1 = insertBook("h1", "Foundation 1", seriesName = "Foundation", seriesIndex = 1.0)
+
+        val ids = shelf().map { it.id }
+        assertThat(ids).containsExactly(b1, noIdx).inOrder()
+    }
+
+    @Test fun `shelf caps the result list`() = runTest {
+        val finished = insertBook("hfin", "Series A 1", seriesName = "Series A", seriesIndex = 1.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+        repeat(15) { i ->
+            insertBook("h${i + 2}", "Series A ${i + 2}", seriesName = "Series A", seriesIndex = (i + 2).toDouble())
+        }
+
+        assertThat(shelf()).hasSize(12)
+    }
+
+    @Test fun `books with NULL seriesName never appear on the shelf`() = runTest {
+        val finished = insertBook("hf1", "Foundation", seriesName = "Foundation", seriesIndex = 1.0)
+        setProgress(finished, percent = 1.0, finishedAt = 100L)
+        insertBook("hbare", "Standalone novel", seriesName = null, seriesIndex = null)
+        insertBook("hempty", "Series-less", seriesName = "", seriesIndex = null)
+        val candidate = insertBook("hf2", "Foundation 2", seriesName = "Foundation", seriesIndex = 2.0)
+
+        assertThat(shelf().map { it.id }).containsExactly(candidate)
+    }
+
+    @Test fun `shelf is reactive to a new finish in a sibling book`() = runTest {
+        val a = insertBook("h1", "Foundation 1", seriesName = "Foundation", seriesIndex = 1.0)
+        val b = insertBook("h2", "Foundation 2", seriesName = "Foundation", seriesIndex = 2.0)
+        // Initially nothing finished → empty shelf.
+        assertThat(shelf()).isEmpty()
+        // Mark book 1 finished → book 2 should now appear.
+        setProgress(a, percent = 1.0, finishedAt = 100L)
+        assertThat(shelf().map { it.id }).containsExactly(b)
     }
 }

--- a/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
@@ -45,5 +45,41 @@ class MigrationTest {
         }
     }
 
+    @Test fun `migrate 4 to 5 adds seriesName and seriesIndex columns plus index`() {
+        helper.createDatabase(DB, 4).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, localPath, coverPath, downloadedAt) " +
+                    "VALUES (7, 'm7', 'h7', 'Pre-migration title', NULL, 'u', 'p', NULL, 17)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(DB, 5, true, EReaderDatabase.MIGRATION_4_5).use { db ->
+            // Existing row survives with NULLs for the new columns.
+            db.query("SELECT seriesName, seriesIndex, title FROM documents WHERE id=7").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.isNull(0)).isTrue()
+                assertThat(c.isNull(1)).isTrue()
+                assertThat(c.getString(2)).isEqualTo("Pre-migration title")
+            }
+            // The new index exists by the contracted name.
+            db.query(
+                "SELECT name FROM sqlite_master " +
+                    "WHERE type='index' AND name='index_documents_seriesName_seriesIndex'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+            }
+            // New columns round-trip.
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, localPath, coverPath, downloadedAt, seriesName, seriesIndex) " +
+                    "VALUES (8, 'm8', 'h8', 'Post-migration title', NULL, 'u', 'p', NULL, 18, 'Foundation', 2.5)"
+            )
+            db.query("SELECT seriesName, seriesIndex FROM documents WHERE id=8").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getString(0)).isEqualTo("Foundation")
+                assertThat(c.getDouble(1)).isEqualTo(2.5)
+            }
+        }
+    }
+
     private companion object { const val DB = "migration-test.db" }
 }

--- a/docs/superpowers/plans/2026-05-17-series-shelf.md
+++ b/docs/superpowers/plans/2026-05-17-series-shelf.md
@@ -1,0 +1,115 @@
+# PR8 — Series continuity shelf: implementation plan
+
+**Date:** 2026-05-17
+**Spec:** `docs/superpowers/specs/2026-05-17-series-shelf-design.md`
+**Branch:** `feat/series-shelf` off `main`.
+
+## Overview
+
+Android-only PR. Adds a horizontal "Continue your series" shelf above the main library grid that lists books the user has not started, whose series has a finished sibling. Pure Room query; no server work; no AI.
+
+Note: the brief assumed PR1 had landed the Room migration adding `series_name` + `series_index` to the local `documents` table. It hadn't — only the server-side `library_items` table shipped in PR1. **PR8 lands the Android-side Room migration (4 → 5) as well**, documented in the PR body.
+
+## Sequence
+
+### Phase 1 — Room schema
+
+1. Extend `DocumentEntity` with `seriesName: String?` and `seriesIndex: Double?`. Add an `Index("seriesName")` (non-unique) in `@Entity(indices = ...)`.
+2. Bump `@Database(version = 5)` and add `MIGRATION_4_5` to `EReaderDatabase` companion. Migration SQL:
+   ```sql
+   ALTER TABLE documents ADD COLUMN seriesName TEXT;
+   ALTER TABLE documents ADD COLUMN seriesIndex REAL;
+   CREATE INDEX IF NOT EXISTS index_documents_seriesName ON documents(seriesName);
+   ```
+3. Register `MIGRATION_4_5` in `addMigrations(...)`.
+4. Run `scripts/dgradle :data:local:kspDebugKotlin` to regenerate the Room schema JSON at `data/local/schemas/.../5.json`. Commit the new schema file.
+
+**TDD checkpoint:** add `MigrationTest`'s `migrate 4 to 5` case BEFORE touching `EReaderDatabase`. It must fail (no MIGRATION_4_5 exists), then pass once the migration lands.
+
+### Phase 2 — DAO query
+
+5. Add `DocumentDao.observeSeriesContinuationCandidates(startedThreshold: Double, maxItems: Int): Flow<List<DocumentEntity>>` with the SQL from the spec.
+6. Add the DAO tests listed in the spec (`DocumentDaoTest`):
+   - Finished sibling + unread candidate → returned.
+   - No finished books → empty.
+   - User finished the candidate too → excluded.
+   - Started past threshold but not finished → excluded.
+   - Case-insensitive match.
+   - Multi-series fan-out.
+   - Order within series by `seriesIndex ASC`.
+   - Cap of 12.
+   - NULL seriesName never appears.
+
+Write the failing tests first, then implement the query body until they pass.
+
+### Phase 3 — Repository + insert plumbing
+
+7. Widen `DocumentRepository.insert(...)` with `seriesName: String? = null` and `seriesIndex: Double? = null` parameters (defaulted to null so existing callers compile).
+8. Add `DocumentRepository.observeSeriesContinuationCandidates(): Flow<List<Document>>`, wiring through the DAO with `startedThreshold = 0.05`, `maxItems = 12` as private companion constants.
+9. Update `Document` (`core/model`) to carry `seriesName: String?` and `seriesIndex: Double?`. Update the `toDomain()` mapper.
+10. Update download-path call sites (find via `grep -rn "documentRepository.insert\|DocumentRepository.insert\|\.insert("` under `app/src/main`) to thread `MetadataBundle.seriesName` and `seriesPosition?.toDouble()` through to the insert. Most importantly: `BookDownloader` or whoever creates a `Document` from the OPF.
+
+### Phase 4 — ViewModel
+
+11. Add `seriesContinuationCandidates: StateFlow<List<Document>>` to `LibraryViewModel`, sourced from `docs.observeSeriesContinuationCandidates()`, `stateIn(...)` with the same `WhileSubscribed(5000)` cadence the rest of the file uses.
+12. Add the `LibraryViewModelTest` cases:
+    - Sibling finished + candidate unread → flow emits list of 1.
+    - Mark candidate finished → flow emits empty list.
+
+### Phase 5 — UI
+
+13. Add `SeriesContinuationShelf.kt` composable per spec.
+14. Wire it into `LibraryScreen` as a full-span grid item, above `ContinueReadingCard`. Render only when the list is non-empty.
+15. Add Compose UI test for the shelf (Robolectric): renders nothing on empty list, renders titles + section label on non-empty, click invokes callback.
+
+### Phase 6 — Verify, commit, PR
+
+16. Run:
+    ```bash
+    scripts/dgradle :data:local:testDebugUnitTest
+    scripts/dgradle :app:testDebugUnitTest
+    scripts/dgradle :app:lintDebug
+    ```
+    All must be green.
+17. Commit. Single commit, message `:sparkles: feat: series continuity shelf on library home`. NO Claude attribution.
+18. `git push -u origin feat/series-shelf`.
+19. `gh pr create --base main --head feat/series-shelf` with the body called out in the brief: summary, the SQL query verbatim, test plan, GPT verdict, explicit note "deterministic — no AI calls", explicit note about the unexpected Room migration.
+
+## Files touched
+
+**Modified:**
+
+- `core/model/src/main/java/io/theficos/ereader/core/model/Document.kt` — add two fields.
+- `data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt` — add two fields + index.
+- `data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentDao.kt` — add `observeSeriesContinuationCandidates`.
+- `data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt` — version bump + MIGRATION_4_5.
+- `data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt` — widen `insert`, add new observer.
+- `app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt` — add new StateFlow.
+- `app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt` — render the shelf.
+- Any download-path call site of `DocumentRepository.insert` (TBD by grep in Phase 3 step 10).
+- `data/local/src/test/java/io/theficos/ereader/data/local/db/DocumentDaoTest.kt` — new tests.
+- `data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt` — new 4→5 test.
+- `app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt` — new tests.
+
+**New:**
+
+- `app/src/main/java/io/theficos/ereader/ui/library/SeriesContinuationShelf.kt`
+- `app/src/test/java/io/theficos/ereader/ui/library/SeriesContinuationShelfTest.kt`
+- `data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/5.json` (generated)
+- `docs/superpowers/specs/2026-05-17-series-shelf-design.md` (this PR)
+- `docs/superpowers/plans/2026-05-17-series-shelf.md` (this PR)
+
+## Risks during execution
+
+- **Generated schema JSON.** If the KSP build doesn't run, the `5.json` schema file won't appear and the migration test will fail at runtime (Room sanity-check). Fix: run `:data:local:kspDebugKotlin` explicitly before testing.
+- **Existing test fragility.** `DocumentDaoTest` and `MigrationTest` assume version-4 column shape. New tests for the version-5 schema must coexist with the older fixtures. The older `migrate 2 to 3` test uses a hand-written `documents` table SQL and is unaffected.
+- **`Document` data class fan-out.** Adding two fields to `core.model.Document` will surface compile errors at every constructor call site. Each site needs to be checked for whether passing `null` is correct (it almost always will be).
+- **Compose test runner setup.** If no Compose UI tests exist in the `app` module yet, configure `androidx.compose.ui.test.junit4` deps. (Spot-check `app/build.gradle.kts` first; if Compose test runner isn't there, fall back to a simpler `runComposeUiTest` block from `androidx.compose.ui.test.runComposeUiTest`.)
+
+## Definition of done
+
+- Three test commands above all green.
+- Spec + plan committed.
+- PR open on GitHub against `main`.
+- GPT architect verdict captured in PR body.
+- No Claude attribution anywhere.

--- a/docs/superpowers/specs/2026-05-17-series-shelf-design.md
+++ b/docs/superpowers/specs/2026-05-17-series-shelf-design.md
@@ -1,0 +1,212 @@
+# PR8 — Series continuity shelf (Android-only)
+
+**Date:** 2026-05-17
+**Status:** Spec for implementation; design locked in `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §"PR8".
+
+## Problem
+
+Quire users often acquire a series in chunks (book 1 first, then 2–4 once they like the first). Today the library home is a flat grid sorted by recent read / added. A reader who just finished book 2 of *Foundation* sees no signal that book 3 is sitting unread one row down — the title doesn't even hint at series membership unless the publisher embedded it in the EPUB title string.
+
+A dedicated **"Continue your series"** horizontal shelf at the top of the library fixes that. It is purely deterministic, computed locally, and shows only books whose sibling-in-series the user has actually finished.
+
+## Non-goals
+
+- Server-side series logic. PR1 added a server-side `library_items.series_name`, but PR8 reads only local Room data — the shelf must work offline and must not depend on the server having upgraded `library_items` ingestion for every book.
+- AI-derived series detection. We trust EPUB OPF `calibre:series` (already extracted by `:core:metadata`).
+- Cross-author series ("read everything by this author"). That's a different feature.
+- Reading time / progress estimates per book. PR9 owns library stats.
+- Reordering the main library grid. The shelf appears *above* the existing grid, no other changes.
+- Empty-state UX. When the shelf is empty (no finished sibling-in-series), it renders nothing — no "no series yet" placeholder.
+
+## Schema
+
+PR1 (`4a79c7c`) promised to add `series_name` + `series_index` to the local Room `documents` table in the same PR, but only the server-side migration shipped. The Android side was never landed.
+
+**This PR therefore adds the Room migration as well**, bumping the local DB from version 4 → 5. The schema additions are:
+
+```sql
+ALTER TABLE documents ADD COLUMN seriesName  TEXT;
+ALTER TABLE documents ADD COLUMN seriesIndex REAL;
+CREATE INDEX index_documents_seriesName_seriesIndex
+  ON documents(seriesName, seriesIndex);
+```
+
+- `seriesName` is nullable text. Most books have no series.
+- `seriesIndex` is `REAL` (matches Room's mapping for `Double?`). The server-side type is `numeric` because OPF allows half-book entries like `2.5`; SQLite's `REAL` round-trips that.
+- Composite index on `(seriesName, seriesIndex)`, declared via Room's `@Index` annotation so the Room schema validator stays happy. We do **not** mark the index `COLLATE NOCASE` — Room doesn't surface per-index collation, and at personal-library scale (<500 books, <50 with non-null seriesName) the case-insensitive `COLLATE NOCASE` predicate used in the query falls back to a scan over a tiny set. Adding a second NOCASE index via raw SQL would speed up worst-case cardinality but complicate schema validation; trade rejected.
+- The query uses `COLLATE NOCASE` rather than `LOWER()` — equivalent semantics, slightly cheaper, and a no-op behaviour change if the index ever gains NOCASE collation.
+- Columns are backfilled to NULL on the migration — the existing reconcile loop in `DocumentRepository` (PR1's Android side) will populate them on the next OPF extraction. Books downloaded before PR8 keep working; they just don't appear on the shelf until their OPF is re-read.
+
+The columns are written by `DocumentRepository.insert(..., seriesName, seriesIndex, ...)` callers. Today the only caller is `BookDownloader` → `DocumentRepository`. PR8 widens the `insert()` signature with two defaulted-null parameters so existing call sites compile unchanged. **The download path itself is updated in this PR** to pass through `MetadataBundle.seriesName` and `MetadataBundle.seriesPosition` from the OPF extractor, so newly-downloaded books on a PR8 build populate the columns immediately.
+
+The deletion of `seriesIndex` from a `Numeric` server type to `Double` on the Android side is acceptable: even at the absurd upper bound of a `Long.MAX_VALUE` series position, `Double`'s 53-bit mantissa handles it. Real-world series indices are ≤ 100.
+
+## Query
+
+The load-bearing piece. Single SQL, run from `DocumentDao.observeSeriesContinuationCandidates()`, returning `Flow<List<DocumentEntity>>`:
+
+```sql
+WITH finished_series AS (
+    SELECT sibling.seriesName     AS seriesName,
+           MAX(sp.finishedAt)     AS lastFinishedAt
+    FROM documents AS sibling
+    JOIN progress AS sp ON sp.documentId = sibling.id
+    WHERE sibling.seriesName IS NOT NULL
+      AND sibling.seriesName != ''
+      AND sp.finishedAt IS NOT NULL
+    GROUP BY sibling.seriesName COLLATE NOCASE
+)
+SELECT d.*
+FROM documents AS d
+JOIN finished_series fs
+  ON fs.seriesName = d.seriesName COLLATE NOCASE
+WHERE d.seriesName IS NOT NULL
+  AND d.seriesName != ''
+  AND NOT EXISTS (
+      SELECT 1 FROM progress AS p
+      WHERE p.documentId = d.id
+        AND (p.finishedAt IS NOT NULL OR p.percent >= :startedThreshold)
+  )
+ORDER BY
+  fs.lastFinishedAt DESC,
+  (d.seriesIndex IS NULL) ASC,
+  d.seriesIndex ASC,
+  d.title COLLATE NOCASE ASC,
+  d.id ASC
+LIMIT :maxItems
+```
+
+**Parameter values used by the repository:**
+
+- `startedThreshold = 0.05` (5%). A book the user briefly tapped into but didn't really start is treated as "still continuation-worthy". This matches the brief's suggested default and gives noise tolerance against accidental opens. Books with no `progress` row pass the `NOT EXISTS` filter trivially.
+- `maxItems = 12`. Cap on shelf length; avoids unbounded `LazyRow`.
+
+**Semantics, line by line:**
+
+1. **`finished_series` CTE** — collapses all "books the user has finished" to one row per case-folded `seriesName`, recording the most-recent finish per series. Computed once per query rather than per candidate (avoids the correlated-subquery shape and makes the planner's job trivial).
+2. **`JOIN finished_series fs ON ... COLLATE NOCASE`** — only books whose series actually has a finished sibling reach the candidate set. The `COLLATE NOCASE` matches the index, so the join is index-driven.
+3. **`d.seriesName IS NOT NULL AND d.seriesName != ''`** — defensive; the CTE already filters nulls/empty, but explicit on `d` keeps the planner honest.
+4. **`NOT EXISTS (... finishedAt IS NOT NULL OR percent >= 0.05)`** — the candidate book itself must be unread (or barely-touched). Finished books are out; in-progress books past 5% are out (they show up under "Continue reading" instead). This also implicitly excludes "the only finished book in a one-book series" — that book is finished, so it self-excludes here.
+5. **`ORDER BY fs.lastFinishedAt DESC`** — series whose latest read happened most recently bubble to the front. If a user finished *Foundation* book 2 yesterday and *Dune* book 1 last year, *Foundation* book 3 sits to the left of *Dune* book 2.
+6. **`(d.seriesIndex IS NULL) ASC`** — NULL-handling: SQLite sorts NULL before all values in ASC order. Without this term, an unread book with no `seriesIndex` would sort before book 1 of its own series. Putting null-indices last per series is the correct UX.
+7. **`d.seriesIndex ASC`** — within a series, lowest unread index first.
+8. **`d.title COLLATE NOCASE ASC`** — deterministic tiebreaker when `seriesIndex` is null or duplicated.
+9. **`d.id ASC`** — final deterministic tiebreaker.
+10. **`LIMIT 12`** — cap.
+
+**Performance:**
+
+- The candidate set is bounded by "books with a non-null `seriesName`" — typically << 100 for a personal library, often < 20. The new index on `seriesName` keeps the EXISTS subqueries small.
+- The correlated subquery in `ORDER BY` could be cached as a CTE, but Room/SQLite handles ~12 outer rows × ~5 siblings per series at sub-millisecond cost. Not worth the complexity.
+- The query is re-run via the Flow whenever **any** row in `documents` or `progress` changes, by virtue of Room's reactive `@Query` semantics. The brief explicitly asks for this.
+
+**Case-sensitivity decision:** case-insensitive match on `seriesName`. EPUB metadata is inconsistent across publishers and re-imports; insisting on exact-case match would break the shelf for any library with mixed-case duplicates. The cost is potential collision between two genuinely different series that happen to share a case-normalised name — vanishingly rare for a personal library.
+
+## Repository
+
+`DocumentRepository` gains:
+
+```kotlin
+fun observeSeriesContinuationCandidates(): Flow<List<Document>> =
+    dao.observeSeriesContinuationCandidates(
+        startedThreshold = 0.05,
+        maxItems = 12,
+    ).map { rows -> rows.map { it.toDomain() } }
+```
+
+Mapping rules unchanged from the rest of the file. The threshold and cap are constants on the repository (private vals) so callers don't drift.
+
+## ViewModel
+
+`LibraryViewModel` gains:
+
+```kotlin
+val seriesContinuationCandidates: StateFlow<List<Document>> =
+    docs.observeSeriesContinuationCandidates()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+```
+
+No interaction with `sort` or `query`. The shelf shows the deterministic set regardless of the main-grid sort or search filter — its purpose is to be a constant nudge.
+
+## UI
+
+New `SeriesContinuationShelf.kt` in `ui/library/`:
+
+```kotlin
+@Composable
+fun SeriesContinuationShelf(
+    books: List<Document>,
+    onBookClick: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+)
+```
+
+- `LazyRow` of items, each ~96 dp wide.
+- Per-item layout: `CoverImage` (reuses existing component), then title (1 line, ellipsis), then `seriesName · Book N` (1 line, smaller, onSurfaceVariant). If `seriesIndex` is null, the second line is just `seriesName`.
+- Section header above the row: `SectionLabel("Continue your series")`.
+- When `books` is empty, the composable renders nothing (no `Spacer`, no header). The caller can include it unconditionally and it'll disappear from layout.
+- Tapping a cover invokes `onBookClick(book.id)`. Same target as a main-grid tap → opens the reader.
+
+Integration in `LibraryScreen`:
+
+- Insert the shelf as a full-span `item` in the `LazyVerticalGrid`, between the existing `Quire` title row and the `ContinueReadingCard` row (or wherever fits best aesthetically — above the grid contents but below the toolbar). Hide via `if (candidates.isNotEmpty())` to avoid an empty span eating padding.
+
+## Tests
+
+Three test layers; matches the brief.
+
+1. **`DocumentDaoTest` (Room, Robolectric)** — add tests for the new query:
+   - Finished sibling + unread candidate in same series → candidate appears.
+   - No finished books at all → result empty.
+   - User started AND finished the next-in-series → it does not appear (own `finishedAt` excludes it).
+   - User started next-in-series past 5% but not finished → it does not appear (started filter).
+   - Multi-series: finished book in two distinct series → both unread continuations appear, ordered by most-recent-finished sibling DESC.
+   - Within one series, multiple unread later books → ordered by `seriesIndex ASC`.
+   - Case-insensitive match: sibling `seriesName = "Foundation"`, candidate `seriesName = "foundation"` → matches.
+   - Cap: > 12 candidates → exactly 12 returned.
+   - Books with NULL `seriesName` → never appear, even if user has finished other books.
+
+2. **Room `MigrationTest`** — add a 4 → 5 migration test that:
+   - Creates DB at version 4 with one `documents` row.
+   - Runs `MIGRATION_4_5`.
+   - Asserts the row survives.
+   - Asserts the `seriesName` and `seriesIndex` columns now exist.
+   - Asserts the new `index_documents_seriesName` index exists.
+
+3. **`LibraryViewModelTest`** — add a test that exercises the new StateFlow:
+   - Seed: two books in same series; sibling finished, candidate unread.
+   - Assert `seriesContinuationCandidates` eventually emits a list of size 1 containing the candidate.
+   - Mutate: mark the candidate as finished; assert flow emits empty list (reactivity).
+
+4. **Compose UI test for `SeriesContinuationShelf`** — Robolectric Compose:
+   - Empty list → no `SectionLabel("Continue your series")` in the tree.
+   - Non-empty list → header present, all book titles rendered.
+   - Click on first item → `onBookClick` invoked with that book's id.
+
+## Wiring
+
+- `AppNavGraph.kt`: no change needed. `LibraryScreen` reads the new flow off `LibraryViewModel` it already constructs.
+- `AppContainer.kt`: no change needed. `DocumentRepository` is constructed once and the new method is on the same class.
+- F-Droid posture: pure UI + Room work; no new destinations, no server calls, no new third-party dependencies.
+
+## Cache-version checklist
+
+N/A — no AI prompt or schema bumped.
+
+## Risks
+
+- **Stale `seriesName` on pre-PR8 downloads.** Books already in the library on upgrade have NULL `seriesName` until something re-runs OPF extraction. This is acceptable: the shelf will populate over time as users re-download or as a future PR adds a background reconcile. Users see no error, just a slowly-populating shelf.
+- **MIGRATION_4_5 risk on production DBs.** Pure `ALTER TABLE ADD COLUMN` + `CREATE INDEX` — SQLite handles both online. Tested via `MigrationTest`.
+- **Series detection false positives.** If two unrelated books share a normalised `seriesName` ("Untitled"), they'll cross-pollinate the shelf. Trivial cost; revisit only if reports come in.
+- **Performance on huge libraries (10k books).** The candidate-set pre-filter on `seriesName IS NOT NULL` with the new index keeps the EXISTS subqueries bounded. Even pathological cases are far inside a single SQLite tick.
+
+## Hand-off to PR9 (library stats)
+
+PR9 will want some of the same primitives:
+
+- The `(documents.seriesName, progress.finishedAt)` join pattern is reusable as-is for "finished books per series" counters.
+- The `LOWER()` case-insensitive series grouping should be lifted to PR9's stats query for consistency.
+- The `0.05` "started threshold" is a useful constant for "in-progress vs not-started" stats; PR9 should pull it into a shared `LibraryThresholds` object if it ends up reusing it.
+- The reactive `Flow<List<...>>` shape on `DocumentRepository` is the right model for PR9's stats; mimic it.
+
+No code is shared today (premature abstraction), but the patterns are documented here so PR9's spec can lift them verbatim.


### PR DESCRIPTION
## Summary

New "Continue your series" horizontal shelf at the top of the library home, surfacing books whose sibling-in-series the user has finished but which they themselves have not yet started. **Deterministic — pure local Room query; no AI calls, no server changes.**

## Schema note (unexpected)

PR1 (#16) was meant to ship the Android Room migration adding `series_name` + `series_index` to the local `documents` table alongside the server-side `library_items` table. The diff in PR1 only contained the server side — the Android Room migration was never landed. This PR therefore lands the Android half as well:

- Bumps DB version 4 → 5
- New `MIGRATION_4_5`: adds `seriesName TEXT`, `seriesIndex REAL`, and a composite index `(seriesName, seriesIndex)`
- Backfill is NULL — existing library rows get series metadata the next time they're downloaded / re-read; the new download path threads OPF series fields through on every new download

## Load-bearing query

`DocumentDao.observeSeriesContinuationCandidates(startedThreshold, maxItems)`:

```sql
WITH finished_series AS (
    SELECT sibling.seriesName       AS seriesName,
           MAX(sp.finishedAt)       AS lastFinishedAt
    FROM documents AS sibling
    JOIN progress  AS sp ON sp.documentId = sibling.id
    WHERE sibling.seriesName IS NOT NULL
      AND sibling.seriesName != ''
      AND sp.finishedAt IS NOT NULL
    GROUP BY sibling.seriesName COLLATE NOCASE
)
SELECT d.*
FROM documents AS d
JOIN finished_series fs
  ON fs.seriesName = d.seriesName COLLATE NOCASE
WHERE d.seriesName IS NOT NULL
  AND d.seriesName != ''
  AND NOT EXISTS (
      SELECT 1 FROM progress AS p
      WHERE p.documentId = d.id
        AND (p.finishedAt IS NOT NULL OR p.percent >= :startedThreshold)
  )
ORDER BY
  fs.lastFinishedAt DESC,
  (d.seriesIndex IS NULL) ASC,
  d.seriesIndex ASC,
  d.title COLLATE NOCASE ASC,
  d.id ASC
LIMIT :maxItems
```

Repository defaults: `startedThreshold = 0.05` (5% — tolerates an accidental open), `maxItems = 12`.

## Where it shows up

Above the existing library grid, beneath the `Quire` title row and below `ContinueReadingCard` when present. Renders nothing when the candidate list is empty — no "no series yet" placeholder, keeps the home clean.

## GPT verdict

Advisory review by the architect prompt: **APPROVE WITH CHANGES**. Incorporated:

1. Use `COLLATE NOCASE` in the query body instead of `LOWER()` (cleaner, identical semantics, will participate in a NOCASE index if one is added later).
2. Explicit `(d.seriesIndex IS NULL) ASC` ahead of `d.seriesIndex ASC` to push null-index books to the end of their series (SQLite sorts NULL first in ASC by default).
3. Rewrote the ordering's correlated subquery as a CTE — easier to reason about, identical semantics.
4. Kept `startedThreshold = 0.05` (the brief's suggested default) over `0.0` — tolerates accidental opens.
5. Dropped the explicit `sibling.id != d.id` predicate — collapsing into the CTE made it redundant; finished candidates self-exclude via the `NOT EXISTS` on their own progress.

Rejected: changing the column-level collation to `NOCASE` (requires table rebuild for trivial benefit at personal-library scale); adding a second NOCASE index via raw SQL (Room schema validator complications, not worth the speedup at <500 books).

## Test plan

- [x] `scripts/dgradle :data:local:testDebugUnitTest` — green (Room migration 4→5, 11 new DAO tests for the shelf query, existing tests unchanged)
- [x] `scripts/dgradle :app:testDebugUnitTest` — green (2 new `LibraryViewModelTest` cases + 5 label-builder unit tests; existing catalog/library tests unchanged)
- [x] `scripts/dgradle :app:lintDebug` — clean
- [x] Reactivity: shelf emits when a sibling becomes finished, and re-emits empty when the candidate itself becomes finished (covered by `LibraryViewModelTest`)
- [x] Schema: `data/local/schemas/.../5.json` regenerated and committed
- [ ] Manual smoke on a real device with a multi-book series (deferred to CI / app QA)

## Files

- New: `SeriesContinuationShelf.kt`, `EpubOpfReader.kt`, schema `5.json`, spec + plan docs.
- Modified: `DocumentEntity`, `DocumentDao`, `DocumentRepository`, `EReaderDatabase`, `Document`, `CatalogViewModel`, `LibraryViewModel`, `LibraryScreen`, and the corresponding tests.

## Notes for downstream PRs

PR9 (library stats) will want the same `(documents.seriesName, progress.finishedAt)` join shape and the same case-insensitive grouping. The `0.05` "started" threshold is exposed as `DocumentRepository.SERIES_CONTINUATION_STARTED_THRESHOLD`; PR9 should lift it into a shared constants object if it ends up reusing it.