### PR TITLE
feat(deploy): Caddy-fronted reference compose

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,47 @@
 # Copy to .env and fill in. Do not commit .env.
-OPDS_SYNC_CWA_BASE_URL=https://library.example.com
+#
+# This file is consumed by BOTH `docker-compose.yml` (minimal: postgres
+# + opds-sync) and `docker-compose.full.yml` (full stack: postgres +
+# calibre-web + opds-sync + Caddy). Vars marked "full-only" are only
+# read by the full-stack compose.
+
+# --- Shared (minimal + full) ---
 POSTGRES_PASSWORD=change-me
-OPDS_SYNC_PORT=8000
 OPDS_SYNC_LOG_LEVEL=INFO
+
+# --- Minimal-only ---
+# Upstream calibre-web URL (you bring your own). Ignored by full-stack
+# compose, which wires opds-sync to its in-network calibre-web service.
+OPDS_SYNC_CWA_BASE_URL=https://library.example.com
+OPDS_SYNC_PORT=8000
+
+# --- Full-stack only ---
+# Hostname Caddy serves on. Leave as `localhost` for the reference
+# self-signed (`tls internal`) setup. For production with a real cert,
+# set this to your public hostname (e.g. `ebooks.example.com`) AND
+# replace `tls internal` in caddy/Caddyfile with the appropriate
+# directive — see server/README.md for the swap.
+QUIRE_SITE_ADDRESS=localhost
+# Override only if 443/80 are taken on the host (e.g. behind another
+# reverse proxy).
+CADDY_HTTPS_PORT=443
+CADDY_HTTP_PORT=80
+# calibre-web file-ownership mapping.
+PUID=1000
+PGID=1000
+TZ=UTC
+
+# Deploy-mode flags. Defaults give the full stack. Flip to false for
+# sync-only (drops /ai/*) or AI-only (drops /sync/* + /library/*).
+OPDS_SYNC_PROGRESS_ENABLED=true
+OPDS_SYNC_AI_ENABLED=true
+
+# AI provider. Required when OPDS_SYNC_AI_ENABLED=true. Point at any
+# OpenAI-compatible endpoint.
+# OPDS_SYNC_AI_BASE_URL=https://ollama.example.com/v1
+# OPDS_SYNC_AI_MODEL=gpt-oss:120b-cloud
+# OPDS_SYNC_AI_API_KEY=sk-...
+# OPDS_SYNC_AI_SOURCES=wikipedia,openlibrary
+# OPDS_SYNC_AI_RATE_PER_MIN=10
+# OPDS_SYNC_AI_DAILY_BUDGET=200
+# OPDS_SYNC_AI_REGEN_DAILY_LIMIT=3

--- a/server/README.md
+++ b/server/README.md
@@ -19,6 +19,15 @@ Tests require Docker (testcontainers spins up Postgres).
 
 ## Self-hosting via docker-compose
 
+Two reference composes ship in this directory. Pick one:
+
+| File                       | Brings up                                             | Use when                                                                                  |
+| -------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `docker-compose.yml`       | postgres + opds-sync                                  | You already run calibre-web (and maybe TLS) elsewhere and only want the sync/AI server.   |
+| `docker-compose.full.yml`  | postgres + calibre-web + opds-sync + Caddy (TLS)      | You want the whole stack behind a single base URL with TLS, matching the production k8s ingress. |
+
+### Minimal: bring your own proxy
+
 ```sh
 cd server
 cp .env.example .env
@@ -26,6 +35,109 @@ cp .env.example .env
 docker compose up -d
 curl http://localhost:8000/health
 ```
