### PR TITLE
feat: catalog detail screen with AI insight preview

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -20,6 +20,10 @@ import io.theficos.ereader.ui.bookdetail.AppInsightAuditSource
 import io.theficos.ereader.ui.bookdetail.BookDetailViewModel
 import io.theficos.ereader.ui.bookdetail.InsightAuditViewModel
 import io.theficos.ereader.ui.catalog.CatalogPreferencesStore
+import io.theficos.ereader.ui.catalogdetail.AiRepositoryAdapter
+import io.theficos.ereader.ui.catalogdetail.CatalogAiPort
+import io.theficos.ereader.ui.catalogdetail.CatalogDetailRegistry
+import io.theficos.ereader.ui.catalogdetail.CatalogDetailViewModel
 import io.theficos.ereader.ui.library.LibraryPreferencesStore
 import java.io.File
 import kotlinx.coroutines.Dispatchers
@@ -77,6 +81,14 @@ class AppContainer(context: Context) {
             ai = aiRepository,
         )
 
+    val catalogDetailRegistry: CatalogDetailRegistry = CatalogDetailRegistry()
+
+    val catalogDetailViewModelFactory: CatalogDetailViewModelFactory =
+        CatalogDetailViewModelFactory(
+            ai = AiRepositoryAdapter(aiRepository),
+            registry = catalogDetailRegistry,
+        )
+
     private suspend fun readOpfBytes(doc: Document): ByteArray? = withContext(Dispatchers.IO) {
         runCatching {
             java.util.zip.ZipFile(doc.localPath).use { zip ->
@@ -117,4 +129,20 @@ class InsightAuditViewModelFactory(
         documentId = documentId,
         source = AppInsightAuditSource(documents = documents, ai = ai),
     )
+}
+
+class CatalogDetailViewModelFactory(
+    private val ai: CatalogAiPort,
+    private val registry: CatalogDetailRegistry,
+) {
+    /**
+     * Look up the [OpdsPublication] by nav key and build the viewmodel.
+     * Returns null if the key is unknown (typically because the process
+     * died and the in-memory registry was reset). Callers render a
+     * graceful fallback in that case.
+     */
+    fun create(key: String): CatalogDetailViewModel? {
+        val pub = registry.get(key) ?: return null
+        return CatalogDetailViewModel(publication = pub, ai = ai)
+    }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -1,10 +1,20 @@
 package io.theficos.ereader.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -15,6 +25,7 @@ import io.theficos.ereader.ui.bookdetail.BookDetailScreen
 import io.theficos.ereader.ui.bookdetail.InsightAuditScreen
 import io.theficos.ereader.ui.catalog.CatalogScreen
 import io.theficos.ereader.ui.catalog.CatalogViewModel
+import io.theficos.ereader.ui.catalogdetail.CatalogDetailScreen
 import io.theficos.ereader.ui.library.LibraryScreen
 import io.theficos.ereader.ui.library.LibraryViewModel
 import io.theficos.ereader.ui.main.MainScaffold
@@ -72,6 +83,10 @@ fun AppNavGraph(container: AppContainer) {
                     Tab.CATALOG -> CatalogScreen(
                         viewModel = catVm,
                         contentPadding = padding,
+                        onShowDetails = { pub ->
+                            val key = container.catalogDetailRegistry.put(pub)
+                            nav.navigate("catalog-detail/$key")
+                        },
                     )
                     Tab.SETTINGS -> SettingsScreen(
                         viewModel = setVm,
@@ -143,8 +158,36 @@ fun AppNavGraph(container: AppContainer) {
                 },
             )
         }
+        composable(
+            "catalog-detail/{key}",
+            arguments = listOf(navArgument("key") { type = NavType.StringType }),
+        ) { backStack ->
+            val key = backStack.arguments!!.getString("key")!!
+            val vm = remember(key) { container.catalogDetailViewModelFactory.create(key) }
+            if (vm == null) {
+                CatalogDetailUnavailable(onBack = { nav.popBackStack() })
+            } else {
+                CatalogDetailScreen(viewModel = vm, onBack = { nav.popBackStack() })
+            }
+        }
         composable("licenses") {
             LicensesScreen(onBack = { nav.popBackStack() })
+        }
+    }
+}
+
+@Composable
+private fun CatalogDetailUnavailable(onBack: () -> Unit) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "This catalog entry is no longer available. Reload the catalog from the Catalog tab.",
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            TextButton(onClick = onBack) { Text("Back") }
         }
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
@@ -1,7 +1,5 @@
 package io.theficos.ereader.ui.catalog
 
-import android.content.Intent
-import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -33,6 +31,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -41,12 +40,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -70,6 +66,7 @@ import io.theficos.ereader.ui.components.SectionLabel
 fun CatalogScreen(
     viewModel: CatalogViewModel,
     contentPadding: PaddingValues,
+    onShowDetails: (OpdsPublication) -> Unit = {},
 ) {
     val state by viewModel.state.collectAsState()
     val downloadedUrls by viewModel.downloadedUrls.collectAsState()
@@ -105,6 +102,7 @@ fun CatalogScreen(
                         onBack = viewModel::back,
                         onSearch = viewModel::search,
                         onDownload = { pub -> viewModel.download(pub, context) },
+                        onShowDetails = onShowDetails,
                     )
                 }
             }
