### PR TITLE
:memo: docs: post-batch-3 documentation refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,14 +105,14 @@ in the same PR**, and update the fixtures.
 - **`tests/integration/test_cache_key_audit.py`** splits the audit into
   two parametrize lists (PR2, 2026-05-16):
   - **`SHARED_CACHE_TABLES`** (`book_insights`, `external_source_cache`,
-    plus future shared-cache tables): rows reused across every tenant
-    requesting the same identity + model + prompt + tone + language.
-    Carry **no** principal columns (`user_id`, `tenant_id`, `subject`,
-    `principal_id`). The cross-tenant cache-hit property is load-bearing
-    for hosted Quire Cloud AI economics. Any PR that adds a tenant column
-    to a shared cache, or adds a new shared cache without registering it
-    in this list, will break it on purpose. Per-call audit data goes on
-    `ai_generation_log` instead.
+    `book_themes` (PR3, 2026-05-17), plus future shared-cache tables):
+    rows reused across every tenant requesting the same identity + model +
+    prompt + tone + language. Carry **no** principal columns (`user_id`,
+    `tenant_id`, `subject`, `principal_id`). The cross-tenant cache-hit
+    property is load-bearing for hosted Quire Cloud AI economics. Any PR
+    that adds a tenant column to a shared cache, or adds a new shared
+    cache without registering it in this list, will break it on purpose.
+    Per-call audit data goes on `ai_generation_log` instead.
   - **`SCOPED_ALIAS_TABLES`** (`insight_identity_aliases`): rows whose
     `user_id` is INTENTIONAL cache-key scoping, NOT a tenant-leak. The
     inverse-property test asserts `user_id` IS present on these tables,
@@ -128,6 +128,26 @@ in the same PR**, and update the fixtures.
   global alias scope (`SCOPE_BY_SCHEME`), and `AliasConflict` on
   disagreeing canonicals. Any change to the alias scope rules or the
   resolution order must update this test deliberately.
+
+### Cache-version checklist (server + Android together)
+
+When bumping any cache-key dimension, move all three forward in the same
+PR (or document why one was skipped):
+
+- **`opds_sync/core/ai/prompts.py::PROMPT_VERSION`** — string. Currently
+  `"4"` (PR3, 2026-05-17). Bump when prompt bytes change.
+- **`opds_sync/api/ai_schemas.py::BookInsightPayload.schema_version`** —
+  int. Currently `3` (PR3). Bump when payload shape changes.
+- **Android Room schema version** in
+  `data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt`
+  — currently `5` (PR8, 2026-05-17 adds `seriesName`/`seriesIndex`). Every
+  bump needs a `MIGRATION_n_n+1` entry and an exported schema JSON under
+  `data/local/schemas/`.
+
+`book_insights` unique indexes already cover `(metadata_id, model_id,
+prompt_version, tone, language)` plus the `content_hash` variant; the
+`service.py` orchestrator lock key must include every dimension that
+participates in the cache key.
 
 ## Code of Conduct
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -374,6 +374,54 @@ the request body. Soft-deletes via `deleted_at`; `GET ?since=<ISO>` returns
 delta rows including tombstones for sync. The table is USER-SCOPED — not
 shared cache — so the cache-key audit does not cover it.
 
