### PR TITLE
:memo: docs: post-batch-4 documentation refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ OpenLibrary to ground the generated insights with citations. The
 generated insight is cached server-side per book and reused across all
 of that user's devices and other opted-in users on the same instance.
 
+Surfaces in the app today: book-detail cards (summary, author, series,
+themes, content advisory, sources); a catalog detail screen that
+previews the same insight cards before download via an `info` icon on
+each catalog tile; and a library Stats screen (totals, top authors,
+top themes) backed by `GET /library/v1/stats`.
+
 For configuration details see [`server/README.md`](server/README.md).
 
 ## Install
@@ -99,7 +105,10 @@ For configuration details see [`server/README.md`](server/README.md).
 Grab the latest APK from [Releases], install it, and point it at your
 calibre-web URL on first launch. F-Droid listing is planned.
 
-For the sync server, see [`server/README.md`](server/README.md).
+For the sync server, see [`server/README.md`](server/README.md) — it
+ships two reference docker-compose files (`docker-compose.yml` for
+"bring your own proxy"; `docker-compose.full.yml` for a Caddy-fronted
+full stack with calibre-web + opds-sync + TLS behind one base URL).
 
 ## Roadmap
 
@@ -146,6 +155,7 @@ core/model/           Domain types (Document, Progress, Bookmark)
 data/local/           Room database, DAOs
 data/opds/            calibre-web OPDS client
 data/sync/            opds-sync REST client + WorkManager job