@@ -123,9 +121,8 @@ private fun Loaded(
     onBack: () -> Unit,
     onSearch: (String) -> Unit,
     onDownload: (OpdsPublication) -> Unit,
+    onShowDetails: (OpdsPublication) -> Unit,
 ) {
-    val context = LocalContext.current
-    var menuFor by remember { mutableStateOf<OpdsPublication?>(null) }
     val publications = remember(state.feed.publications, sort) {
         applyCatalogSort(state.feed.publications, sort)
     }
@@ -177,7 +174,7 @@ private fun Loaded(
                     modifier = Modifier.combinedClickable(
                         enabled = !downloading,
                         onClick = { if (!downloaded) onDownload(pub) },
-                        onLongClick = { menuFor = pub },
+                        onLongClick = { onShowDetails(pub) },
                     ),
                 ) {
                     Box {
@@ -222,6 +219,31 @@ private fun Loaded(
                                     .size(20.dp),
                             )
                         }
+                        // Visible info affordance — opens the catalog detail screen
+                        // without competing with the cover-tap download target
+                        // (positioned at TopStart while the download badge sits
+                        // at TopEnd).
+                        IconButton(
+                            onClick = { onShowDetails(pub) },
+                            modifier = Modifier
+                                .align(Alignment.TopStart)
+                                .padding(2.dp)
+                                .size(32.dp),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(28.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.85f)),
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Info,
+                                    contentDescription = "Details",
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.align(Alignment.Center).size(18.dp),
+                                )
+                            }
+                        }
                     }
                     Text(
                         text = pub.title,
@@ -244,44 +266,6 @@ private fun Loaded(
         }
     }
 