+### Structured themes + `book_themes` (PR3, 2026-05-17)
+
+`BookInsightPayload.themes` is back as a first-class field at schema v3 —
+a list of 1–5 topic tags drawn from a controlled vocabulary (~57 entries in
+`opds_sync/core/ai/themes.py::CONTROLLED_THEMES`, covering broad fiction
+buckets, speculative subgenres, genre fiction, and nonfiction categories).
+`PROMPT_VERSION` bumped to `"4"`. Vocab hits are normalized to snake_case
+and persisted to the side table `book_themes(book_insight_id, theme,
+confidence)` at `confidence=1.0`; off-vocab strings are preserved verbatim
+at `confidence=0.5` so future vocabulary evolution doesn't lose data.
+
+`book_themes` lives on the `ai` alembic branch (`ai_004_themes`) and joins
+**`SHARED_CACHE_TABLES`** in the cache-key audit — no `user_id`/`tenant_id`
+columns. Per-user filtering happens at query time by joining
+`book_themes → book_insights → library_items` on
+`metadata_id`/`content_hash`. PR9 library stats (future) MUST also filter
+`book_insights.superseded_at IS NULL` to avoid double-counting regenerated
+insights, and `confidence >= 1.0` if it wants vocab-only aggregation.
+
+The payload's `themes` field is the source of truth for the client;
+`book_themes` is the SQL-queryable mirror. Old cached v2 payloads (no
+`themes` key) deserialize cleanly with `themes=null` and contribute zero
+rows to `book_themes` until regenerated. `schema_version=3` is pinned by
+the server after model return so cache rows never reflect a model's
+accidental version emission.
+
+### Android UI surfaces (batch 3, 2026-05-17)
+
+- **Inspect insight screen (PR6).** Book-detail overflow → "Inspect
+  insight" opens `InsightAuditScreen` (route `book/{id}/inspect-insight`,
+  `InsightAuditViewModel`). Shows `model_id`, `prompt_version`,
+  `schema_version`, `tone`, `language`, `generated_at`, sources list with
+  tappable URLs, and an Invalidate button that reuses the existing
+  body-based `/ai/v1/insights/invalidate` endpoint. No new server endpoint.
+- **Series continuity shelf (PR8).** Horizontal shelf "Continue your
+  series" on the library home, populated by a Room CTE join on
+  `documents.series_name` against `progress`. Pure deterministic — no AI
+  call. Room schema 4→5 adds `seriesName`/`seriesIndex` columns and a
+  `(seriesName, seriesIndex)` index; opportunistic OPF series extraction
+  is wired into the catalog download path (`CatalogViewModel`).
+- **Regenerate dropped (PR11).** The book-detail overflow no longer
+  exposes "Regenerate insights" — the cache key already invalidates
+  naturally on `tone`/`language`/`model_id`/`prompt_version` changes, and
+  the "ask again" case is now served by the Inspect-insight Invalidate
+  button (one AI call instead of two). The
+  `POST /ai/v1/insights/regenerate` server endpoint is retained for
+  admin/cluster tooling.
+
 ## Decision log
 
 | # | Decision | Rationale |

--- a/docs/development.md
+++ b/docs/development.md
@@ -161,7 +161,7 @@ uv run alembic upgrade head
 In containers, the entrypoint calls `python /app/scripts/migrate.py`, a wrapper
 that upgrades the unlabeled `0001..0004` backbone, then runs
 `alembic upgrade <branch>@head` for each enabled+materialized branch
-(`progress`, `ai`). Today's heads: `ai@head=ai_003_identity_aliases`,
+(`progress`, `ai`). Today's heads: `ai@head=ai_004_themes` (PR3, 2026-05-17),
 `progress@head=progress_001_library_items`. See `server/migrations/README.md`
 for the branch-label convention and the `--splice` rule for adding the first
 migration on a new branch.

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,6 +15,24 @@ lands without any Android-relevant change produces no APK and no tag;
 the next Android-relevant push picks up the next CalVer slot. This is
 intentional and matches CalVer's "calendar + run number" semantics.
 
+### Known limitation: version-bump race on stacked Android merges
+
+The `build` job commits the version bump and tag, then pushes back to
+`main`. If two Android-relevant PRs merge inside one CI cycle, the
+second push from the `[bot]` author can lose the race with the first
+and the second tag is silently orphaned. Observed on 2026-05-17 when
+PR #21 (PR6 inspect-insight) and PR #22 (PR8 series shelf) merged
+within minutes: PR8's standalone tag never materialized; both PRs
+shipped in PR6's release `v2026.05.17.87`. No artifact was lost — the
+release APK contains the merged tree at the time the build ran — but
+the per-PR tag mapping degrades.
+
+Workaround for now: when stacking Android merges, wait for the version-
+bump push from the previous run to land before merging the next PR.
+The longer-term fix is a `git pull --rebase` step in the `build` job
+before the push back, so a lost race retries instead of orphaning a
+tag — tracked as a follow-up.
+
 ### Mode-branched migrations on deploy
 
 Container starts run `python /app/scripts/migrate.py`, which upgrades

--- a/docs/superpowers/plans/2026-05-17-drop-regenerate-button.md
+++ b/docs/superpowers/plans/2026-05-17-drop-regenerate-button.md
@@ -1,5 +1,7 @@
 # Plan — Drop "Regenerate insights" affordance
 
