### PR TITLE
feat: library stats v0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     implementation(project(":auth"))
     implementation(project(":data:sync"))
     implementation(project(":data:ai"))
+    implementation(project(":data:library"))
     implementation(project(":reader"))
     implementation(libs.work.runtime.ktx)
     implementation(libs.kotlinx.serialization.json)

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -5,6 +5,7 @@ import io.theficos.ereader.auth.CalibreCredentialStore
 import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.data.ai.AiClient
 import io.theficos.ereader.data.ai.AiRepository
+import io.theficos.ereader.data.library.LibraryClient
 import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.ProgressRepository
 import io.theficos.ereader.data.local.db.EReaderDatabase
@@ -21,6 +22,7 @@ import io.theficos.ereader.ui.bookdetail.BookDetailViewModel
 import io.theficos.ereader.ui.bookdetail.InsightAuditViewModel
 import io.theficos.ereader.ui.catalog.CatalogPreferencesStore
 import io.theficos.ereader.ui.library.LibraryPreferencesStore
+import io.theficos.ereader.ui.library.LibraryStatsViewModel
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -64,6 +66,14 @@ class AppContainer(context: Context) {
         http = opdsHttp.okHttp,
     )
     val aiRepository: AiRepository = AiRepository(aiClient)
+
+    val libraryClient: LibraryClient = LibraryClient(
+        baseUrlProvider = { credentialStore.get()?.baseUrl },
+        http = opdsHttp.okHttp,
+    )
+
+    val libraryStatsViewModelFactory: LibraryStatsViewModelFactory =
+        LibraryStatsViewModelFactory(client = libraryClient)
 
     val bookDetailViewModelFactory: BookDetailViewModelFactory = BookDetailViewModelFactory(
         documents = documentRepository,
@@ -117,4 +127,10 @@ class InsightAuditViewModelFactory(
         documentId = documentId,
         source = AppInsightAuditSource(documents = documents, ai = ai),
     )
+}
+
+class LibraryStatsViewModelFactory(
+    private val client: LibraryClient,
+) {
+    fun create() = LibraryStatsViewModel(fetch = { client.getStats() })
 }

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -16,6 +16,7 @@ import io.theficos.ereader.ui.bookdetail.InsightAuditScreen
 import io.theficos.ereader.ui.catalog.CatalogScreen
 import io.theficos.ereader.ui.catalog.CatalogViewModel
 import io.theficos.ereader.ui.library.LibraryScreen
+import io.theficos.ereader.ui.library.LibraryStatsScreen
 import io.theficos.ereader.ui.library.LibraryViewModel
 import io.theficos.ereader.ui.main.MainScaffold
 import io.theficos.ereader.ui.main.Tab
@@ -66,6 +67,7 @@ fun AppNavGraph(container: AppContainer) {
                         viewModel = libVm,
                         onOpenBook = { id -> nav.navigate("reader/$id") },
                         onShowDetails = { id -> nav.navigate("book/$id") },
+                        onShowStats = { nav.navigate("library/stats") },
                         aiConfigured = aiConfig?.configured == true,
                         contentPadding = padding,
                     )
@@ -145,6 +147,13 @@ fun AppNavGraph(container: AppContainer) {
         }
         composable("licenses") {
             LicensesScreen(onBack = { nav.popBackStack() })
+        }
+        composable("library/stats") {
+            val vm = remember { container.libraryStatsViewModelFactory.create() }
+            LibraryStatsScreen(
+                viewModel = vm,
+                onBack = { nav.popBackStack() },
+            )
         }
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Sort
 import androidx.compose.material.icons.outlined.Info
@@ -74,6 +75,7 @@ fun LibraryScreen(
     viewModel: LibraryViewModel,
     onOpenBook: (documentId: Long) -> Unit,
     onShowDetails: (documentId: Long) -> Unit = {},
+    onShowStats: () -> Unit = {},
     aiConfigured: Boolean = false,
     contentPadding: PaddingValues,
 ) {
@@ -148,6 +150,24 @@ fun LibraryScreen(
                                     },
                                 )
                             }