-    menuFor?.let { pub ->
-        val sheetState = rememberModalBottomSheetState()
-        ModalBottomSheet(
-            onDismissRequest = { menuFor = null },
-            sheetState = sheetState,
-        ) {
-            Column(modifier = Modifier.fillMaxWidth().padding(bottom = 24.dp)) {
-                Text(
-                    text = pub.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
-                )
-                if (pub.webUrl != null) {
-                    TextButton(
-                        onClick = {
-                            context.startActivity(
-                                Intent(Intent.ACTION_VIEW, Uri.parse(pub.webUrl))
-                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            )
-                            menuFor = null
-                        },
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                    ) {
-                        Text("Open in calibre-web", modifier = Modifier.fillMaxWidth())
-                    }
-                } else {
-                    Text(
-                        text = "No detail link in this feed entry",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
-                    )
-                }
-            }
-        }
-    }
 }
 
 private val catalogSortLabels: List<Pair<CatalogSort, String>> = listOf(

--- a/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailRegistry.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailRegistry.kt
@@ -1,0 +1,30 @@
+package io.theficos.ereader.ui.catalogdetail
+
+import io.theficos.ereader.data.opds.OpdsPublication
+import java.util.UUID
+
+/**
+ * Transient in-memory map keyed by a short UUID, used to pass an
+ * [OpdsPublication] from `CatalogScreen` to `CatalogDetailScreen` without
+ * encoding the entire publication into a nav route argument.
+ *
+ * Lifetime: bound to the process. On process death the registry resets;
+ * a navigated detail screen restored from the back stack will get `null`
+ * and show a fallback message. That matches the AndroidViewModel back-stack
+ * behavior on process death — the catalog screen also re-fetches on resume.
+ *
+ * Memory cost: O(catalog tiles tapped in this session). Not GC'd until the
+ * process exits, but the catalog scope is bounded by the server's feed size
+ * so this is acceptable.
+ */
+class CatalogDetailRegistry {
+    private val map = mutableMapOf<String, OpdsPublication>()
+
+    fun put(publication: OpdsPublication): String {
+        val key = UUID.randomUUID().toString()
+        synchronized(map) { map[key] = publication }
+        return key
+    }
+
+    fun get(key: String): OpdsPublication? = synchronized(map) { map[key] }
+}

--- a/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailScreen.kt
@@ -1,0 +1,134 @@
+package io.theficos.ereader.ui.catalogdetail
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.theficos.ereader.ui.bookdetail.InsightSection
+import io.theficos.ereader.ui.components.CoverImage
+
+/**
+ * Pre-download book detail. Shows cover + title + author, the same
+ * `InsightSection` the book-detail screen uses, and an "Open in
+ * calibre-web" footer when the OPDS entry exposed a web URL.
+ *
+ * The screen does NOT trigger downloads — that stays a catalog-tile tap.
+ * The catalog screen handles download progress + state.
+ */
+@Composable
+fun CatalogDetailScreen(
+    viewModel: CatalogDetailViewModel,
+    onBack: () -> Unit,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+    val pub = state.publication
+
+    Box(modifier = Modifier.fillMaxSize().padding(contentPadding)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+        ) {
+            // Top bar
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            }
+
+            // Header: cover + title + author
+            Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                Box(modifier = Modifier.width(120.dp).aspectRatio(2f / 3f)) {
+                    CoverImage(
+                        source = pub.coverUrl,
+                        title = pub.title,
+                        author = pub.author,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+                Spacer(Modifier.width(16.dp))
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = pub.title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    pub.author?.let {
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(16.dp))
+
+            // AI insight section — same composable as BookDetailScreen.
+            InsightSection(state = state.insight, onRetry = viewModel::retry)
+
+            Spacer(Modifier.height(16.dp))
+
+            // Footer: open in calibre-web.
+            pub.webUrl?.let { web ->
+                HorizontalDivider()
+                Spacer(Modifier.height(8.dp))
+                TextButton(
+                    onClick = {
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW, Uri.parse(web))
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Open in calibre-web")
+                }
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}

--- a/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModel.kt
@@ -1,0 +1,159 @@
+package io.theficos.ereader.ui.catalogdetail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.theficos.ereader.core.metadata.MetadataBundle
+import io.theficos.ereader.core.model.DocumentIdentity
+import io.theficos.ereader.data.ai.AiConfig
+import io.theficos.ereader.data.ai.AiHttpException
+import io.theficos.ereader.data.ai.AiPreferences
+import io.theficos.ereader.data.ai.AiQuotaException
+import io.theficos.ereader.data.ai.AiRepository
+import io.theficos.ereader.data.ai.BookInsightResponse
+import io.theficos.ereader.data.opds.OpdsPublication
+import io.theficos.ereader.ui.bookdetail.InsightUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.security.MessageDigest
+
+/**
+ * Narrow adapter over [AiRepository] used by [CatalogDetailViewModel]. Lets
+ * the viewmodel be tested without standing up the real repository (which
+ * needs a configured `AiClient` and OkHttp). Production wiring in
+ * `AppContainer` passes [AiRepositoryAdapter] which forwards to the real
+ * [AiRepository].
+ */
+interface CatalogAiPort {
+    val configFlow: StateFlow<AiConfig?>
+    val prefsFlow: StateFlow<AiPreferences?>
+    suspend fun getCachedInsight(identity: DocumentIdentity): BookInsightResponse?
+    suspend fun lookupInsight(
+        identity: DocumentIdentity,
+        bundle: MetadataBundle,
+    ): BookInsightResponse
+}
+
+class AiRepositoryAdapter(private val repo: AiRepository) : CatalogAiPort {
+    override val configFlow get() = repo.config
+    override val prefsFlow get() = repo.preferences
+    override suspend fun getCachedInsight(identity: DocumentIdentity) =
+        repo.getCachedInsight(identity)
+    override suspend fun lookupInsight(
+        identity: DocumentIdentity,
+        bundle: MetadataBundle,
+    ) = repo.lookupInsight(identity, bundle)
+}
+
+data class CatalogDetailState(
+    val publication: OpdsPublication,
+    val insight: InsightUiState = InsightUiState.Hidden,
+)
+
+class CatalogDetailViewModel(
+    private val publication: OpdsPublication,
+    private val ai: CatalogAiPort,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(CatalogDetailState(publication = publication))
+    val state: StateFlow<CatalogDetailState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch { load() }
+    }
+
+    fun retry() {
+        viewModelScope.launch { load() }
+    }
+
+    private suspend fun load() {
+        val cfg = ai.configFlow.value
+        val prefs = ai.prefsFlow.value
+        if (cfg?.configured != true || prefs?.aiEnabled != true) {
+            _state.value = _state.value.copy(insight = InsightUiState.Hidden)
+            return
+        }
+
+        val identity = buildIdentity(publication)
+        val bundle = MetadataBundle(title = publication.title, author = publication.author)
+
+        val cached = runCatching { ai.getCachedInsight(identity) }.getOrNull()
+        if (cached != null) {
+            _state.value = _state.value.copy(
+                insight = InsightUiState.Loaded(cached.payload, cached.sources),
+            )
+            return
+        }
+
+        _state.value = _state.value.copy(insight = InsightUiState.Loading)
+        runCatching { ai.lookupInsight(identity, bundle) }
+            .onSuccess { resp ->
+                _state.value = _state.value.copy(
+                    insight = InsightUiState.Loaded(resp.payload, resp.sources),
+                )
+            }
+            .onFailure { e ->
+                val msg = when {
+                    e is AiQuotaException ->
+                        "You've reached today's regeneration limit. Try again after ${e.info.resetsAt.take(10)}."
+                    e is AiHttpException && e.code == 429 ->
+                        "You've reached today's regeneration limit. Try again tomorrow."
+                    e is AiHttpException -> "Couldn't generate insights (${e.code})."
+                    else -> "Couldn't generate insights."
+                }
+                _state.value = _state.value.copy(insight = InsightUiState.Error(msg))
+            }
+    }
+
+    companion object {
+        /**
+         * Build the AI identity payload for a pre-download publication.
+         *
+         * Strategy (spec §"Identity strategy", verified against
+         * server/opds_sync/core/ai/service.py::generate at line 200):
+         *  - `metadata_id = "opds-href:" + sha256Hex(epubDownloadHref)` —
+         *    a canonical so the server's `generate()` proceeds instead of
+         *    raising `IdentityUnresolvable` (which it does for alias-only
+         *    payloads). The `opds-href:` prefix keeps the value identifiable
+         *    in `book_insights.metadata_id`.
+         *  - `opds_href` mirrors `metadata_id` so the server's
+         *    `reconcile_aliases` writes an alias row of scheme `opds_href`
+         *    pointing at the canonical metadata_id (lets a future request
+         *    sent under `opds_href` alone resolve via the alias table).
+         *  - `opds_dc_id`, `calibre_book_id`, `isbn` — alias hints for the
+         *    server to record when the OPDS entry exposes them. Calibre-web's
+         *    stock template emits none of these.
+         *  - `content_hash` stays null; the server synthesizes
+         *    `synthetic:metadata_id:opds-href:<sha>` via
+         *    `_synthetic_content_hash`.
+         *
+         * Note: this catalog row does NOT converge with the post-download
+         * row (different identifier spaces — calibre-web's OPDS uuid vs the
+         * EPUB OPF dc:identifier). Convergence requires a server-side
+         * promote endpoint, tracked as a follow-up.
+         */
+        fun buildIdentity(publication: OpdsPublication): DocumentIdentity {
+            val opdsHrefValue = "opds-href:" + sha256Hex(publication.epubDownloadHref)
+            return DocumentIdentity(
+                metadataId = opdsHrefValue,
+                opdsHref = opdsHrefValue,
+                opdsDcId = publication.opdsDcId,
+                calibreBookId = publication.calibreBookId,
+            )
+        }
+
+        private fun sha256Hex(input: String): String {
+            val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+            val sb = StringBuilder(bytes.size * 2)
+            for (b in bytes) {
+                val v = b.toInt() and 0xff
+                sb.append(HEX[v ushr 4])
+                sb.append(HEX[v and 0x0f])
+            }
+            return sb.toString()
+        }
+
+        private val HEX = "0123456789abcdef".toCharArray()
+    }
+}

--- a/app/src/test/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModelTest.kt
@@ -1,0 +1,240 @@
+package io.theficos.ereader.ui.catalogdetail
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.core.metadata.MetadataBundle
+import io.theficos.ereader.core.model.DocumentIdentity
+import io.theficos.ereader.data.ai.AiConfig
+import io.theficos.ereader.data.ai.AiHttpException
+import io.theficos.ereader.data.ai.AiPreferences
+import io.theficos.ereader.data.ai.AiStyle
+import io.theficos.ereader.data.ai.BookInsightPayload
+import io.theficos.ereader.data.ai.BookInsightResponse
+import io.theficos.ereader.data.ai.Citation
+import io.theficos.ereader.data.opds.OpdsPublication
+import io.theficos.ereader.ui.bookdetail.InsightUiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CatalogDetailViewModelTest {
+
+    private val publication = OpdsPublication(
+        title = "The Long Earth",
+        author = "Pratchett & Baxter",
+        epubDownloadHref = "https://calibre.example/opds/download/42/epub",
+        coverUrl = null,
+        webUrl = "https://calibre.example/book/42",
+        opdsDcId = "urn:uuid:abc-123",
+        calibreBookId = "42",
+    )
+
+    private val response = BookInsightResponse(
+        payload = BookInsightPayload(intro = "About this book.", schemaVersion = 3),
+        sources = listOf(
+            Citation(kind = "wikipedia", title = "Wikipedia", url = "https://en.wikipedia.org/wiki/X"),
+        ),
+        modelId = "gpt-4o-mini",
+        promptVersion = "4",
+        generatedAt = "2026-05-17T00:00:00Z",
+    )
+
+    private lateinit var fakeAi: FakeAi
+
+    @Before fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        fakeAi = FakeAi()
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // -- buildIdentity contract -------------------------------------------------
+
+    @Test
+    fun `buildIdentity sets metadataId and opdsHref to the same opds-href sha`() {
+        val ident = CatalogDetailViewModel.buildIdentity(publication)
+        assertThat(ident.metadataId).isNotNull()
+        assertThat(ident.metadataId!!).startsWith("opds-href:")
+        // sha256 hex length = 64; plus prefix length
+        assertThat(ident.metadataId!!.length).isEqualTo("opds-href:".length + 64)
+        // opds_href is identical — same value, different scheme for symmetry.
+        assertThat(ident.opdsHref).isEqualTo(ident.metadataId)
+        // content_hash stays null pre-download.
+        assertThat(ident.contentHash).isNull()
+    }
+
+    @Test
+    fun `buildIdentity includes opdsDcId when present`() {
+        val ident = CatalogDetailViewModel.buildIdentity(publication)
+        assertThat(ident.opdsDcId).isEqualTo("urn:uuid:abc-123")
+    }
+
+    @Test
+    fun `buildIdentity omits opdsDcId when null`() {
+        val ident = CatalogDetailViewModel.buildIdentity(publication.copy(opdsDcId = null))
+        assertThat(ident.opdsDcId).isNull()
+    }
+
+    @Test
+    fun `buildIdentity includes calibreBookId when present`() {
+        val ident = CatalogDetailViewModel.buildIdentity(publication)
+        assertThat(ident.calibreBookId).isEqualTo("42")
+    }
+
+    @Test
+    fun `buildIdentity omits calibreBookId when null`() {
+        val ident = CatalogDetailViewModel.buildIdentity(publication.copy(calibreBookId = null))
+        assertThat(ident.calibreBookId).isNull()
+    }
+
+    @Test
+    fun `buildIdentity metadataId is stable across calls for same href`() {
+        val a = CatalogDetailViewModel.buildIdentity(publication)
+        val b = CatalogDetailViewModel.buildIdentity(publication)
+        assertThat(a.metadataId).isEqualTo(b.metadataId)
+    }
+
+    @Test
+    fun `buildIdentity metadataId differs across different hrefs`() {
+        val a = CatalogDetailViewModel.buildIdentity(publication)
+        val b = CatalogDetailViewModel.buildIdentity(
+            publication.copy(epubDownloadHref = "https://other.example/book.epub"),
+        )
+        assertThat(a.metadataId).isNotEqualTo(b.metadataId)
+    }
+
+    // -- state machine ---------------------------------------------------------
+
+    @Test
+    fun `state is Hidden when AI is disabled`() = runTest {
+        fakeAi.configFlow.value = AiConfig(configured = false)
+        fakeAi.prefsFlow.value = AiPreferences(aiEnabled = false)
+
+        val vm = CatalogDetailViewModel(publication, fakeAi)
+
+        vm.state.test {
+            var s = awaitItem()
+            while (s.insight is InsightUiState.Loading) s = awaitItem()
+            assertThat(s.insight).isEqualTo(InsightUiState.Hidden)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertThat(fakeAi.lookupCallCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `state is Loaded on cache hit and lookup is not called`() = runTest {
+        fakeAi.configFlow.value = AiConfig(configured = true)
+        fakeAi.prefsFlow.value = AiPreferences(aiEnabled = true, style = AiStyle())
+        fakeAi.cached = response
+
+        val vm = CatalogDetailViewModel(publication, fakeAi)
+
+        vm.state.test {
+            var s = awaitItem()
+            while (s.insight !is InsightUiState.Loaded) s = awaitItem()
+            assertThat((s.insight as InsightUiState.Loaded).payload.intro)
+                .isEqualTo("About this book.")
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertThat(fakeAi.lookupCallCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `state goes Loading then Loaded on cache miss and identity contains canonical plus aliases`() = runTest {
+        fakeAi.configFlow.value = AiConfig(configured = true)
+        fakeAi.prefsFlow.value = AiPreferences(aiEnabled = true, style = AiStyle())
+        fakeAi.cached = null
+        fakeAi.lookupResult = response
+
+        val vm = CatalogDetailViewModel(publication, fakeAi)
+
+        vm.state.test {
+            var s = awaitItem()
+            while (s.insight !is InsightUiState.Loaded) s = awaitItem()
+            // Loading may or may not be observed depending on dispatcher coalescing;
+            // the important assertions are the lookup body shape and final Loaded state.
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertThat(fakeAi.lookupCallCount).isEqualTo(1)
+
+        val sent = fakeAi.lastLookupIdentity!!
+        assertThat(sent.metadataId).startsWith("opds-href:")
+        assertThat(sent.opdsHref).isEqualTo(sent.metadataId)
+        assertThat(sent.opdsDcId).isEqualTo("urn:uuid:abc-123")
+        assertThat(sent.calibreBookId).isEqualTo("42")
+        assertThat(sent.contentHash).isNull()
+
+        val bundle = fakeAi.lastLookupBundle!!
+        assertThat(bundle.title).isEqualTo("The Long Earth")
+        assertThat(bundle.author).isEqualTo("Pratchett & Baxter")
+    }
+
+    @Test
+    fun `state is Error on lookup failure`() = runTest {
+        fakeAi.configFlow.value = AiConfig(configured = true)
+        fakeAi.prefsFlow.value = AiPreferences(aiEnabled = true, style = AiStyle())
+        fakeAi.cached = null
+        fakeAi.lookupError = RuntimeException("boom")
+
+        val vm = CatalogDetailViewModel(publication, fakeAi)
+
+        vm.state.test {
+            var s = awaitItem()
+            while (s.insight !is InsightUiState.Error) s = awaitItem()
+            assertThat((s.insight as InsightUiState.Error).message).isNotEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `state Error on AiHttpException maps to friendly message`() = runTest {
+        fakeAi.configFlow.value = AiConfig(configured = true)
+        fakeAi.prefsFlow.value = AiPreferences(aiEnabled = true, style = AiStyle())
+        fakeAi.cached = null
+        fakeAi.lookupError = AiHttpException(code = 502, body = "bad gateway")
+
+        val vm = CatalogDetailViewModel(publication, fakeAi)
+
+        vm.state.test {
+            var s = awaitItem()
+            while (s.insight !is InsightUiState.Error) s = awaitItem()
+            assertThat((s.insight as InsightUiState.Error).message).contains("502")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakeAi : CatalogAiPort {
+        override val configFlow = MutableStateFlow<AiConfig?>(null)
+        override val prefsFlow = MutableStateFlow<AiPreferences?>(null)
+        var cached: BookInsightResponse? = null
+        var lookupResult: BookInsightResponse? = null
+        var lookupError: Throwable? = null
+        var lookupCallCount = 0
+        var lastLookupIdentity: DocumentIdentity? = null
+        var lastLookupBundle: MetadataBundle? = null
+
+        override suspend fun getCachedInsight(identity: DocumentIdentity): BookInsightResponse? =
+            cached
+
+        override suspend fun lookupInsight(
+            identity: DocumentIdentity,
+            bundle: MetadataBundle,
+        ): BookInsightResponse {
+            lookupCallCount++
+            lastLookupIdentity = identity
+            lastLookupBundle = bundle
+            lookupError?.let { throw it }
+            return lookupResult ?: error("no result configured")
+        }
+    }
+}

--- a/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
@@ -3,12 +3,37 @@ package io.theficos.ereader.core.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Mirrors `DocumentIdentity` in `server/opds_sync/api/ai_schemas.py`.
+ *
+ * Canonical schemes (`metadataId`, `contentHash`) identify a downloaded EPUB
+ * by stable byte-level or OPF-derived hashes. Alias fields (`opdsHref`,
+ * `opdsDcId`, `calibreBookId`, `isbn`) are used pre-download by the
+ * catalog-preview flow (PR7); the server resolves them to a canonical via
+ * `insight_identity_aliases` (PR2).
+ *
+ * Invariant: at least one field must be non-null. The previous post-download
+ * invariant (`contentHash` non-empty) is enforced by the call site
+ * (`EpubIdentityExtractor`), not the type — pre-download paths legitimately
+ * have no `contentHash`.
+ */
 @Serializable
 data class DocumentIdentity(
-    @SerialName("metadata_id") val metadataId: String?,
-    @SerialName("content_hash") val contentHash: String,
+    @SerialName("metadata_id") val metadataId: String? = null,
+    @SerialName("content_hash") val contentHash: String? = null,
+    @SerialName("opds_dc_id") val opdsDcId: String? = null,
+    @SerialName("opds_href") val opdsHref: String? = null,
+    @SerialName("calibre_book_id") val calibreBookId: String? = null,
+    val isbn: String? = null,
 ) {
     init {
-        require(contentHash.isNotEmpty()) { "contentHash must not be empty" }
+        require(
+            metadataId != null ||
+                contentHash != null ||
+                opdsDcId != null ||
+                opdsHref != null ||
+                calibreBookId != null ||
+                isbn != null,
+        ) { "DocumentIdentity needs at least one canonical or alias hint" }
     }
 }

--- a/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
+++ b/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
@@ -4,19 +4,41 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class DocumentIdentityTest {
-    @Test fun `requires content_hash`() {
+    @Test fun `accepts contentHash-only`() {
         val id = DocumentIdentity(metadataId = null, contentHash = "abc123")
         assertThat(id.contentHash).isEqualTo("abc123")
         assertThat(id.metadataId).isNull()
     }
 
-    @Test fun `accepts both ids`() {
+    @Test fun `accepts metadataId plus contentHash`() {
         val id = DocumentIdentity(metadataId = "42", contentHash = "abc123")
         assertThat(id.metadataId).isEqualTo("42")
+        assertThat(id.contentHash).isEqualTo("abc123")
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun `rejects empty content_hash`() {
-        DocumentIdentity(metadataId = "42", contentHash = "")
+    fun `rejects all-null payload`() {
+        DocumentIdentity()
+    }
+
+    @Test fun `accepts opdsHref-only alias payload`() {
+        val id = DocumentIdentity(opdsHref = "opds-href:deadbeef")
+        assertThat(id.opdsHref).isEqualTo("opds-href:deadbeef")
+        assertThat(id.contentHash).isNull()
+    }
+
+    @Test fun `accepts opdsDcId-only alias payload`() {
+        val id = DocumentIdentity(opdsDcId = "urn:uuid:abc")
+        assertThat(id.opdsDcId).isEqualTo("urn:uuid:abc")
+    }
+
+    @Test fun `accepts calibreBookId-only alias payload`() {
+        val id = DocumentIdentity(calibreBookId = "42")
+        assertThat(id.calibreBookId).isEqualTo("42")
+    }
+
+    @Test fun `accepts isbn-only alias payload`() {
+        val id = DocumentIdentity(isbn = "9780553293357")
+        assertThat(id.isbn).isEqualTo("9780553293357")
     }
 }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
@@ -29,7 +29,10 @@ class DocumentRepository(private val dao: DocumentDao) {
 
     suspend fun findByIdentity(identity: DocumentIdentity): Document? {
         identity.metadataId?.let { dao.findByMetadataId(it)?.let { return it.toDomain() } }
-        return dao.findByContentHash(identity.contentHash)?.toDomain()
+        // Post-download identity always carries a contentHash; pre-download identity
+        // (catalog-preview) never reaches this DAO. The null branch is defensive.
+        val hash = identity.contentHash ?: return null
+        return dao.findByContentHash(hash)?.toDomain()
     }
 
     suspend fun findById(id: Long): Document? = dao.findById(id)?.toDomain()
@@ -67,7 +70,9 @@ class DocumentRepository(private val dao: DocumentDao) {
         seriesIndex: Double? = null,
     ): Long = dao.insert(DocumentEntity(
         metadataId = identity.metadataId,
-        contentHash = identity.contentHash,
+        contentHash = requireNotNull(identity.contentHash) {
+            "documents.content_hash is NOT NULL; the downloaded EPUB must have a sha256."
+        },
         title = title,
         author = author,
         downloadUrl = downloadUrl,

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsCatalog.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsCatalog.kt
@@ -19,6 +19,20 @@ data class OpdsPublication(
     val coverUrl: String?,
     /** OPDS `rel=alternate type=text/html` href — the book's web detail page on the OPDS server (calibre-web's `/book/{id}`). Null if the feed didn't expose one. */
     val webUrl: String? = null,
+    /**
+     * Trimmed `<dc:identifier>` text from the Atom entry (e.g. `urn:uuid:…`).
+     * Surfaced when the OPDS feed includes one; calibre-web's stock template
+     * does NOT, so this is null on most real feeds. Used as the `opds_dc_id`
+     * alias hint by the catalog-preview AI lookup (PR7).
+     */
+    val opdsDcId: String? = null,
+    /**
+     * Numeric book id parsed from a calibre-web-style acquisition href
+     * (`…/opds/download/<id>/<format>`). Used as the `calibre_book_id`
+     * alias hint by the catalog-preview AI lookup (PR7). Null for non-
+     * calibre-web feeds.
+     */
+    val calibreBookId: String? = null,
 )
 
 data class OpdsSearchLink(

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsClient.kt
@@ -32,6 +32,10 @@ class OpdsClient(
             // The `rel=alternate type=text/html` link points at the OPDS server's web detail page
             // (e.g. calibre-web's `/book/{id}`); Readium doesn't surface it, so we read raw XML too.
             val webUrlsByEpubHref = parseWebUrls(bytes, absoluteUrl)
+            // PR7: dc:identifier per entry, used as the opds_dc_id alias hint
+            // for the AI catalog-preview lookup. Readium doesn't surface DC
+            // elements either.
+            val dcIdsByEpubHref = parseDcIdentifiers(bytes, absoluteUrl)
             OpdsFeed(
                 title = feed.metadata.title,
                 navigation = feed.navigation.map { link ->
@@ -53,6 +57,8 @@ class OpdsClient(
                         coverUrl = coversByEpubHref[absoluteEpubHref],
                         webUrl = webUrlsByEpubHref[absoluteEpubHref]
                             ?: deriveCalibreWebDetailUrl(absoluteEpubHref),
+                        opdsDcId = dcIdsByEpubHref[absoluteEpubHref],
+                        calibreBookId = extractCalibreBookId(absoluteEpubHref),
                     )
                 },
                 searchLink = searchLink,
@@ -147,6 +153,66 @@ class OpdsClient(
         return "$origin/book/$bookId"
     }
 
+    /** Extract the numeric book id from a calibre-web acquisition href. Null on non-match. */
+    private fun extractCalibreBookId(absoluteEpubHref: String): String? =
+        CALIBRE_DOWNLOAD_REGEX.find(absoluteEpubHref)?.groupValues?.get(1)
+
+    /**
+     * Walk each Atom entry looking for `<dc:identifier>` (under either the
+     * `http://purl.org/dc/terms/` or `http://purl.org/dc/elements/1.1/`
+     * namespace). Returns a map keyed by the absolute acquisition href so
+     * the caller can join by epubDownloadHref. Entries with no identifier
+     * or only blank ones are skipped.
+     *
+     * Calibre-web's stock OPDS template emits the book uuid in the Atom
+     * `<id>`, not in `<dc:identifier>`. Other OPDS producers (some library
+     * exporters, koreader's CalibreSync, etc.) do emit `<dc:identifier>`,
+     * so this parser stays useful even if calibre-web users see nothing.
+     */
+    private fun parseDcIdentifiers(bytes: ByteArray, feedUrl: String): Map<String, String> {
+        val doc = runCatching {
+            DocumentBuilderFactory.newInstance()
+                .apply { isNamespaceAware = true }
+                .newDocumentBuilder()
+                .parse(ByteArrayInputStream(bytes))
+        }.getOrNull() ?: return emptyMap()
+        val entries = doc.getElementsByTagNameNS("http://www.w3.org/2005/Atom", "entry")
+        val result = mutableMapOf<String, String>()
+        for (i in 0 until entries.length) {
+            val entry = entries.item(i) as org.w3c.dom.Element
+            val links = entry.getElementsByTagNameNS("http://www.w3.org/2005/Atom", "link")
+            var epubHref: String? = null
+            for (j in 0 until links.length) {
+                val el = links.item(j) as org.w3c.dom.Element
+                if (el.getAttribute("rel") == "http://opds-spec.org/acquisition" &&
+                    el.getAttribute("type") == "application/epub+zip"
+                ) {
+                    epubHref = el.getAttribute("href").takeIf { it.isNotBlank() }
+                    break
+                }
+            }
+            if (epubHref == null) continue
+            val dcId = firstNonBlankChildText(entry, DC_TERMS_NS, "identifier")
+                ?: firstNonBlankChildText(entry, DC_ELEMENTS_NS, "identifier")
+                ?: continue
+            result[absolutize(feedUrl, epubHref)] = dcId
+        }
+        return result
+    }
+
+    private fun firstNonBlankChildText(
+        entry: org.w3c.dom.Element,
+        ns: String,
+        name: String,
+    ): String? {
+        val list = entry.getElementsByTagNameNS(ns, name)
+        for (i in 0 until list.length) {
+            val text = (list.item(i) as org.w3c.dom.Element).textContent?.trim()
+            if (!text.isNullOrEmpty()) return text
+        }
+        return null
+    }
+
     private fun parseSearchLink(bytes: ByteArray, feedUrl: String): OpdsSearchLink? {
         val doc = runCatching {
             DocumentBuilderFactory.newInstance()
@@ -217,5 +283,7 @@ class OpdsClient(
     private companion object {
         private val OPTIONAL_PARAM = Regex("""\{[^{}]+\?\}""")
         private val CALIBRE_DOWNLOAD_REGEX = Regex("""/opds/download/(\d+)/[^/?]+/?(?:\?.*)?$""")
+        private const val DC_TERMS_NS = "http://purl.org/dc/terms/"
+        private const val DC_ELEMENTS_NS = "http://purl.org/dc/elements/1.1/"
     }
 }

--- a/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
+++ b/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
@@ -46,6 +46,8 @@ class OpdsClientTest {
                         .setBody(resource("/opds/catalog-feed-thumbnail-and-image.xml"))
                     "/opds/thumb-only" -> MockResponse().setHeader("Content-Type", "application/atom+xml")
                         .setBody(resource("/opds/catalog-feed-thumbnail-only.xml"))
+                    "/opds/calibre-style" -> MockResponse().setHeader("Content-Type", "application/atom+xml")
+                        .setBody(resource("/opds/catalog-feed-calibre-no-dc.xml"))
                     else -> MockResponse().setResponseCode(404)
                 }
             }
@@ -152,4 +154,31 @@ class OpdsClientTest {
         assertThat(pub.coverUrl).endsWith("/opds/cover/42")
     }
 
+    @Test fun `extracts dc identifier when present on entry`() = runTest {
+        val feed = client.fetch(server.url("/opds/new").toString())
+        val pub = feed.publications.single()
+        assertThat(pub.opdsDcId).isEqualTo("urn:uuid:550e8400-e29b-41d4-a716-446655440000")
+    }
+
+    @Test fun `extracts calibreBookId when href matches calibre-web pattern`() = runTest {
+        val feed = client.fetch(server.url("/opds/new").toString())
+        val pub = feed.publications.single()
+        assertThat(pub.calibreBookId).isEqualTo("42")
+    }
+
+    @Test fun `opdsDcId is null when entry has no dc identifier (calibre-web stock template)`() = runTest {
+        val feed = client.fetch(server.url("/opds/calibre-style").toString())
+        val matched = feed.publications.first { it.title == "Pattern-matched book" }
+        val unmatched = feed.publications.first { it.title == "Non-calibre href book" }
+        assertThat(matched.opdsDcId).isNull()
+        assertThat(unmatched.opdsDcId).isNull()
+    }
+
+    @Test fun `calibreBookId set only when acquisition href matches pattern`() = runTest {
+        val feed = client.fetch(server.url("/opds/calibre-style").toString())
+        val matched = feed.publications.first { it.title == "Pattern-matched book" }
+        val unmatched = feed.publications.first { it.title == "Non-calibre href book" }
+        assertThat(matched.calibreBookId).isEqualTo("77")
+        assertThat(unmatched.calibreBookId).isNull()
+    }
 }

--- a/data/opds/src/test/resources/opds/catalog-feed-calibre-no-dc.xml
+++ b/data/opds/src/test/resources/opds/catalog-feed-calibre-no-dc.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/terms/" xmlns:dcterms="http://purl.org/dc/terms/">
+  <id>urn:uuid:feed-no-dc</id>
+  <title>Calibre-web style (no dc:identifier)</title>
+  <updated>2026-05-17T00:00:00Z</updated>
+  <link rel="self" href="/opds/calibre-style" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+  <entry>
+    <title>Pattern-matched book</title>
+    <id>urn:uuid:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</id>
+    <updated>2026-05-17T00:00:00Z</updated>
+    <author><name>Author A</name></author>
+    <link rel="http://opds-spec.org/acquisition" href="/opds/download/77/epub" type="application/epub+zip"/>
+  </entry>
+  <entry>
+    <title>Non-calibre href book</title>
+    <id>urn:uuid:11111111-2222-3333-4444-555555555555</id>
+    <updated>2026-05-17T00:00:00Z</updated>
+    <author><name>Author B</name></author>
+    <link rel="http://opds-spec.org/acquisition" href="/files/random.epub" type="application/epub+zip"/>
+  </entry>
+</feed>

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
@@ -26,7 +26,12 @@ class SyncOrchestrator(
                 val doc = documentRepo.findById(progress.documentId)
                     ?: return SyncResult.HttpFailure(0, "missing document for documentId=${progress.documentId}")
                 ProgressItemDto(
-                    document = DocumentIdDto(metadataId = doc.identity.metadataId, contentHash = doc.identity.contentHash),
+                    document = DocumentIdDto(
+                        metadataId = doc.identity.metadataId,
+                        contentHash = requireNotNull(doc.identity.contentHash) {
+                            "downloaded document must have a contentHash"
+                        },
+                    ),
                     locator = progress.locator,
                     percent = progress.percent,
                     clientUpdatedAt = Instant.ofEpochMilli(progress.updatedAt).toString(),


### PR DESCRIPTION
## Summary

Adds a pre-download catalog detail screen that reuses the existing `InsightSection` composable from book-detail, so the AI insight preview UI is consistent between the catalog and library halves of the app. Replaces the prior catalog long-press bottom sheet (whose only action was "Open in calibre-web") with the new screen; the calibre-web link is preserved as the screen's footer button.

Android-only. No server changes — the existing PR2 identity-alias surface accepts the payload as-is.

## Identity strategy

For each `OpdsPublication`, the catalog viewmodel sends:

```
metadata_id     = "opds-href:" + sha256Hex(epubDownloadHref)
opds_href       = same value (alias mirror for future symmetry)
opds_dc_id      = raw <dc:identifier> when the OPDS entry exposes one
calibre_book_id = digits from /opds/download/<id>/<fmt> when the href matches
content_hash    = null
```

Why `metadata_id` is set to the `opds-href:<sha>` value: the server's `generate()` raises `IdentityUnresolvable` (HTTP 422) when no canonical or pre-registered alias is supplied (`server/opds_sync/core/ai/service.py:200`). Setting `metadata_id` to a deterministic, identifiable value gives the server a canonical to key on; the `opds-href:` prefix keeps the row recognizable in `book_insights.metadata_id` for debugging. `content_hash` is null pre-download — the server synthesizes `synthetic:metadata_id:opds-href:<sha>` via `_synthetic_content_hash`.

Example payload sent to `/ai/v1/insights/lookup`:

```json
{
  "identity": {
    "metadata_id": "opds-href:7a3b1c…64hex",
    "opds_href":   "opds-href:7a3b1c…64hex",
    "opds_dc_id":  "urn:uuid:550e8400-e29b-41d4-a716-446655440000",
    "calibre_book_id": "42"
  },
  "bundle": { "title": "The Long Earth", "author": "Pratchett & Baxter" }
}
```

### What this does NOT do

The catalog row and the post-download row use **different** identifier spaces — calibre-web's OPDS feed emits the book's calibre-internal uuid in Atom `<id>`, not in `<dc:identifier>`, while `EpubIdentityExtractor` post-download reads the publisher's `dc:identifier` from the OPF. So the catalog `metadata_id` (an `opds-href:<sha>` of the acquisition href) does not equal the EPUB-derived `metadata_id`. Two cache rows will exist for the same book.

This is acceptable for PR7's scope: each row delivers value on its own surface, and the duplicate costs at most one extra generation per (tone, language, model, prompt-version) tuple. **Convergence is a follow-up** — closing the gap needs a server-side promote endpoint that merges the synthetic row into the EPUB-derived row when the user downloads. Tracked locally.

## Screen mock

```
┌─────────────────────────────────────┐
│ ←                                    │
│                                      │
│   ┌──────┐  The Long Earth           │
│   │cover │  Pratchett & Baxter       │
│   └──────┘                           │
│                                      │
│   ─────────────────────────────      │
│                                      │
│   <InsightSection state/>            │
│     · About this book                │
│     · About the author               │
│     · Series                         │
│     · Themes & analysis              │
│     · Content warnings               │
│     · Based on: Wikipedia · …        │
│                                      │
│   ─────────────────────────────      │
│   [ Open in calibre-web ]            │
└─────────────────────────────────────┘
```

## CatalogScreen changes

- Drop the long-press `ModalBottomSheet` (its sole action was "Open in calibre-web" — now in the detail footer).
- Tile tap: unchanged (downloads).
- Tile long-press: navigates to `catalog-detail/{key}`.
- New visible `IconButton` overlay (Info, outlined, 28 dp tonal circle, 18 dp icon) at `TopStart` of each tile — keeps the cover's tap target clean and stays clear of the download/check badge at `TopEnd`.

## What was kept

The library screen's info `IconButton` stays as-is. The round-2 architect ruling held that removing it would leave the post-download book without an equivalent surface; library detail and catalog detail are now symmetric entry points for the two states of the same book.

## Test plan

- [x] `:core:model:test` — 7 tests (loosened `DocumentIdentity` invariant: at-least-one non-null; legacy callers still satisfy).
- [x] `:data:opds:testDebugUnitTest` — 16 tests including 4 new ones: dc:identifier extraction (present / absent), calibreBookId extraction (matched / unmatched).
- [x] `:app:testDebugUnitTest` — 12 new `CatalogDetailViewModelTest` cases:
  - `buildIdentity` always sets `metadataId` and `opdsHref` to identical `opds-href:<64-hex>`.
  - Optional alias fields populate only when their source data is present.
  - Same href → stable `metadataId`; different href → different `metadataId`.
  - State machine: `Hidden` when AI is off; `Loaded` on cache hit (no `lookupInsight` call); cache miss → `Loaded` with the right identity body and bundle; `Error` on `AiHttpException`.
- [x] `:app:lintDebug` — no new warnings.
- Manual verification deferred to first device run (the registry's process-death path is hard to exercise in unit tests but mirrors `CatalogViewModel` itself).

## GPT architect review verdict

Two rounds. First round caught a real P0: my initial alias-only plan would have hit `IdentityUnresolvable` for every brand-new book on a calibre-web feed. Verified directly in `server/opds_sync/core/ai/service.py:200` and `server/tests/unit/test_ai_identity_resolution.py:308`. Second round inspected calibre-web's actual OPDS template at `https://raw.githubusercontent.com/janeczku/calibre-web/master/cps/templates/feed.xml` and confirmed it emits the book uuid as Atom `<id>`, never as `<dc:identifier>`. The revised "use opds-href as both metadata_id and alias" strategy ships value without server work and documents the convergence gap as a known follow-up. Local context: `docs/superpowers/specs/2026-05-17-catalog-detail-design.md` and `docs/superpowers/plans/2026-05-17-catalog-detail.md` (gitignored per PR #24; not in this diff).