+
+opds-sync listens on `${OPDS_SYNC_PORT:-8000}`. Point Quire's "sync
+URL" at it and Quire's "OPDS URL" at your existing calibre-web. Two
+URLs to configure in the app; you handle TLS yourself if exposing to
+the internet.
+
+### Full-stack reference compose
+
+A Caddy front-end with path-based routing that mirrors the production
+Kubernetes ingress, so the Android app only needs to know one base URL
+(the Caddy hostname) — calibre-web's OPDS catalog AND opds-sync's
+`/sync/*`, `/library/*`, `/ai/*` endpoints all live under the same
+origin.
+
+```sh
+cd server
+cp .env.example .env
+# Edit .env. At minimum:
+#   - POSTGRES_PASSWORD
+#   - PUID/PGID (your host user)
+#   - QUIRE_SITE_ADDRESS (or leave `localhost` for self-signed reference setup)
+#   - mount your calibre library: uncomment the library volume in
+#     docker-compose.full.yml and edit the host path
+#   - if AI is enabled (default), uncomment + fill the OPDS_SYNC_AI_* vars
+docker compose -f docker-compose.full.yml up -d
+curl -fsSk https://localhost/health
+```
+
+Routing inside the Caddy front-end (`caddy/Caddyfile`):
+
+```caddyfile
+{$QUIRE_SITE_ADDRESS:localhost} {
+    tls internal
+
+    @opds path /sync/* /ai/* /library/* /health /readyz
+    handle @opds {
+        reverse_proxy opds-sync:8000
+    }
+
+    handle {
+        reverse_proxy calibre-web:8083
+    }
+}
+```
+
+Smoke commands (replace `https://localhost` with `https://<your-host>`
+for non-default `QUIRE_SITE_ADDRESS`; `-k` skips cert verification
+against `tls internal`):
+
+```sh
+# Unauth health probes (opds-sync mounts these at the root)
+curl -fsSk https://localhost/health
+curl -fsSk https://localhost/readyz
+
+# AI provider health (unauth — see PR5)
+curl -fsSk https://localhost/ai/v1/health | jq
+
+# Authenticated sync surfaces (Basic auth proxied to calibre-web)
+USER=admin
+read -rs PASS && echo
+AUTH=$(printf '%s' "$USER:$PASS" | base64)
+curl -fsSk -H "Authorization: Basic $AUTH" "https://localhost/library/v1/items"
+curl -fsSk -H "Authorization: Basic $AUTH" "https://localhost/sync/v1/progress?since=0"
+
+# Calibre-web root (fall-through)
+curl -fsSkI https://localhost/
+```
+
+#### `tls internal` caveat
+
+The reference Caddyfile uses `tls internal`, which issues a
+self-signed certificate from Caddy's built-in CA. This is fine for
+localhost and lab setups (Caddy persists the CA in the `caddy_data`
+volume), but browsers and Android will reject the certificate until
+either:
+
+- You install Caddy's root CA on each client. With the Caddy
+  container running, `docker compose -f docker-compose.full.yml exec
+  caddy cat /data/caddy/pki/authorities/local/root.crt` prints it.
+- You replace `tls internal` with a real-cert directive. The simplest
+  swap is to set `QUIRE_SITE_ADDRESS` to a public hostname (e.g.
+  `ebooks.example.com`) AND drop the `tls internal` line from
+  `caddy/Caddyfile` — Caddy then provisions a Let's Encrypt cert
+  automatically via ACME (port 80 must be reachable from the
+  internet for HTTP-01). For DNS-01, BYO certs, or other strategies
+  see the Caddy docs.
+
+#### Deploy modes in the full-stack compose
+
+The same image supports three modes via env flags. The defaults below
+match the table in [Deploy modes](#deploy-modes).
+
+| Mode       | `OPDS_SYNC_PROGRESS_ENABLED` | `OPDS_SYNC_AI_ENABLED` | What the Caddy front-end serves                                  |
+| ---------- | ---------------------------- | ---------------------- | ---------------------------------------------------------------- |
+| Full stack | `true` (default)             | `true` (default)       | `/sync/v1/*` + `/library/v1/*` + `/ai/v1/*` + calibre-web at `/` |
+| Sync only  | `true`                       | `false`                | `/sync/v1/*` + `/library/v1/*` + calibre-web at `/`              |
+| AI only    | `false`                      | `true`                 | `/ai/v1/*` only — drop the `calibre-web` service from the compose for a leaner stack |
+
+Set both flags in `.env`. Sync-only deploys don't need
+`OPDS_SYNC_AI_*`; AI-only deploys don't need calibre-web auth once
+PR-B's token mode is selected (`OPDS_SYNC_AI_AUTH_MODE=token`).
+
+### Migrations
 
 Migrations run automatically on container start via `scripts/migrate.py`,
 which respects the deploy-mode flags `OPDS_SYNC_PROGRESS_ENABLED` and

--- a/server/caddy/Caddyfile
+++ b/server/caddy/Caddyfile
@@ -1,0 +1,30 @@
+# Quire reference Caddyfile (full-stack compose).
+#
+# Mirrors the production Kubernetes ingress in `theficos-cluster`:
+# path-based routing puts opds-sync's `/sync/*`, `/library/*`, `/ai/*`,
+# `/health`, and `/readyz` in front of calibre-web, with everything else
+# falling through to calibre-web on `/`.
+#
+# This file is intended for `docker-compose.full.yml`. For production
+# behind a real domain, swap `:443 { tls internal }` for a hostname
+# block (e.g. `ebooks.example.com { ... }`) so Caddy provisions a real
+# certificate via ACME. See server/README.md "Full-stack reference
+# compose" for the swap instructions.
+
+{$QUIRE_SITE_ADDRESS:localhost} {
+	tls internal
+
+	# Paths handled by opds-sync. `handle` preserves the full request
+	# path (unlike `handle_path`, which strips the matched prefix);
+	# FastAPI mounts routers at `/sync/v1`, `/library/v1`, and
+	# `/ai/v1`, so we must forward the prefix intact.
+	@opds path /sync/* /ai/* /library/* /health /readyz
+	handle @opds {
+		reverse_proxy opds-sync:8000
+	}
+
+	# Everything else falls through to calibre-web.
+	handle {
+		reverse_proxy calibre-web:8083
+	}
+}

--- a/server/docker-compose.full.yml
+++ b/server/docker-compose.full.yml
@@ -1,0 +1,107 @@
+# Quire full-stack reference compose.
+#
+# Brings up postgres + calibre-web + opds-sync + Caddy with path-based
+# routing identical to the production Kubernetes ingress. Use this if
+# you want a single base URL with TLS in front of everything.
+#
+# For "I'll bring my own proxy / I already run calibre-web elsewhere",
+# use the minimal `docker-compose.yml` in this directory instead.
+#
+# Usage:
+#   cp .env.example .env
+#   # edit .env (set POSTGRES_PASSWORD, mount your calibre library, etc.)
+#   docker compose -f docker-compose.full.yml up -d
+#
+# See server/README.md "Full-stack reference compose" for smoke
+# commands and the TLS swap for production.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: opds_sync
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      POSTGRES_DB: opds_sync
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U opds_sync"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  calibre-web:
+    image: crocodilestick/calibre-web-automated:latest
+    restart: unless-stopped
+    environment:
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
+      TZ: ${TZ:-UTC}
+      # Caddy is the only upstream proxy in this stack.
+      TRUSTED_PROXY_COUNT: "1"
+    volumes:
+      - calibre_config:/config
+      # Mount your existing calibre library here. The path inside the
+      # container must stay `/calibre-library` for calibre-web-automated.
+      # Uncomment and edit:
+      # - /path/to/your/calibre-library:/calibre-library
+      # Optional: ingest folder for drop-in book imports.
+      # - /path/to/your/ingest:/cwa-book-ingest
+
+  opds-sync:
+    image: ghcr.io/vitofico/opds-sync:latest
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      OPDS_SYNC_DATABASE_URL: postgresql+asyncpg://opds_sync:${POSTGRES_PASSWORD:-changeme}@postgres:5432/opds_sync
+      OPDS_SYNC_CWA_BASE_URL: http://calibre-web:8083
+      OPDS_SYNC_LOG_LEVEL: ${OPDS_SYNC_LOG_LEVEL:-INFO}
+      # Deploy mode flags. Defaults give the full-stack experience; flip
+      # one of these to false for sync-only or AI-only mode (see README).
+      OPDS_SYNC_PROGRESS_ENABLED: ${OPDS_SYNC_PROGRESS_ENABLED:-true}
+      OPDS_SYNC_AI_ENABLED: ${OPDS_SYNC_AI_ENABLED:-true}
+      # AI provider configuration. Required when AI_ENABLED=true.
+      # Point this at any OpenAI-compatible endpoint (Ollama, llama.cpp,
+      # vLLM, hosted OpenAI/Anthropic-compatible gateways, …).
+      OPDS_SYNC_AI_BASE_URL: ${OPDS_SYNC_AI_BASE_URL:-}
+      OPDS_SYNC_AI_MODEL: ${OPDS_SYNC_AI_MODEL:-}
+      OPDS_SYNC_AI_API_KEY: ${OPDS_SYNC_AI_API_KEY:-}
+      OPDS_SYNC_AI_SOURCES: ${OPDS_SYNC_AI_SOURCES:-wikipedia,openlibrary}
+      OPDS_SYNC_AI_RATE_PER_MIN: ${OPDS_SYNC_AI_RATE_PER_MIN:-10}
+      OPDS_SYNC_AI_DAILY_BUDGET: ${OPDS_SYNC_AI_DAILY_BUDGET:-200}
+      OPDS_SYNC_AI_REGEN_DAILY_LIMIT: ${OPDS_SYNC_AI_REGEN_DAILY_LIMIT:-3}
+    # No `ports:` mapping — opds-sync is reached through Caddy only.
+    # Add `ports: ["8000:8000"]` temporarily for direct debugging.
+    command: >
+      sh -c "python /app/scripts/migrate.py &&
+             uvicorn opds_sync.main:app --host 0.0.0.0 --port 8000"
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      - opds-sync
+      - calibre-web
+    environment:
+      # Set to your hostname (e.g. ebooks.example.com) for a real cert
+      # via ACME. Defaults to `localhost` with self-signed `tls internal`.
+      QUIRE_SITE_ADDRESS: ${QUIRE_SITE_ADDRESS:-localhost}
+    ports:
+      - "${CADDY_HTTPS_PORT:-443}:443"
+      - "${CADDY_HTTP_PORT:-80}:80"
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      # Persist Caddy's local CA + cert cache. Without this, `tls
+      # internal` regenerates a fresh root CA on every container
+      # recreation and clients re-prompt about trust.
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  pg_data:
+  calibre_config:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Summary

Adds `server/docker-compose.full.yml` — a postgres + calibre-web + opds-sync + Caddy stack that mirrors the production Kubernetes ingress so non-k8s self-hosters get a single base URL with TLS in one command. The existing minimal `server/docker-compose.yml` stays as the "I'll bring my own proxy" option.

**Why now:** k8s users get a unified base URL via Traefik ingress today (`/sync/*`, `/library/*`, `/ai/*` route to opds-sync, everything else to calibre-web). Compose users had to run calibre-web separately on a different port and configure two URLs in the Android app. This closes that deployment-path divergence.

## What's in the new file

- **Caddy** (`caddy:2-alpine`) on `:443` with `tls internal` by default. Uses `handle` (path-preserving) so the FastAPI router prefixes (`/sync/v1`, `/library/v1`, `/ai/v1`) are forwarded intact — `handle_path` would strip them and break routing.
- **calibre-web** (`crocodilestick/calibre-web-automated:latest`) — production-parity image. Library and ingest volumes are commented placeholders so users wire in their own paths.
- **opds-sync** — same image and migrate-then-uvicorn boot sequence as the minimal compose; full env-var set for full-stack mode.
- **postgres** — unchanged from the minimal compose.

### Caddyfile

```caddyfile
{$QUIRE_SITE_ADDRESS:localhost} {
    tls internal

    @opds path /sync/* /ai/* /library/* /health /readyz
    handle @opds {
        reverse_proxy opds-sync:8000
    }

    handle {
        reverse_proxy calibre-web:8083
    }
}
```

## Smoke commands

```sh
# Unauth health
curl -fsSk https://localhost/health
curl -fsSk https://localhost/readyz
curl -fsSk https://localhost/ai/v1/health | jq

# Authenticated sync
AUTH=$(printf '%s' "$USER:$PASS" | base64)
curl -fsSk -H "Authorization: Basic $AUTH" https://localhost/library/v1/items
curl -fsSk -H "Authorization: Basic $AUTH" "https://localhost/sync/v1/progress?since=0"

# Calibre-web fall-through
curl -fsSkI https://localhost/
```

## When to use which compose

| File | Brings up | Use when |
| --- | --- | --- |
| `docker-compose.yml` | postgres + opds-sync | You already run calibre-web (and TLS) elsewhere. |
| `docker-compose.full.yml` | postgres + calibre-web + opds-sync + Caddy | You want the whole stack behind a single base URL with TLS, matching the production k8s ingress. |

README also documents how the three deploy modes (`full` / `sync-only` / `AI-only`) map onto the full-stack compose via `OPDS_SYNC_PROGRESS_ENABLED` and `OPDS_SYNC_AI_ENABLED`.

## TLS caveat

Reference uses `tls internal` (self-signed). README documents the swap: set `QUIRE_SITE_ADDRESS` to a public hostname AND drop the `tls internal` line — Caddy will then do ACME automatically. Caddy state is persisted in named volumes so the local CA survives container recreations.

## GPT review

Architect reviewed the routing decision (`handle` vs `handle_path`), image choice (`crocodilestick/calibre-web-automated` vs `linuxserver/calibre-web`), env-var completeness, and TLS trade-off. Confirmed the design; suggested compressing routes with a named matcher and persisting Caddy's `/data` and `/config` volumes — both incorporated.

## Verification

- `docker compose -f server/docker-compose.full.yml config` exits 0; all 4 services + 4 named volumes present with expected images.
- `caddy validate --config /etc/caddy/Caddyfile` reports `Valid configuration`.
- `caddy fmt` clean.
- No server code, Android, or migration changes.

## Test plan

- [ ] On a host with Docker, copy `.env.example` to `.env`, set `POSTGRES_PASSWORD`, mount a calibre library, optionally fill `OPDS_SYNC_AI_*`.
- [ ] `docker compose -f server/docker-compose.full.yml up -d`.
- [ ] Run the smoke commands above and confirm `/health`, `/readyz`, `/library/v1/items`, and `/` (calibre-web) all answer correctly via the same `https://localhost` origin.