+                        }
+                    }
+                    var moreMenuOpen by rememberSaveable { mutableStateOf(false) }
+                    Box {
+                        IconButton(onClick = { moreMenuOpen = true }) {
+                            Icon(Icons.Filled.MoreVert, contentDescription = "More")
+                        }
+                        DropdownMenu(
+                            expanded = moreMenuOpen,
+                            onDismissRequest = { moreMenuOpen = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Stats") },
+                                onClick = {
+                                    moreMenuOpen = false
+                                    onShowStats()
+                                },
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsScreen.kt
@@ -1,0 +1,175 @@
+package io.theficos.ereader.ui.library
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.theficos.ereader.data.library.LibraryStatsResponse
+import io.theficos.ereader.data.library.TopAuthor
+import io.theficos.ereader.data.library.TopTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LibraryStatsScreen(
+    viewModel: LibraryStatsViewModel,
+    onBack: () -> Unit,
+) {
+    LaunchedEffect(Unit) { viewModel.load() }
+    val state by viewModel.state.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Library stats") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (val s = state) {
+            is LibraryStatsUiState.Loading -> LoadingState(padding)
+            is LibraryStatsUiState.Error -> ErrorState(padding, s.message, onRetry = { viewModel.load() })
+            is LibraryStatsUiState.Ready -> ReadyState(padding, s.stats)
+        }
+    }
+}
+
+@Composable
+private fun LoadingState(padding: PaddingValues) {
+    Box(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentAlignment = Alignment.Center,
+    ) { Text("Loading…") }
+}
+
+@Composable
+private fun ErrorState(padding: PaddingValues, message: String, onRetry: () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(message, style = MaterialTheme.typography.bodyMedium)
+            TextButton(onClick = onRetry) { Text("Retry") }
+        }
+    }
+}
+
+@Composable
+private fun ReadyState(padding: PaddingValues, stats: LibraryStatsResponse) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                CountCard(label = "Books", value = stats.totalBooks, modifier = Modifier.weight(1f))
+                CountCard(label = "Finished", value = stats.finishedCount, modifier = Modifier.weight(1f))
+                CountCard(label = "Reading", value = stats.inProgressCount, modifier = Modifier.weight(1f))
+            }
+        }
+        item { SectionHeading("Top authors") }
+        if (stats.topAuthors.isEmpty()) {
+            item { PlaceholderText("No authors yet — add books to your library.") }
+        } else {
+            items(stats.topAuthors) { TopAuthorRow(it) }
+        }
+        item { SectionHeading("Top themes") }
+        item {
+            Text(
+                stats.themesCaveat,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (stats.topThemes.isEmpty()) {
+            item { PlaceholderText("No themes yet — open a book to generate insights, or regenerate older ones.") }
+        } else {
+            items(stats.topThemes) { TopThemeRow(it) }
+        }
+    }
+}
+
+@Composable
+private fun CountCard(label: String, value: Int, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(text = value.toString(), style = MaterialTheme.typography.displaySmall)
+            Text(text = label, style = MaterialTheme.typography.labelMedium)
+        }
+    }
+}
+
+@Composable
+private fun SectionHeading(text: String) {
+    Text(text, style = MaterialTheme.typography.titleMedium)
+}
+
+@Composable
+private fun PlaceholderText(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun TopAuthorRow(a: TopAuthor) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(a.name, style = MaterialTheme.typography.bodyLarge)
+        Text(a.count.toString(), style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+@Composable
+private fun TopThemeRow(t: TopTheme) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(t.theme.replace('_', ' '), style = MaterialTheme.typography.bodyLarge)
+        Text(t.count.toString(), style = MaterialTheme.typography.bodyLarge)
+    }
+}

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsViewModel.kt
@@ -1,0 +1,52 @@
+package io.theficos.ereader.ui.library
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.theficos.ereader.data.library.LibraryHttpException
+import io.theficos.ereader.data.library.LibraryStatsResponse
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed interface LibraryStatsUiState {
+    data object Loading : LibraryStatsUiState
+    data class Ready(val stats: LibraryStatsResponse) : LibraryStatsUiState
+    data class Error(val message: String) : LibraryStatsUiState
+}
+
+/**
+ * One-shot loader for the library stats endpoint. Re-runnable via [load] (the
+ * Stats screen's retry button calls it).
+ *
+ * Injected `fetch` lambda keeps the ViewModel purely testable — production
+ * binds it to `libraryClient::getStats`.
+ */
+class LibraryStatsViewModel(
+    private val fetch: suspend () -> LibraryStatsResponse,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<LibraryStatsUiState>(LibraryStatsUiState.Loading)
+    val state: StateFlow<LibraryStatsUiState> = _state.asStateFlow()
+
+    fun load() {
+        _state.value = LibraryStatsUiState.Loading
+        viewModelScope.launch {
+            _state.value = try {
+                LibraryStatsUiState.Ready(fetch())
+            } catch (e: LibraryHttpException) {
+                LibraryStatsUiState.Error(
+                    when (e.code) {
+                        401 -> "Sign in to your calibre-web instance to see stats."
+                        404 -> "Library stats aren't available on this server."
+                        else -> "Couldn't load stats (HTTP ${e.code})."
+                    }
+                )
+            } catch (e: Throwable) {
+                LibraryStatsUiState.Error(
+                    "Couldn't reach the server: ${e.message ?: "unknown error"}."
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryStatsViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryStatsViewModelTest.kt
@@ -1,0 +1,97 @@
+package io.theficos.ereader.ui.library
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.data.library.LibraryHttpException
+import io.theficos.ereader.data.library.LibraryStatsResponse
+import io.theficos.ereader.data.library.TopAuthor
+import io.theficos.ereader.data.library.TopTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryStatsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private val fakeStats = LibraryStatsResponse(
+        totalBooks = 3,
+        finishedCount = 1,
+        inProgressCount = 1,
+        topAuthors = listOf(TopAuthor("A", 1)),
+        topThemes = listOf(TopTheme("noir", 1, "v3+ insights only")),
+        themesCaveat = "caveat",
+    )
+
+    @Test
+    fun `load success transitions Loading to Ready`() = runTest(dispatcher) {
+        val vm = LibraryStatsViewModel(fetch = { fakeStats })
+        vm.state.test {
+            assertThat(awaitItem()).isInstanceOf(LibraryStatsUiState.Loading::class.java)
+            vm.load()
+            val ready = awaitItem()
+            assertThat(ready).isInstanceOf(LibraryStatsUiState.Ready::class.java)
+            assertThat((ready as LibraryStatsUiState.Ready).stats.totalBooks).isEqualTo(3)
+        }
+    }
+
+    @Test
+    fun `http error transitions to Error with code`() = runTest(dispatcher) {
+        val vm = LibraryStatsViewModel(fetch = { throw LibraryHttpException(503, "down") })
+        vm.state.test {
+            assertThat(awaitItem()).isInstanceOf(LibraryStatsUiState.Loading::class.java)
+            vm.load()
+            val err = awaitItem()
+            assertThat(err).isInstanceOf(LibraryStatsUiState.Error::class.java)
+            assertThat((err as LibraryStatsUiState.Error).message).contains("503")
+        }
+    }
+
+    @Test
+    fun `unauthorized maps to specific message`() = runTest(dispatcher) {
+        val vm = LibraryStatsViewModel(fetch = { throw LibraryHttpException(401, "nope") })
+        vm.state.test {
+            awaitItem() // Loading
+            vm.load()
+            val err = awaitItem() as LibraryStatsUiState.Error
+            assertThat(err.message).contains("Sign in")
+        }
+    }
+
+    @Test
+    fun `not found 404 maps to specific message`() = runTest(dispatcher) {
+        val vm = LibraryStatsViewModel(fetch = { throw LibraryHttpException(404, "nope") })
+        vm.state.test {
+            awaitItem() // Loading
+            vm.load()
+            val err = awaitItem() as LibraryStatsUiState.Error
+            assertThat(err.message).contains("aren't available")
+        }
+    }
+
+    @Test
+    fun `retry after error triggers fresh load`() = runTest(dispatcher) {
+        var attempt = 0
+        val vm = LibraryStatsViewModel(fetch = {
+            attempt++
+            if (attempt == 1) throw LibraryHttpException(500, "x") else fakeStats
+        })
+        vm.state.test {
+            awaitItem() // Loading
+            vm.load()
+            assertThat(awaitItem()).isInstanceOf(LibraryStatsUiState.Error::class.java)
+            vm.load()
+            assertThat(awaitItem()).isInstanceOf(LibraryStatsUiState.Loading::class.java)
+            assertThat(awaitItem()).isInstanceOf(LibraryStatsUiState.Ready::class.java)
+        }
+    }
+}

--- a/data/library/build.gradle.kts
+++ b/data/library/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "io.theficos.ereader.data.library"
+    compileSdk = 34
+    defaultConfig {
+        minSdk = 26
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+    kotlinOptions { jvmTarget = "21" }
+    testOptions { unitTests.isIncludeAndroidResources = true }
+}
+
+dependencies {
+    api(project(":core:model"))
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.okhttp.mockwebserver)
+}

--- a/data/library/src/main/AndroidManifest.xml
+++ b/data/library/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt
@@ -1,0 +1,5 @@
+package io.theficos.ereader.data.library
+
+object LibraryApi {
+    const val PATH_STATS = "/library/v1/stats"
+}

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
@@ -1,0 +1,46 @@
+package io.theficos.ereader.data.library
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * REST client for the `/library/v1` endpoints on opds-sync.
+ *
+ * Auth: relies on the shared OkHttpClient already carrying Basic auth (the
+ * same one used by `:data:sync` and `:data:ai`). This client does not add
+ * Authorization headers.
+ *
+ * v0 (PR9) exposes only `getStats`; future additions (`putItem`, `listItems`,
+ * `deleteItem`) will move here when Android-side library upload lands.
+ */
+class LibraryClient(
+    private val baseUrlProvider: () -> String?,
+    private val http: OkHttpClient,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    private fun resolveBaseUrl(): String {
+        val raw = baseUrlProvider()
+        if (raw.isNullOrBlank()) {
+            throw LibraryHttpException(0, "baseUrl not configured")
+        }
+        return raw.trimEnd('/')
+    }
+
+    suspend fun getStats(): LibraryStatsResponse = withContext(Dispatchers.IO) {
+        val req = Request.Builder()
+            .url(resolveBaseUrl() + LibraryApi.PATH_STATS)
+            .get()
+            .build()
+        http.newCall(req).execute().use { resp ->
+            val body = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) throw LibraryHttpException(resp.code, body)
+            json.decodeFromString(LibraryStatsResponse.serializer(), body)
+        }
+    }
+}
+
+class LibraryHttpException(val code: Int, val body: String) :
+    RuntimeException("library request failed: $code body=${body.take(200)}")

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
@@ -1,0 +1,27 @@
+package io.theficos.ereader.data.library
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TopAuthor(val name: String, val count: Int)
+
+@Serializable
+data class TopTheme(val theme: String, val count: Int, val note: String)
+
+/**
+ * Response body of `GET /library/v1/stats` (PR9).
+ *
+ * `themesCaveat` is a constant copy emitted by the server (sourcing it
+ * server-side means the wording can change without an app release). The
+ * client renders it verbatim under the top-themes section.
+ */
+@Serializable
+data class LibraryStatsResponse(
+    @SerialName("total_books") val totalBooks: Int,
+    @SerialName("finished_count") val finishedCount: Int,
+    @SerialName("in_progress_count") val inProgressCount: Int,
+    @SerialName("top_authors") val topAuthors: List<TopAuthor>,
+    @SerialName("top_themes") val topThemes: List<TopTheme>,
+    @SerialName("themes_caveat") val themesCaveat: String,
+)

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryClientTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryClientTest.kt
@@ -1,0 +1,82 @@
+package io.theficos.ereader.data.library
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class LibraryClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: LibraryClient
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = LibraryClient(
+            baseUrlProvider = { server.url("").toString().trimEnd('/') },
+            http = OkHttpClient.Builder().callTimeout(5, TimeUnit.SECONDS).build(),
+        )
+    }
+
+    @After fun tearDown() = server.shutdown()
+
+    @Test
+    fun `getStats parses response and hits correct path`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"total_books":1,"finished_count":0,"in_progress_count":1,"top_authors":[{"name":"A","count":1}],"top_themes":[{"theme":"noir","count":1,"note":"v3+ insights only"}],"themes_caveat":"caveat"}"""
+            )
+        )
+        val out = client.getStats()
+        assertThat(out.totalBooks).isEqualTo(1)
+        assertThat(out.topAuthors).hasSize(1)
+        assertThat(out.themesCaveat).isEqualTo("caveat")
+        val req = server.takeRequest()
+        assertThat(req.method).isEqualTo("GET")
+        assertThat(req.path).isEqualTo("/library/v1/stats")
+    }
+
+    @Test
+    fun `401 raises LibraryHttpException with code 401`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("nope"))
+        try {
+            client.getStats()
+            error("expected throw")
+        } catch (e: LibraryHttpException) {
+            assertThat(e.code).isEqualTo(401)
+        }
+    }
+
+    @Test
+    fun `404 raises LibraryHttpException with code 404`() = runTest {
+        // Mode-gated server (PROGRESS_ENABLED=false) returns 404. Surface it
+        // as a distinct error so the UI can render an actionable message.
+        server.enqueue(MockResponse().setResponseCode(404).setBody("not_found"))
+        try {
+            client.getStats()
+            error("expected throw")
+        } catch (e: LibraryHttpException) {
+            assertThat(e.code).isEqualTo(404)
+        }
+    }
+
+    @Test
+    fun `null baseUrl raises LibraryHttpException with code 0`() = runTest {
+        val noBase = LibraryClient(
+            baseUrlProvider = { null },
+            http = OkHttpClient.Builder().callTimeout(1, TimeUnit.SECONDS).build(),
+        )
+        try {
+            noBase.getStats()
+            error("expected throw")
+        } catch (e: LibraryHttpException) {
+            assertThat(e.code).isEqualTo(0)
+            assertThat(e.body).contains("baseUrl not configured")
+        }
+    }
+}

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
@@ -1,0 +1,40 @@
+package io.theficos.ereader.data.library
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class LibraryDtosTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `parses full response`() {
+        val body = """
+            {
+              "total_books": 5,
+              "finished_count": 2,
+              "in_progress_count": 1,
+              "top_authors": [{"name":"Asimov","count":3}],
+              "top_themes": [{"theme":"noir","count":2,"note":"v3+ insights only"}],
+              "themes_caveat": "Theme stats include books with AI theme data; older cached insights may be missing until regenerated."
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryStatsResponse.serializer(), body)
+        assertThat(parsed.totalBooks).isEqualTo(5)
+        assertThat(parsed.finishedCount).isEqualTo(2)
+        assertThat(parsed.inProgressCount).isEqualTo(1)
+        assertThat(parsed.topAuthors).containsExactly(TopAuthor("Asimov", 3))
+        assertThat(parsed.topThemes).containsExactly(TopTheme("noir", 2, "v3+ insights only"))
+        assertThat(parsed.themesCaveat).contains("may be missing")
+    }
+
+    @Test
+    fun `parses empty lists`() {
+        val body = """
+            {"total_books":0,"finished_count":0,"in_progress_count":0,"top_authors":[],"top_themes":[],"themes_caveat":"x"}
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryStatsResponse.serializer(), body)
+        assertThat(parsed.topAuthors).isEmpty()
+        assertThat(parsed.topThemes).isEmpty()
+    }
+}

--- a/server/opds_sync/api/library.py
+++ b/server/opds_sync/api/library.py
@@ -30,18 +30,28 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import and_, select
+from sqlalchemy import and_, case, func, literal_column, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opds_sync.api.library_schemas import (
+    LIBRARY_STATS_THEMES_CAVEAT,
     LibraryItemDeleteBody,
     LibraryItemListResponse,
     LibraryItemPutBody,
     LibraryItemRequest,
     LibraryItemResponse,
+    LibraryStatsResponse,
+    TopAuthor,
+    TopTheme,
 )
 from opds_sync.core.auth import current_user_id
-from opds_sync.db.models import LibraryItem
+from opds_sync.db.models import (
+    BookInsight,
+    BookTheme,
+    Document,
+    LibraryItem,
+    Progress,
+)
 from opds_sync.db.session import get_session
 
 router = APIRouter(tags=["library"])
@@ -221,3 +231,190 @@ async def delete_item(
         await session.refresh(row)
 
     return _to_response(row)
+
+
+# ---------------------------------------------------------------------------
+# GET /stats — PR9 library stats v0.
+# ---------------------------------------------------------------------------
+# User-scoped throughout. The three load-bearing theme-join filters
+# (documented in PR3's body and architecture.md):
+#
+#   1. `book_insights.superseded_at IS NULL` — regenerate is supersede-not-
+#      delete; FK CASCADE only fires on actual DELETE. Without this,
+#      regenerated insights double-count.
+#   2. `book_themes.confidence >= 1.0` — off-vocab passthroughs and the
+#      empty-input "other" fallback live at 0.5. Filter excludes them from
+#      the controlled-vocab top-N.
+#   3. `COUNT(DISTINCT library_items.pk)` per theme — combined with the
+#      pick-one CTE below, this prevents a book with multiple cache
+#      variants (different tone/language/model_id, all `superseded_at IS
+#      NULL`) from contributing to multiple theme keys.
+#
+# Architect finding (2026-05-17): a naive `JOIN ... ON metadata_id OR
+# content_hash` plus `COUNT(DISTINCT li.pk)` can still attribute one book
+# to MULTIPLE theme keys when variants emit different theme sets (variant
+# A says {mystery}, variant B says {noir, crime}). The DISTINCT-ON CTE
+# below picks exactly one insight row per library item before aggregating
+# themes; pick order mirrors the orchestrator's lookup hierarchy
+# (metadata_id > content_hash; most-recent generated_at as tiebreaker).
+@router.get("/stats", response_model=LibraryStatsResponse)
+async def get_stats(
+    user_id: Annotated[str, Depends(current_user_id)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> LibraryStatsResponse:
+    # 1. total_books: alive library items for this user.
+    total_books = (
+        await session.scalar(
+            select(func.count())
+            .select_from(LibraryItem)
+            .where(LibraryItem.user_id == user_id, LibraryItem.deleted_at.is_(None))
+        )
+    ) or 0
+
+    # 2a. finished_count: library_items JOIN documents JOIN progress, where
+    #     finished_at IS NOT NULL. The (user_id, content_hash) join is the
+    #     only correct way to bridge — library_items.pk and documents.pk are
+    #     independent identifiers.
+    finished_count = (
+        await session.scalar(
+            select(func.count())
+            .select_from(LibraryItem)
+            .join(
+                Document,
+                and_(
+                    Document.user_id == LibraryItem.user_id,
+                    Document.content_hash == LibraryItem.content_hash,
+                ),
+            )
+            .join(Progress, Progress.document_pk == Document.pk)
+            .where(
+                LibraryItem.user_id == user_id,
+                LibraryItem.deleted_at.is_(None),
+                Progress.finished_at.is_not(None),
+            )
+        )
+    ) or 0
+
+    # 2b. in_progress_count: started but not finished. We do NOT cap at
+    #     percent < 1: a book at percent=1 with finished_at IS NULL still
+    #     counts as in-progress ("not done until the device says so").
+    in_progress_count = (
+        await session.scalar(
+            select(func.count())
+            .select_from(LibraryItem)
+            .join(
+                Document,
+                and_(
+                    Document.user_id == LibraryItem.user_id,
+                    Document.content_hash == LibraryItem.content_hash,
+                ),
+            )
+            .join(Progress, Progress.document_pk == Document.pk)
+            .where(
+                LibraryItem.user_id == user_id,
+                LibraryItem.deleted_at.is_(None),
+                Progress.finished_at.is_(None),
+                Progress.percent > 0,
+            )
+        )
+    ) or 0
+
+    # 3. top_authors: unnest the JSONB `authors` array via LATERAL and group.
+    #    `jsonb_array_elements_text` returns typed text — no quoting weirdness.
+    #    COUNT(DISTINCT LibraryItem.pk) defends against an upstream OPF
+    #    parser ever emitting the same author twice in one array (it doesn't
+    #    today, but cheaper to defend than to debug later). Secondary alpha
+    #    sort is load-bearing for deterministic tiebreaks.
+    author_col = (
+        func.jsonb_array_elements_text(LibraryItem.authors)
+        .table_valued("value")
+        .render_derived(name="author")
+    )
+    author_value = literal_column("author.value")
+    author_count = func.count(func.distinct(LibraryItem.pk))
+    author_rows = (
+        await session.execute(
+            select(author_value.label("name"), author_count.label("c"))
+            .select_from(LibraryItem)
+            .join(author_col, literal_column("true"))
+            .where(
+                LibraryItem.user_id == user_id,
+                LibraryItem.deleted_at.is_(None),
+            )
+            .group_by(author_value)
+            .order_by(author_count.desc(), author_value.asc())
+            .limit(5)
+        )
+    ).all()
+    top_authors = [TopAuthor(name=row.name, count=int(row.c)) for row in author_rows]
+
+    # 4. top_themes: pick-one-insight-per-book CTE, then aggregate themes.
+    #    See the block comment at the top of this function for the full
+    #    rationale.
+    pick_priority = case(
+        (
+            and_(
+                BookInsight.metadata_id.is_not(None),
+                BookInsight.metadata_id == LibraryItem.metadata_id,
+            ),
+            0,
+        ),
+        else_=1,
+    )
+
+    picked = (
+        select(
+            LibraryItem.pk.label("library_item_pk"),
+            BookInsight.id.label("book_insight_id"),
+        )
+        .select_from(LibraryItem)
+        .join(
+            BookInsight,
+            and_(
+                BookInsight.superseded_at.is_(None),  # filter 1
+                (
+                    (
+                        BookInsight.metadata_id.is_not(None)
+                        & (BookInsight.metadata_id == LibraryItem.metadata_id)
+                    )
+                    | (BookInsight.content_hash == LibraryItem.content_hash)
+                ),
+            ),
+        )
+        .where(
+            LibraryItem.user_id == user_id,
+            LibraryItem.deleted_at.is_(None),
+        )
+        .order_by(LibraryItem.pk, pick_priority, BookInsight.generated_at.desc())
+        # PostgreSQL DISTINCT ON via SQLAlchemy: keep one row per
+        # library_item_pk, picking the lowest priority (metadata match)
+        # and most recent generated_at via the trailing ORDER BY.
+        .distinct(LibraryItem.pk)
+        .subquery("picked_insight")
+    )
+
+    theme_count = func.count(func.distinct(picked.c.library_item_pk))
+    theme_rows = (
+        await session.execute(
+            select(BookTheme.theme.label("theme"), theme_count.label("c"))
+            .select_from(picked)
+            .join(BookTheme, BookTheme.book_insight_id == picked.c.book_insight_id)
+            .where(BookTheme.confidence >= 1.0)  # filter 2
+            .group_by(BookTheme.theme)
+            .order_by(theme_count.desc(), BookTheme.theme.asc())
+            .limit(5)
+        )
+    ).all()
+    top_themes = [
+        TopTheme(theme=row.theme, count=int(row.c), note="v3+ insights only")
+        for row in theme_rows
+    ]
+
+    return LibraryStatsResponse(
+        total_books=int(total_books),
+        finished_count=int(finished_count),
+        in_progress_count=int(in_progress_count),
+        top_authors=top_authors,
+        top_themes=top_themes,
+        themes_caveat=LIBRARY_STATS_THEMES_CAVEAT,
+    )

--- a/server/opds_sync/api/library.py
+++ b/server/opds_sync/api/library.py
@@ -406,8 +406,7 @@ async def get_stats(
         )
     ).all()
     top_themes = [
-        TopTheme(theme=row.theme, count=int(row.c), note="v3+ insights only")
-        for row in theme_rows
+        TopTheme(theme=row.theme, count=int(row.c), note="v3+ insights only") for row in theme_rows
     ]
 
     return LibraryStatsResponse(

--- a/server/opds_sync/api/library_schemas.py
+++ b/server/opds_sync/api/library_schemas.py
@@ -105,3 +105,42 @@ def _iso(v: datetime) -> str:
     if v.tzinfo is None:
         v = v.replace(tzinfo=UTC)
     return v.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Library stats v0 (PR9)
+# ---------------------------------------------------------------------------
+# Pure aggregation response. `themes_caveat` is a constant server-emitted
+# copy: the client renders it verbatim. Sourcing it server-side means the
+# wording can change without an app release.
+
+
+class TopAuthor(BaseModel):
+    name: str
+    count: int
+
+
+class TopTheme(BaseModel):
+    theme: str
+    count: int
+    note: str  # always "v3+ insights only" in v0
+
+
+# Public copy lives here so both the endpoint and (eventually) the docs page
+# can reference the same string. Honest wording (architect review,
+# 2026-05-17): the query gates on presence of `book_themes` rows, not on a
+# specific `prompt_version` threshold — `OPDS_SYNC_AI_PROMPT_VERSION` is
+# operator-configured and may not be pinned to "4" in every deployment.
+LIBRARY_STATS_THEMES_CAVEAT: str = (
+    "Theme stats include books with AI theme data; older cached insights "
+    "may be missing until regenerated."
+)
+
+
+class LibraryStatsResponse(BaseModel):
+    total_books: int
+    finished_count: int
+    in_progress_count: int
+    top_authors: list[TopAuthor]
+    top_themes: list[TopTheme]
+    themes_caveat: str

--- a/server/tests/integration/test_library_stats.py
+++ b/server/tests/integration/test_library_stats.py
@@ -171,9 +171,7 @@ async def test_in_progress_excludes_zero_percent(app_under_test, unique_user):
     assert data["in_progress_count"] == 1  # only b
 
 
-async def test_in_progress_includes_percent_one_without_finished_at(
-    app_under_test, unique_user
-):
+async def test_in_progress_includes_percent_one_without_finished_at(app_under_test, unique_user):
     """Edge case: percent=1 but finished_at IS NULL. Architect-reviewed
     semantics — "not done until the device says so". Still counts as in
     progress.
@@ -217,9 +215,7 @@ async def test_user_scoping(app_under_test, unique_user):
 # ---------------------------------------------------------------------------
 
 
-async def test_top_authors_groups_jsonb_and_orders_by_count_desc(
-    app_under_test, unique_user
-):
+async def test_top_authors_groups_jsonb_and_orders_by_count_desc(app_under_test, unique_user):
     transport = ASGITransport(app=app_under_test)
     headers = _basic(*unique_user)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
@@ -391,9 +387,7 @@ async def test_top_themes_basic(app_under_test, unique_user, session_factory):
 
 
 @pytest.mark.requires_ai
-async def test_top_themes_filters_superseded(
-    app_under_test, unique_user, session_factory
-):
+async def test_top_themes_filters_superseded(app_under_test, unique_user, session_factory):
     """Regenerate produces a new live row + supersedes the old. Old themes
     must NOT count. Filter 1 from the three load-bearing filters.
     """
@@ -449,9 +443,7 @@ async def test_top_themes_filters_off_vocab_confidence(
 
 
 @pytest.mark.requires_ai
-async def test_top_themes_dedup_across_tone_variants(
-    app_under_test, unique_user, session_factory
-):
+async def test_top_themes_dedup_across_tone_variants(app_under_test, unique_user, session_factory):
     """Same identity, two LIVE insight rows under different tones, SAME
     themes. Book counts ONCE per theme. Filter 3 from the three load-
     bearing filters (COUNT DISTINCT).
@@ -520,6 +512,7 @@ async def test_top_themes_picks_one_insight_per_book_when_variants_differ(
 
     async with session_factory() as s:
         from sqlalchemy import select as _sel
+
         seeded = (
             await s.execute(_sel(BookInsight).where(BookInsight.content_hash == "t-ch-vs"))
         ).scalar_one()

--- a/server/tests/integration/test_library_stats.py
+++ b/server/tests/integration/test_library_stats.py
@@ -1,0 +1,583 @@
+"""Integration tests for `GET /library/v1/stats` (PR9).
+
+Mode-gated: requires_progress. The CI mode matrix skips this whole module
+when OPDS_SYNC_PROGRESS_ENABLED=false; the mode-gated 404 case is asserted
+in test_modes.py once routing is verified.
+
+Theme tests additionally require AI mode for the orchestrator-seeded
+`book_insights` + `book_themes` rows. Themes tests carry `requires_ai`
+on top of the module-level `requires_progress` marker.
+"""
+
+from __future__ import annotations
+
+import base64
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from opds_sync.api.ai_schemas import DocumentIdentity, MetadataBundle
+from opds_sync.core.ai.service import InsightOrchestrator
+from opds_sync.db.models import BookInsight, BookTheme
+
+pytestmark = pytest.mark.requires_progress
+
+
+def _basic(user: str, pw: str) -> dict[str, str]:
+    token = base64.b64encode(f"{user}:{pw}".encode()).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+@pytest.fixture
+def unique_user(cwa_users) -> tuple[str, str]:
+    user = f"user-{uuid.uuid4().hex[:8]}"
+    pw = "pw"
+    cwa_users[user] = pw
+    return user, pw
+
+
+def _put_body(**overrides) -> dict:
+    base = {
+        "metadata_id": "md-1",
+        "content_hash": "ch-1",
+        "title": "Foundation",
+        "authors": ["Isaac Asimov"],
+        "series_name": None,
+        "series_index": None,
+        "isbn": None,
+        "language": None,
+        "subjects": [],
+        "opds_href": None,
+    }
+    base.update(overrides)
+    return {"item": base}
+
+
+def _progress_body(content_hash: str, percent: float, finished: bool, when: str) -> dict:
+    return {
+        "items": [
+            {
+                "document": {"metadata_id": None, "content_hash": content_hash},
+                "locator": "{}",
+                "percent": percent,
+                "client_updated_at": when,
+                "finished_at": when if finished else None,
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_library_returns_zero_counts(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get("/library/v1/stats", headers=headers)
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["total_books"] == 0
+    assert data["finished_count"] == 0
+    assert data["in_progress_count"] == 0
+    assert data["top_authors"] == []
+    assert data["top_themes"] == []
+    assert "may be missing" in data["themes_caveat"]
+
+
+async def test_total_books_counts_alive_only(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put("/library/v1/items", json=_put_body(content_hash="a"), headers=headers)
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="b", metadata_id="md-2"),
+            headers=headers,
+        )
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="c", metadata_id="md-3"),
+            headers=headers,
+        )
+        await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "c"}},
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["total_books"] == 2
+
+
+async def test_finished_count_requires_finished_at(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    now = datetime.now(UTC).isoformat()
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put("/library/v1/items", json=_put_body(content_hash="a"), headers=headers)
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="b", metadata_id="md-2"),
+            headers=headers,
+        )
+        # `a` finished; `b` has progress but never finished.
+        await c.post(
+            "/sync/v1/progress",
+            json=_progress_body("a", 1.0, True, now),
+            headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress",
+            json=_progress_body("b", 0.4, False, now),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    data = r.json()
+    assert data["finished_count"] == 1
+    assert data["in_progress_count"] == 1
+
+
+async def test_in_progress_excludes_zero_percent(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    now = datetime.now(UTC).isoformat()
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put("/library/v1/items", json=_put_body(content_hash="a"), headers=headers)
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="b", metadata_id="md-2"),
+            headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress",
+            json=_progress_body("a", 0.0, False, now),
+            headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress",
+            json=_progress_body("b", 0.5, False, now),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    data = r.json()
+    assert data["in_progress_count"] == 1  # only b
+
+
+async def test_in_progress_includes_percent_one_without_finished_at(
+    app_under_test, unique_user
+):
+    """Edge case: percent=1 but finished_at IS NULL. Architect-reviewed
+    semantics — "not done until the device says so". Still counts as in
+    progress.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    now = datetime.now(UTC).isoformat()
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="edge"),
+            headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress",
+            json=_progress_body("edge", 1.0, False, now),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    data = r.json()
+    assert data["in_progress_count"] == 1
+    assert data["finished_count"] == 0
+
+
+async def test_user_scoping(app_under_test, unique_user):
+    """User A's books invisible to user B; both use real `cwa_users` entries."""
+    transport = ASGITransport(app=app_under_test)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="aaa"),
+            headers=_basic("alice", "alicepass"),
+        )
+        r = await c.get("/library/v1/stats", headers=_basic("bob", "bobpass"))
+    assert r.status_code == 200
+    assert r.json()["total_books"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Top authors
+# ---------------------------------------------------------------------------
+
+
+async def test_top_authors_groups_jsonb_and_orders_by_count_desc(
+    app_under_test, unique_user
+):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # 3 Asimov, 2 Le Guin, 1 co-authored (Asimov + Pohl).
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="a1", authors=["Isaac Asimov"]),
+            headers=headers,
+        )
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="a2", metadata_id="md-a2", authors=["Isaac Asimov"]),
+            headers=headers,
+        )
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(
+                content_hash="a3",
+                metadata_id="md-a3",
+                authors=["Isaac Asimov", "Frederik Pohl"],
+            ),
+            headers=headers,
+        )
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="l1", metadata_id="md-l1", authors=["Ursula K. Le Guin"]),
+            headers=headers,
+        )
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="l2", metadata_id="md-l2", authors=["Ursula K. Le Guin"]),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    top = r.json()["top_authors"]
+    assert top == [
+        {"name": "Isaac Asimov", "count": 3},
+        {"name": "Ursula K. Le Guin", "count": 2},
+        {"name": "Frederik Pohl", "count": 1},
+    ]
+
+
+async def test_top_authors_limit_5_with_stable_tiebreak(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # 6 distinct authors, one book each → ties on count=1, alphabetical wins.
+        for i, name in enumerate(["F", "E", "D", "C", "B", "A"]):
+            await c.put(
+                "/library/v1/items",
+                json=_put_body(content_hash=f"ch-{i}", metadata_id=f"md-{i}", authors=[name]),
+                headers=headers,
+            )
+        r = await c.get("/library/v1/stats", headers=headers)
+    top = [x["name"] for x in r.json()["top_authors"]]
+    assert top == ["A", "B", "C", "D", "E"]  # top 5, alphabetical
+
+
+async def test_top_authors_ignores_tombstoned_books(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="x", authors=["Tombstone Author"]),
+            headers=headers,
+        )
+        await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "x"}},
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    assert r.json()["top_authors"] == []
+
+
+# ---------------------------------------------------------------------------
+# Top themes — require AI mode for orchestrator-driven seeding.
+# ---------------------------------------------------------------------------
+
+
+class _FakeAIClient:
+    def __init__(self, themes: list[str] | None) -> None:
+        self.themes = themes
+
+    async def chat_structured(self, *, system, user, schema, timeout_s):  # noqa: ARG002
+        return schema.model_validate(
+            {
+                "schema_version": 3,
+                "intro": "Fake.",
+                "confidence": "high",
+                "themes": self.themes,
+            }
+        )
+
+
+class _FakeRetriever:
+    async def lookup_wikipedia(self, **_kw):
+        return []
+
+    async def lookup_openlibrary(self, **_kw):
+        return []
+
+
+def _orch(ai: _FakeAIClient) -> InsightOrchestrator:
+    return InsightOrchestrator(
+        ai=ai,
+        retriever_factory=lambda _s: _FakeRetriever(),
+        sources_enabled=(),
+        model_id="stats-test-model",
+        prompt_version="4",
+        max_concurrency=2,
+        ai_timeout_s=5.0,
+    )
+
+
+@pytest.fixture
+async def session_factory(engine) -> AsyncIterator[async_sessionmaker]:
+    yield async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_insight(
+    session_factory, *, metadata_id: str, content_hash: str, themes: list[str]
+) -> None:
+    ai = _FakeAIClient(themes=themes)
+    orch = _orch(ai)
+    ident = DocumentIdentity(metadata_id=metadata_id, content_hash=content_hash)
+    bundle = MetadataBundle(title=content_hash)
+    async with session_factory() as s:
+        await orch.generate(s, ident, bundle, user_id="stats-seed", tenant_id="local")
+
+
+async def _seed_regen(
+    session_factory, *, metadata_id: str, content_hash: str, themes: list[str]
+) -> None:
+    ai = _FakeAIClient(themes=themes)
+    orch = _orch(ai)
+    ident = DocumentIdentity(metadata_id=metadata_id, content_hash=content_hash)
+    bundle = MetadataBundle(title=content_hash)
+    async with session_factory() as s:
+        await orch.regenerate(
+            s, ident, bundle, user_id="stats-seed", reason="redo", tenant_id="local"
+        )
+
+
+@pytest.mark.requires_ai
+async def test_top_themes_basic(app_under_test, unique_user, session_factory):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    await _seed_insight(
+        session_factory,
+        metadata_id="t-md-1",
+        content_hash="t-ch-1",
+        themes=["mystery", "noir"],
+    )
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="t-ch-1", metadata_id="t-md-1"),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    themes = r.json()["top_themes"]
+    names = sorted([t["theme"] for t in themes])
+    assert names == ["mystery", "noir"]
+    assert all(t["count"] == 1 for t in themes)
+    assert all(t["note"] == "v3+ insights only" for t in themes)
+
+
+@pytest.mark.requires_ai
+async def test_top_themes_filters_superseded(
+    app_under_test, unique_user, session_factory
+):
+    """Regenerate produces a new live row + supersedes the old. Old themes
+    must NOT count. Filter 1 from the three load-bearing filters.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    await _seed_insight(
+        session_factory,
+        metadata_id="t-md-2",
+        content_hash="t-ch-2",
+        themes=["mystery", "noir"],
+    )
+    await _seed_regen(
+        session_factory,
+        metadata_id="t-md-2",
+        content_hash="t-ch-2",
+        themes=["thriller", "crime"],
+    )
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="t-ch-2", metadata_id="t-md-2"),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    names = sorted([t["theme"] for t in r.json()["top_themes"]])
+    assert names == ["crime", "thriller"]  # superseded mystery/noir excluded
+
+
+@pytest.mark.requires_ai
+async def test_top_themes_filters_off_vocab_confidence(
+    app_under_test, unique_user, session_factory
+):
+    """Off-vocab strings land at confidence=0.5; filter excludes them.
+    Filter 2 from the three load-bearing filters.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    await _seed_insight(
+        session_factory,
+        metadata_id="t-md-3",
+        content_hash="t-ch-3",
+        themes=["mystery", "weird genre"],
+    )
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="t-ch-3", metadata_id="t-md-3"),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    names = sorted([t["theme"] for t in r.json()["top_themes"]])
+    assert names == ["mystery"]
+
+
+@pytest.mark.requires_ai
+async def test_top_themes_dedup_across_tone_variants(
+    app_under_test, unique_user, session_factory
+):
+    """Same identity, two LIVE insight rows under different tones, SAME
+    themes. Book counts ONCE per theme. Filter 3 from the three load-
+    bearing filters (COUNT DISTINCT).
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+
+    await _seed_insight(
+        session_factory,
+        metadata_id="t-md-4",
+        content_hash="t-ch-4",
+        themes=["mystery"],
+    )
+    async with session_factory() as s:
+        insight2 = BookInsight(
+            metadata_id="t-md-4",
+            content_hash="t-ch-4",
+            model_id="stats-test-model",
+            prompt_version="4",
+            tone="scholarly",
+            language="auto",
+            sources_used=[],
+            payload={"schema_version": 3, "intro": "v2", "confidence": "high"},
+            sources=[],
+            generated_by="stats-seed",
+        )
+        s.add(insight2)
+        await s.flush()
+        s.add(BookTheme(book_insight_id=insight2.id, theme="mystery", confidence=1.0))
+        await s.commit()
+
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="t-ch-4", metadata_id="t-md-4"),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    themes = r.json()["top_themes"]
+    assert themes == [{"theme": "mystery", "count": 1, "note": "v3+ insights only"}]
+
+
+@pytest.mark.requires_ai
+async def test_top_themes_picks_one_insight_per_book_when_variants_differ(
+    app_under_test, unique_user, session_factory
+):
+    """Architect finding (2026-05-17): two LIVE insights for the same book
+    with DIFFERENT themes (variant A → {mystery}, variant B → {noir, crime})
+    would, under a naive `JOIN ... ON metadata_id OR content_hash` + COUNT
+    DISTINCT, attribute the book to three theme keys.
+
+    The DISTINCT-ON CTE picks exactly one insight per library item; most
+    recent generated_at wins. So the book contributes to one canonical
+    theme set, not the union.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+
+    # Seed the OLDER variant first (themes={mystery}).
+    await _seed_insight(
+        session_factory,
+        metadata_id="t-md-vs",
+        content_hash="t-ch-vs",
+        themes=["mystery"],
+    )
+
+    async with session_factory() as s:
+        from sqlalchemy import select as _sel
+        seeded = (
+            await s.execute(_sel(BookInsight).where(BookInsight.content_hash == "t-ch-vs"))
+        ).scalar_one()
+        # Backdate the seeded row so generated_at ordering is unambiguous.
+        seeded.generated_at = datetime.now(UTC) - timedelta(hours=1)
+
+        # NEWER live variant under a different tone, different themes.
+        newer = BookInsight(
+            metadata_id="t-md-vs",
+            content_hash="t-ch-vs",
+            model_id="stats-test-model",
+            prompt_version="4",
+            tone="scholarly",
+            language="auto",
+            sources_used=[],
+            payload={"schema_version": 3, "intro": "v2", "confidence": "high"},
+            sources=[],
+            generated_by="stats-seed",
+            generated_at=datetime.now(UTC),
+        )
+        s.add(newer)
+        await s.flush()
+        s.add(BookTheme(book_insight_id=newer.id, theme="noir", confidence=1.0))
+        s.add(BookTheme(book_insight_id=newer.id, theme="crime", confidence=1.0))
+        await s.commit()
+
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="t-ch-vs", metadata_id="t-md-vs"),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    names = sorted([t["theme"] for t in r.json()["top_themes"]])
+    # The newer variant wins → {noir, crime}. `mystery` from the older
+    # variant must NOT appear (without the pick-one CTE we'd see all three).
+    assert names == ["crime", "noir"]
+
+
+@pytest.mark.requires_ai
+async def test_top_themes_user_scoped(app_under_test, unique_user, session_factory):
+    """`book_insights` is shared cache; the per-user filter is on `library_items`.
+    Alice has the book in her library; Bob doesn't, so Bob sees no themes.
+    """
+    transport = ASGITransport(app=app_under_test)
+    await _seed_insight(
+        session_factory,
+        metadata_id="t-md-5",
+        content_hash="t-ch-5",
+        themes=["mystery"],
+    )
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="t-ch-5", metadata_id="t-md-5"),
+            headers=_basic("alice", "alicepass"),
+        )
+        r_alice = await c.get("/library/v1/stats", headers=_basic("alice", "alicepass"))
+        r_bob = await c.get("/library/v1/stats", headers=_basic("bob", "bobpass"))
+    assert [t["theme"] for t in r_alice.json()["top_themes"]] == ["mystery"]
+    assert r_bob.json()["top_themes"] == []