+> Shipped in f422845 on 2026-05-17 as PR #19.
+
 **Spec:** `docs/superpowers/specs/2026-05-17-drop-regenerate-button-design.md`
 **Branch:** `feat/drop-regenerate-button`
 **Mode:** TDD-by-deletion (tests removed before implementation; build is the

--- a/docs/superpowers/plans/2026-05-17-insight-audit-ui.md
+++ b/docs/superpowers/plans/2026-05-17-insight-audit-ui.md
@@ -1,5 +1,7 @@
 # PR6 — Insight audit UI: implementation plan
 
+> Shipped in 92ca525 on 2026-05-17 as PR #21.
+
 **Date:** 2026-05-17
 **Spec:** `docs/superpowers/specs/2026-05-17-insight-audit-ui-design.md`
 **Branch:** `feat/insight-audit-ui`

--- a/docs/superpowers/plans/2026-05-17-series-shelf.md
+++ b/docs/superpowers/plans/2026-05-17-series-shelf.md
@@ -1,5 +1,7 @@
 # PR8 — Series continuity shelf: implementation plan
 
+> Shipped in 275e921 on 2026-05-17 as PR #22.
+
 **Date:** 2026-05-17
 **Spec:** `docs/superpowers/specs/2026-05-17-series-shelf-design.md`
 **Branch:** `feat/series-shelf` off `main`.

--- a/docs/superpowers/plans/2026-05-17-themes-v3.md
+++ b/docs/superpowers/plans/2026-05-17-themes-v3.md
@@ -1,5 +1,7 @@
 # Plan — Structured themes v3 + `book_themes` (PR3)
 
+> Shipped in 2e0caf5 on 2026-05-17 as PR #20.
+
 **Spec:** `docs/superpowers/specs/2026-05-17-themes-v3-design.md`
 **Branch:** `feat/themes-v3`
 **Worktree:** `.claude/worktrees/pr3-themes-v3`

--- a/docs/superpowers/specs/2026-05-17-drop-regenerate-button-design.md
+++ b/docs/superpowers/specs/2026-05-17-drop-regenerate-button-design.md
@@ -1,5 +1,7 @@
 # PR11 — Drop "Regenerate insights" overflow action
 
+> Shipped in f422845 on 2026-05-17 as PR #19.
+
 **Date:** 2026-05-17
 **Branch:** Android-only (server endpoint retained for invalidate-only use by PR6)
 **Effort:** Quick

--- a/docs/superpowers/specs/2026-05-17-insight-audit-ui-design.md
+++ b/docs/superpowers/specs/2026-05-17-insight-audit-ui-design.md
@@ -1,5 +1,7 @@
 # PR6 — Insight audit UI
 
+> Shipped in 92ca525 on 2026-05-17 as PR #21.
+
 **Date:** 2026-05-17
 **Branch:** Android-only (`feat/insight-audit-ui`)
 **Effort:** Short

--- a/docs/superpowers/specs/2026-05-17-series-shelf-design.md
+++ b/docs/superpowers/specs/2026-05-17-series-shelf-design.md
@@ -1,5 +1,7 @@
 # PR8 — Series continuity shelf (Android-only)
 
+> Shipped in 275e921 on 2026-05-17 as PR #22.
+
 **Date:** 2026-05-17
 **Status:** Spec for implementation; design locked in `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §"PR8".
 

--- a/docs/superpowers/specs/2026-05-17-themes-v3-design.md
+++ b/docs/superpowers/specs/2026-05-17-themes-v3-design.md
@@ -1,5 +1,7 @@
 # Spec — Structured themes v3 + `book_themes` (PR3)
 
+> Shipped in 2e0caf5 on 2026-05-17 as PR #20.
+
 **Date:** 2026-05-17
 **Branch:** `feat/themes-v3` (from `main` after PR-A / PR-C / PR4 / PR-B / PR5 / PR1 / PR2 all merged)
 **Roadmap reference:** `.claude/local/quire-ai/2026-05-16-next-deliverables.md` §PR3

--- a/server/migrations/README.md
+++ b/server/migrations/README.md
@@ -30,7 +30,7 @@ From the split point onward, every new migration belongs to exactly one branch:
 | ---------- | ------------ | ------ | ------------------------------------------------------------------------------------------------ |
 | `core`     | `"core"`     | shared | Reserved; no migrations yet.                                                                     |
 | `progress` | `"progress"` | sync   | First and current head: `progress_001_library_items` (PR1, 2026-05-16). Spliced from `0004`.     |
-| `ai`       | `"ai"`       | AI     | Chain: `ai_001_generation_log` (PR-C) → `ai_002_insight_language` (PR4) → `ai_003_identity_aliases` (PR2). All on 2026-05-16. |
+| `ai`       | `"ai"`       | AI     | Chain: `ai_001_generation_log` (PR-C) → `ai_002_insight_language` (PR4) → `ai_003_identity_aliases` (PR2, 2026-05-16) → `ai_004_themes` (PR3, 2026-05-17). |
 
 ### Adding the FIRST migration on a branch (splice)
 


### PR DESCRIPTION
Sweep documentation after batch 3 (PRs #19/#20/#21/#22) landed on `main`.

## Files changed (and why)

- **`docs/architecture.md`** — Document structured themes v3 + `book_themes` side table (PR3): cache-key invariant intact (no `user_id`/`tenant_id`), joins `SHARED_CACHE_TABLES`, PR9 must filter `superseded_at IS NULL` + `confidence >= 1.0` + dedup per `(library_item, theme)`. Add a consolidated batch-3 Android UI subsection covering Inspect-insight (PR6), series continuity shelf (PR8, Room schema 5 + OPF series wiring), and the dropped Regenerate action (PR11, server endpoint retained for admin use).
- **`docs/development.md`** — Bump current `ai@head` from `ai_003_identity_aliases` to `ai_004_themes`.
- **`docs/release.md`** — Document the version-bump race observed on 2026-05-17 (PR #22's standalone tag was orphaned; both PRs shipped in PR #21's release `v2026.05.17.87`). Note the `git pull --rebase` follow-up.
- **`server/migrations/README.md`** — Extend the `ai` branch chain row with `ai_004_themes` (PR3, 2026-05-17).
- **`CONTRIBUTING.md`** — Register `book_themes` in `SHARED_CACHE_TABLES`; add a cache-version checklist that pins the current values of `PROMPT_VERSION` (`"4"`), `BookInsightPayload.schema_version` (`3`), and the Android Room schema version (`5`, plus its migration entry).
- **`docs/superpowers/{specs,plans}/2026-05-17-*.md`** — `> Shipped in <commit> on 2026-05-17 as PR #N.` header on each of the four batch-3 spec/plan pairs (themes-v3, insight-audit-ui, series-shelf, drop-regenerate-button).

## Files audited and clean (no edit)

- `README.md` — feature list and "AI features (optional)" wording still accurate. Series-shelf and inspect-insight are intentionally below the README's high-level scope.
- `docs/sync-api.md` — already covers schema v3, `themes` field, controlled vocab (~57 entries), `book_themes` schema, and the PR11 regenerate-removal note. No drift.
- `server/README.md` — no new env vars in batch 3; smoke commands current.
- `LICENSE` — Apache-2.0 boilerplate; no year/owner header customization.
- `NOTICE` — no new third-party deps added by batch 3.
- `SECURITY.md` — the dropped Regenerate action was an authed write whose server endpoint is retained, so threat-model scope is unchanged.

## Local notes refreshed (gitignored, not in this PR)

- `.claude/local/quire-ai-deployment-notes.md` — removed the `STILL OUTSTANDING` `/sync/v1/healthz` reminder (resolved 2026-05-17 by theficos-cluster `2388a4d`); appended `ai_004_themes` head note.
- `.claude/local/quire-ai/2026-05-09-quire-ai-design.md` — Batch 3 banner added (themes back as first-class, regenerate removed in Android, audit surface).
- `.claude/local/quire-ai/2026-05-16-next-deliverables.md` — struck PR3/PR6/PR8/PR11; added Shipped markers and updated the "if you only ship five" line (only PR7 remains).

## Code-vs-doc drift surfaced (none requiring code change)

No code/doc contradictions discovered during this pass. Caveats already captured in `docs/architecture.md` (themes subsection) for PR9 to honor when it lands: `superseded_at IS NULL`, `confidence >= 1.0` filter, dedup per `(library_item, theme)`.