+data/library/         opds-sync /library/v1 HTTP client (stats today)
 reader/               Readium navigator integration
 server/               opds-sync (Python / FastAPI)
 docs/                 Architecture, development, sync API reference

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ lives there. (A planned read-only Calibre plugin will pull progress from
 :data:local    Room database + DAOs; pending_sync_ops outbox; sync_state
 :data:opds     calibre-web OPDS client
 :data:sync     opds-sync REST client + WorkManager sync job
+:data:library  opds-sync /library/v1 HTTP client (stats today)
 :reader        Readium navigator integration, font/theme controls
 :auth          Keystore-backed calibre-web Basic credential store
 ```
@@ -247,8 +248,8 @@ container image. Modes are controlled by two env-var flags:
 
 | Mode             | `OPDS_SYNC_PROGRESS_ENABLED` | `OPDS_SYNC_AI_ENABLED` | Mounted endpoints                                                          |
 | ---------------- | ---------------------------- | ---------------------- | -------------------------------------------------------------------------- |
-| Full stack       | `true` (default)             | `true` (default)       | `/health`, `/readyz`, `/sync/v1/*`, `/library/v1/*`, `/ai/v1/*`            |
-| Sync only        | `true`                       | `false`                | `/health`, `/readyz`, `/sync/v1/*`, `/library/v1/*`                        |
+| Full stack       | `true` (default)             | `true` (default)       | `/health`, `/readyz`, `/sync/v1/*`, `/library/v1/*` (incl. `/stats`), `/ai/v1/*` |
+| Sync only        | `true`                       | `false`                | `/health`, `/readyz`, `/sync/v1/*`, `/library/v1/*` (incl. `/stats`)        |
 | AI only          | `false`                      | `true`                 | `/health`, `/readyz`, `/ai/v1/*`                                            |
 
 `/health` and `/readyz` are always mounted on the root path (no prefix) so k8s
@@ -400,6 +401,41 @@ rows to `book_themes` until regenerated. `schema_version=3` is pinned by
 the server after model return so cache rows never reflect a model's
 accidental version emission.
 
+### Library stats v0 (PR9, 2026-05-17)
+
+`GET /library/v1/stats` returns a per-user roll-up of the
+`library_items` mirror joined with `book_insights` / `book_themes`:
+`total_books`, `finished_count`, `in_progress_count`, `top_authors`,
+`top_themes`, and a constant server-emitted `themes_caveat` string the
+client renders verbatim. There is no `abandoned_count` until an
+explicit abandoned status exists. Mode-gated on
+`OPDS_SYNC_PROGRESS_ENABLED` (lives next to the existing
+`/library/v1/items` router).
+
+The theme query uses a **DISTINCT-ON CTE that picks one
+`book_insights` row per `library_item`**, mirroring the lookup
+precedence already enforced by `service.py::_lookup_live`:
+`metadata_id`-priority match → `content_hash` fallback → most-recent
+`generated_at` tiebreaker. Three filters on that CTE are load-bearing
+and protect against silently-wrong aggregates:
+
+1. **`BookInsight.superseded_at IS NULL`** inside the CTE join —
+   without it, every regenerate against the same book double-counts
+   the new themes alongside the orphaned ones.
+2. **`BookTheme.confidence >= 1.0`** on the outer aggregation —
+   excludes off-vocab `confidence=0.5` strings so the leaderboard is
+   the controlled vocabulary only.
+3. **`COUNT(DISTINCT picked.library_item_pk)`** per theme — dedupes
+   the rare case where the picker resolves two library items onto the
+   same `book_insight` row.
+
+This DISTINCT-ON pattern is the recommended shape for any future
+endpoint that joins live insights (`book_insights`) to per-user
+library data: every consumer needs the same three guards or they
+diverge from `_lookup_live` on the AI surface and report different
+numbers for the same library. See `server/opds_sync/api/library.py`
+for the reference implementation.
+
 ### Android UI surfaces (batch 3, 2026-05-17)
 
 - **Inspect insight screen (PR6).** Book-detail overflow → "Inspect
@@ -421,6 +457,47 @@ accidental version emission.
   button (one AI call instead of two). The
   `POST /ai/v1/insights/regenerate` server endpoint is retained for
   admin/cluster tooling.
+
+### Android UI surfaces (batch 4, 2026-05-17)
+
+- **Catalog detail screen (PR7).** `CatalogDetailScreen` +
+  `CatalogDetailViewModel` reuse the existing `InsightSection`
+  composable so a catalog tile previews the same insight cards as the
+  book-detail screen — before download. Reached via a visible `info`
+  `IconButton` at the top-start of each catalog tile (long-press also
+  opens it). The previous bottom-sheet preview is gone; the library
+  info icon is retained. A `CatalogDetailRegistry` holds the OPDS
+  entry across navigation. `DocumentIdentity` was loosened in
+  `:core:model` to allow `metadata_id`-only payloads (no
+  `content_hash` until the EPUB body is on the device).
+- **Library Stats screen (PR9).** New `LibraryStatsScreen` +
+  `LibraryStatsViewModel` reached from the library menu's "Stats"
+  entry. Lives in the new `:data:library` Android module (the
+  `library/v1` HTTP client), which today exposes only `getStats`.
+
+#### Catalog identity vs post-download EPUB identity
+
+`CatalogDetailViewModel` synthesizes an identity for a pre-download
+catalog row by combining `metadata_id="opds-href:<sha256(href)>"`
+with all weaker hints the catalog entry provided: an `opds_href`
+alias, a `calibre_book_id` parsed from the download URL, and an
+`opds_dc_id` when the OPDS entry carries a `dc:identifier`. The
+server's identity-alias table (PR2) resolves all of those onto one
+canonical cache row.
+
+**Important: the `opds-href:<sha>` identity does NOT converge with
+the post-download EPUB identity.** Once a user downloads the book,
+the EPUB body produces a real `metadata_id` (from the OPF
+`dc:identifier`) and a `content_hash`; both live in a different
+identifier space than the synthetic `opds-href:<sha>`. The cache row
+that served the catalog preview and the cache row that serves the
+book-detail screen after download can therefore be two distinct
+rows for what is materially the same book. A future
+`POST /ai/v1/insights/promote` endpoint could unify them by
+upgrading the catalog row's canonical to the post-download
+identifiers and reconciling via the alias table. Not built today —
+double-spend on cold catalogs is rare enough that paying for the
+second generation when the user actually downloads is acceptable.
 
 ## Decision log
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,6 +60,7 @@ cp local.properties.template local.properties
 :data:local    Room DB, DAOs, sync outbox
 :data:opds     calibre-web OPDS client
 :data:sync     opds-sync REST client + WorkManager job
+:data:library  opds-sync /library/v1 HTTP client (stats today)
 :reader        Readium navigator integration
 ```
 
@@ -235,6 +236,14 @@ Pushes to `main` that touch Android paths produce:
 
 Server is deployed via the cluster's Kustomize app
 (`applications/opds-sync/`); see the cluster repo for the rollout flow.
+
+For non-Kubernetes self-hosters, `server/` ships two reference
+docker-compose files matching the deploy-mode table above:
+`docker-compose.yml` (minimal: postgres + opds-sync, bring your own
+proxy) and `docker-compose.full.yml` (Caddy-fronted postgres +
+calibre-web + opds-sync with TLS behind one base URL, mirroring the
+k8s ingress). See `server/README.md` for env-var setup and smoke
+commands.
 
 ## Conventions
 

--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -72,6 +72,7 @@ the implementation.
 | `PUT` | `/library/v1/items` | yes | Upsert one library item (mode-gated on `OPDS_SYNC_PROGRESS_ENABLED`) |
 | `GET` | `/library/v1/items` | yes | List items, optional `since=<ISO>` cursor with tombstones |
 | `DELETE` | `/library/v1/items` | yes | Soft-delete one library item by `content_hash` |
+| `GET` | `/library/v1/stats` | yes | Per-user library roll-up: totals + top authors + top themes |
 | `GET` | `/ai/v1/health` | none | AI provider + retrieval reachability snapshot (mode-gated on `OPDS_SYNC_AI_ENABLED`) |
 
 Currently shipped: health probes and progress. The rest are designed; see
@@ -269,6 +270,51 @@ Sets `deleted_at = now()` on the matching row. `404` if no row matches.
 Idempotent: DELETE on an already-deleted row is a no-op (both timestamps
 preserved — refreshing `updated_at` here would re-deliver the tombstone on
 every subsequent `GET ?since=<old_cursor>`).
+
+### `GET /library/v1/stats`
+
+Per-user library roll-up. Joins `library_items` with `progress` for
+the read-state counts and with the live `book_insights` cache for the
+theme leaderboard. Mode-gated on `OPDS_SYNC_PROGRESS_ENABLED`.
+
+```http
+GET /library/v1/stats
+Authorization: Basic ...
+```
+
+Response:
+
+```json
+{
+  "total_books": 142,
+  "finished_count": 37,
+  "in_progress_count": 5,
+  "top_authors": [
+    { "name": "Isaac Asimov", "count": 12 },
+    { "name": "Ursula K. Le Guin", "count": 7 }
+  ],
+  "top_themes": [
+    { "theme": "science_fiction", "count": 28, "note": "v3+ insights only" },
+    { "theme": "epic", "count": 11, "note": "v3+ insights only" }
+  ],
+  "themes_caveat": "Theme stats include books with AI theme data; older cached insights may be missing until regenerated."
+}
+```
+
+- No `abandoned_count`: there is no explicit abandoned status yet.
+- `themes_caveat` is a constant server-emitted string the client renders
+  verbatim. Sourcing it server-side means the wording can change without
+  an app release.
+- The theme query uses a DISTINCT-ON CTE that picks one
+  `book_insights` row per `library_item` (mirroring
+  `service.py::_lookup_live`: `metadata_id`-priority match →
+  `content_hash` fallback → most-recent `generated_at` tiebreaker)
+  filtered by `superseded_at IS NULL` and `BookTheme.confidence >= 1.0`,
+  then `COUNT(DISTINCT picked.library_item_pk)` per theme. Three filters
+  are load-bearing — they protect against regenerate-double-counting
+  and off-vocab pollution. See
+  [`architecture.md`](architecture.md#library-stats-v0-pr9-2026-05-17)
+  for the rationale.
 
 ## Bookmarks (planned)
 

--- a/server/README.md
+++ b/server/README.md
@@ -97,6 +97,7 @@ USER=admin
 read -rs PASS && echo
 AUTH=$(printf '%s' "$USER:$PASS" | base64)
 curl -fsSk -H "Authorization: Basic $AUTH" "https://localhost/library/v1/items"
+curl -fsSk -H "Authorization: Basic $AUTH" "https://localhost/library/v1/stats" | jq
 curl -fsSk -H "Authorization: Basic $AUTH" "https://localhost/sync/v1/progress?since=0"
 
 # Calibre-web root (fall-through)
@@ -129,8 +130,8 @@ match the table in [Deploy modes](#deploy-modes).
 
 | Mode       | `OPDS_SYNC_PROGRESS_ENABLED` | `OPDS_SYNC_AI_ENABLED` | What the Caddy front-end serves                                  |
 | ---------- | ---------------------------- | ---------------------- | ---------------------------------------------------------------- |
-| Full stack | `true` (default)             | `true` (default)       | `/sync/v1/*` + `/library/v1/*` + `/ai/v1/*` + calibre-web at `/` |
-| Sync only  | `true`                       | `false`                | `/sync/v1/*` + `/library/v1/*` + calibre-web at `/`              |
+| Full stack | `true` (default)             | `true` (default)       | `/sync/v1/*` + `/library/v1/*` (items + stats) + `/ai/v1/*` + calibre-web at `/` |
+| Sync only  | `true`                       | `false`                | `/sync/v1/*` + `/library/v1/*` (items + stats) + calibre-web at `/` |
 | AI only    | `false`                      | `true`                 | `/ai/v1/*` only — drop the `calibre-web` service from the compose for a leaner stack |
 
 Set both flags in `.env`. Sync-only deploys don't need
@@ -147,11 +148,11 @@ for the branch-label convention. The image is published to
 
 ### Deploy modes
 
-| Mode             | `OPDS_SYNC_PROGRESS_ENABLED` | `OPDS_SYNC_AI_ENABLED` | Mounts                                            |
-| ---------------- | ---------------------------- | ---------------------- | ------------------------------------------------- |
-| Full stack       | `true` (default)             | `true` (default)       | `/sync/v1/*`, `/library/v1/*`, `/ai/v1/*`         |
-| Sync only        | `true`                       | `false`                | `/sync/v1/*`, `/library/v1/*`                     |
-| AI only          | `false`                      | `true`                 | `/ai/v1/*`                                        |
+| Mode             | `OPDS_SYNC_PROGRESS_ENABLED` | `OPDS_SYNC_AI_ENABLED` | Mounts                                                  |
+| ---------------- | ---------------------------- | ---------------------- | ------------------------------------------------------- |
+| Full stack       | `true` (default)             | `true` (default)       | `/sync/v1/*`, `/library/v1/*` (items + stats), `/ai/v1/*` |
+| Sync only        | `true`                       | `false`                | `/sync/v1/*`, `/library/v1/*` (items + stats)           |
+| AI only          | `false`                      | `true`                 | `/ai/v1/*`                                              |
 
 `/health` and `/readyz` are mounted on the root in every mode.
 
@@ -320,10 +321,17 @@ curl -fsS -H "Authorization: Basic $AUTH" "$BASE/items" | jq '.items[0]'
 
 curl -fsS -X DELETE -H "Authorization: Basic $AUTH" -H "Content-Type: application/json" \
   -d '{"item":{"content_hash":"smoketest"}}' "$BASE/items" | jq '.deleted_at'
+
+# Per-user stats roll-up (PR9, 2026-05-17). Joins library_items with
+# progress and the live book_insights cache.
+curl -fsS -H "Authorization: Basic $AUTH" "$BASE/stats" | jq
 ```
 
 Expect the PUT response to include server-assigned `created_at` /
 `updated_at` and `deleted_at: null`; GET without `since` returns the live
 row; DELETE returns the row with a populated `deleted_at`. A second DELETE
 is a no-op (timestamps preserved — see `docs/sync-api.md` for the
-tombstone semantics).
+tombstone semantics). The `/stats` response includes `total_books`,
+`finished_count`, `in_progress_count`, `top_authors`, `top_themes`, and
+a constant `themes_caveat` string — see `docs/sync-api.md` for the
+schema and the load-bearing DISTINCT-ON CTE rationale.


### PR DESCRIPTION
## Summary

Documentation refresh after batch 4 merges (PR10 Caddy compose, PR9 library stats, PR7 catalog detail).

## Files changed (5)

- **README.md** — note library stats + catalog AI preview surfaces.
- **docs/architecture.md** — `:data:library` Android module added to module graph; new `Library stats v0 (PR9)` subsection documenting the DISTINCT-ON CTE + three load-bearing theme filters (`superseded_at IS NULL`, `confidence >= 1.0`, `COUNT DISTINCT library_item_pk`); catalog identity ≠ EPUB identity architectural note + future `/insights/promote` endpoint idea; mode-mounts table reflects `(incl. /stats)`.
- **docs/development.md** — `:data:library` module mentioned; Caddy reference compose mentioned in deploy modes.
- **docs/sync-api.md** — `GET /library/v1/stats` response schema + themes_caveat.
- **server/README.md** — `/library/v1/stats` added to endpoint list + smoke command; mode-mounts table reflects stats.

## What was audited and clean

- LICENSE, NOTICE, SECURITY.md — no new third-party deps in batch 4; `/library/v1/stats` uses existing Basic auth; no new threat-model entries.
- CONTRIBUTING.md — cache-version checklist still current (no PROMPT_VERSION bump in batch 4).
- docs/release.md — release behavior unchanged.
- server/migrations/README.md — branch heads unchanged (batch 4 added no migrations).

## Follow-up note

The local `.claude/local/quire-ai/2026-05-16-next-deliverables.md` (gitignored) will be updated separately to mark PR7/PR9/PR10 as shipped — that's session-local cleanup, not repo doc drift.