--- a/server/tests/integration/test_modes.py
+++ b/server/tests/integration/test_modes.py
@@ -46,6 +46,10 @@ async def test_full_mode_mounts_everything(monkeypatch, postgres_url: str, alemb
         lib = await c.get("/library/v1/items", headers=_basic_header("alice"))
         assert lib.status_code != 404
 
+        # PR9 stats endpoint is part of the same router.
+        stats = await c.get("/library/v1/stats", headers=_basic_header("alice"))
+        assert stats.status_code != 404
+
         # AI router mounted: any response other than 404 confirms routing.
         ai = await c.get("/ai/v1/config", headers=_basic_header("alice"))
         assert ai.status_code != 404
@@ -77,6 +81,9 @@ async def test_ai_only_mode_excludes_progress(monkeypatch, postgres_url: str, al
         # Library namespace unmounted in AI-only mode.
         lib = await c.get("/library/v1/items", headers=_basic_header("alice"))
         assert lib.status_code == 404
+        # PR9 stats endpoint also rides on the progress gate.
+        stats = await c.get("/library/v1/stats", headers=_basic_header("alice"))
+        assert stats.status_code == 404
 
 
 async def test_neither_mode_only_mounts_health(monkeypatch, postgres_url: str, alembic_upgrade):
@@ -94,5 +101,7 @@ async def test_neither_mode_only_mounts_health(monkeypatch, postgres_url: str, a
         assert prog.status_code == 404
         lib = await c.get("/library/v1/items", headers=_basic_header("alice"))
         assert lib.status_code == 404
+        stats = await c.get("/library/v1/stats", headers=_basic_header("alice"))
+        assert stats.status_code == 404
         ai = await c.get("/ai/v1/config", headers=_basic_header("alice"))
         assert ai.status_code == 404

--- a/server/tests/unit/test_library_schemas.py
+++ b/server/tests/unit/test_library_schemas.py
@@ -1,0 +1,43 @@
+"""Unit tests for `LibraryStatsResponse` and friends (PR9)."""
+
+from __future__ import annotations
+
+from opds_sync.api.library_schemas import (
+    LIBRARY_STATS_THEMES_CAVEAT,
+    LibraryStatsResponse,
+    TopAuthor,
+    TopTheme,
+)
+
+
+def test_library_stats_response_shape_and_defaults() -> None:
+    resp = LibraryStatsResponse(
+        total_books=3,
+        finished_count=1,
+        in_progress_count=1,
+        top_authors=[TopAuthor(name="Asimov", count=2)],
+        top_themes=[TopTheme(theme="noir", count=1, note="v3+ insights only")],
+        themes_caveat=LIBRARY_STATS_THEMES_CAVEAT,
+    )
+    dumped = resp.model_dump()
+    assert dumped["total_books"] == 3
+    assert dumped["finished_count"] == 1
+    assert dumped["in_progress_count"] == 1
+    assert dumped["top_authors"] == [{"name": "Asimov", "count": 2}]
+    assert dumped["top_themes"] == [
+        {"theme": "noir", "count": 1, "note": "v3+ insights only"}
+    ]
+    assert "may be missing" in dumped["themes_caveat"]
+
+
+def test_library_stats_response_empty_lists_allowed() -> None:
+    resp = LibraryStatsResponse(
+        total_books=0,
+        finished_count=0,
+        in_progress_count=0,
+        top_authors=[],
+        top_themes=[],
+        themes_caveat="x",
+    )
+    assert resp.top_authors == []
+    assert resp.top_themes == []

--- a/server/tests/unit/test_library_schemas.py
+++ b/server/tests/unit/test_library_schemas.py
@@ -24,9 +24,7 @@ def test_library_stats_response_shape_and_defaults() -> None:
     assert dumped["finished_count"] == 1
     assert dumped["in_progress_count"] == 1
     assert dumped["top_authors"] == [{"name": "Asimov", "count": 2}]
-    assert dumped["top_themes"] == [
-        {"theme": "noir", "count": 1, "note": "v3+ insights only"}
-    ]
+    assert dumped["top_themes"] == [{"theme": "noir", "count": 1, "note": "v3+ insights only"}]
     assert "may be missing" in dumped["themes_caveat"]
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     ":core:identity",
     ":core:metadata",
     ":data:ai",
+    ":data:library",
     ":data:local",
     ":data:opds",
     ":data:sync",


### PR DESCRIPTION
## Summary

Adds `GET /library/v1/stats` (PROGRESS_ENABLED-gated) returning:

- Counts: `total_books`, `finished_count`, `in_progress_count`.
- `top_authors`: top 5 by alive-library-item count (JSONB `LATERAL jsonb_array_elements_text` unnest, `COUNT(DISTINCT library_items.pk)` per author).
- `top_themes`: top 5 by `COUNT(DISTINCT library_items.pk)`, with controlled-vocab + live-only filters and a DISTINCT-ON pick-one-insight-per-book CTE.
- `themes_caveat`: server-emitted constant copy.

Plus an Android `LibraryStatsScreen` reached from a new overflow menu entry on the library home.

## Response shape

```json
{
  "total_books": 123,
  "finished_count": 42,
  "in_progress_count": 7,
  "top_authors": [{"name": "Isaac Asimov", "count": 12}],
  "top_themes": [{"theme": "noir", "count": 8, "note": "v3+ insights only"}],
  "themes_caveat": "Theme stats include books with AI theme data; older cached insights may be missing until regenerated."
}
```

## Load-bearing theme-join filters

Three filters live in the top-themes query, each with a regression test:

1. `book_insights.superseded_at IS NULL` — regenerate is supersede-not-delete; FK CASCADE only fires on actual DELETE. Without this, regenerated insights double-count.
2. `book_themes.confidence >= 1.0` — off-vocab passthroughs (and the empty-input fallback to ``other``) live at 0.5. This excludes them from the controlled-vocab top-N.
3. `COUNT(DISTINCT library_items.pk)` plus a per-library-item DISTINCT-ON CTE that picks exactly one insight row per book (metadata_id match preferred, content_hash fallback, most-recent ``generated_at`` as tiebreaker). The CTE addresses an architect-flagged latent bug: with multiple live cache variants (different tone/language/model) emitting different theme sets, a naive `JOIN ... ON metadata_id OR content_hash` + outer `COUNT DISTINCT` would attribute one book to multiple theme keys.

Plus the inherent user-scope: `library_items.user_id = :uid AND library_items.deleted_at IS NULL`. `book_insights`/`book_themes` are shared cache with no `user_id` column; per-user filtering happens at the `library_items` join.

## In-progress semantics

`finished_at IS NULL AND percent > 0`. We do **not** cap at `percent < 1` — a book at `percent=1` without a `finished_at` push still counts as in-progress ("not done until the device says so"). Edge case covered by a test.

## Intentionally NOT included

- `abandoned_count` — defer until an explicit ``abandoned`` status exists.
- Pre-v3 theme backfill — older cached insights contribute zero themes until naturally regenerated. The `themes_caveat` surfaces this in-product.

## Caveat copy

The architect flagged that a strict ``prompt_version>=4`` claim is misleading: the query gates on presence of `book_themes` rows, not on the configured `OPDS_SYNC_AI_PROMPT_VERSION` value. The shipped copy is honest:

> Theme stats include books with AI theme data; older cached insights may be missing until regenerated.

## Test plan

- [x] Server: `uv run pytest -q` green under full mode (351 passed), sync-only (292 passed, 59 skipped), AI-only (311 passed, 40 skipped).
- [x] Android: `:app:testDebugUnitTest`, `:data:library:testDebugUnitTest`, `:app:lintDebug` BUILD SUCCESSFUL.
- [x] `LibraryStatsViewModelTest` (5 tests): Loading→Ready, HTTP error, 401, 404, retry.
- [x] `LibraryClientTest` (4 tests): parses response, 401, 404, null baseUrl.
- [x] `LibraryDtosTest` (2 tests): full + empty.
- [x] Server stats endpoint absent (404) when `OPDS_SYNC_PROGRESS_ENABLED=false` (covered in `test_modes.py`).
- [x] User-scoping: user A's books invisible to user B (counts + themes).
- [x] Themes test for each of the three load-bearing filters plus the architect-flagged "different live variants" scenario.

## GPT architect verdict

Bottom line: **fix-then-go**. The three theme filters are necessary; JSONB unnest is fine for v1; no cross-tenant leak. Two concrete fixes were required and shipped:

1. The OR-based identity join + outer `COUNT(DISTINCT li.pk)` is insufficient when one book has live cache variants emitting different theme sets. Fix: DISTINCT-ON pick-one-insight-per-book CTE.
2. Caveat copy claiming `prompt_version>=4` is inaccurate because the query doesn't actually gate on it. Fix: honest "may be missing" wording.

Also addressed: `COUNT(DISTINCT li.pk)` per author (defends against duplicate author strings inside one book's array); explicit `percent=1, finished_at IS NULL` in-progress edge case test; alignment of the in-progress semantics between query and spec.

## Local-only design + plan

Full design spec and step-by-step plan live under `docs/superpowers/specs/2026-05-17-library-stats-design.md` and `docs/superpowers/plans/2026-05-17-library-stats.md`. That directory is `.gitignore`d (PR #24, 2026-05-17), so the files exist only in the local worktree.