### PR TITLE
:sparkles: feat: upload downloaded books to /library/v1/items

### DIFF
--- a/app/src/main/java/io/theficos/ereader/EReaderApp.kt
+++ b/app/src/main/java/io/theficos/ereader/EReaderApp.kt
@@ -1,9 +1,11 @@
 package io.theficos.ereader
 
 import android.app.Application
+import android.util.Log
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import io.theficos.ereader.di.AppContainer
+import kotlinx.coroutines.launch
 
 class EReaderApp : Application(), ImageLoaderFactory {
     lateinit var container: AppContainer
@@ -12,6 +14,17 @@ class EReaderApp : Application(), ImageLoaderFactory {
     override fun onCreate() {
         super.onCreate()
         container = AppContainer(this)
+
+        // Backfill any documents that haven't been pushed to /library/v1/items
+        // yet. On the first run after this version installs, the migration
+        // leaves `librarySyncedAt = NULL` for every existing row, so this is
+        // the only thing that gets the server out of "0 books" state. Best-
+        // effort: failures are logged inside the uploader; the row stays
+        // unsynced and we retry on the next app start.
+        container.libraryUploaderScope.launch {
+            runCatching { container.libraryUploader.runOnce() }
+                .onFailure { Log.w("EReaderApp", "library upload backfill failed", it) }
+        }
     }
 
     override fun newImageLoader(): ImageLoader =

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -6,6 +6,7 @@ import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.data.ai.AiClient
 import io.theficos.ereader.data.ai.AiRepository
 import io.theficos.ereader.data.library.LibraryClient
+import io.theficos.ereader.data.library.LibraryUploader
 import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.ProgressRepository
 import io.theficos.ereader.data.local.db.EReaderDatabase
@@ -28,7 +29,9 @@ import io.theficos.ereader.ui.catalogdetail.CatalogDetailViewModel
 import io.theficos.ereader.ui.library.LibraryPreferencesStore
 import io.theficos.ereader.ui.library.LibraryStatsViewModel
 import java.io.File
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.withContext
 
 class AppContainer(context: Context) {
@@ -74,6 +77,21 @@ class AppContainer(context: Context) {
     val libraryClient: LibraryClient = LibraryClient(
         baseUrlProvider = { credentialStore.get()?.baseUrl },
         http = opdsHttp.okHttp,
+    )
+
+    /**
+     * Process-lifetime scope for fire-and-forget library upload work. A
+     * SupervisorJob means a single PUT failure won't cancel sibling
+     * launches; cancellation propagates only if the process itself goes
+     * away, which is the correct lifetime for this kind of background sync.
+     */
+    val libraryUploaderScope: CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    val libraryUploader: LibraryUploader = LibraryUploader(
+        client = libraryClient,
+        dao = db.documentDao(),
+        scope = libraryUploaderScope,
     )
 
     val libraryStatsViewModelFactory: LibraryStatsViewModelFactory =

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -59,6 +59,7 @@ fun AppNavGraph(container: AppContainer) {
                     credentialStore = container.credentialStore,
                     syncStateDao = container.syncStateDao,
                     catalogPreferencesStore = container.catalogPreferencesStore,
+                    libraryUploader = container.libraryUploader,
                 )
             }
             val setVm = remember {

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import io.theficos.ereader.auth.CalibreCredentialStore
 import io.theficos.ereader.core.identity.extractIdentity
 import io.theficos.ereader.core.metadata.readOpfBundle
+import io.theficos.ereader.data.library.LibraryUploader
 import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.db.SyncStateDao
 import io.theficos.ereader.data.opds.BookDownloader
@@ -32,6 +33,7 @@ class CatalogViewModel(
     private val credentialStore: CalibreCredentialStore,
     private val syncStateDao: SyncStateDao,
     private val catalogPreferencesStore: CatalogPreferencesStore,
+    private val libraryUploader: LibraryUploader? = null,
     private val syncEnqueuer: (Context) -> Unit =
         { ctx -> SyncEnqueuer.enqueue(ctx, expedited = true, replaceExisting = true) },
 ) : ViewModel() {
@@ -144,7 +146,7 @@ class CatalogViewModel(
                     // continuity shelf can include this book the moment it lands.
                     // Failures fall back to a title-only bundle (no series).
                     val opf = readOpfBundle(file, fallbackTitle = pub.title)
-                    docs.insert(
+                    val insertedId = docs.insert(
                         identity = identity,
                         title = pub.title,
                         author = pub.author,
@@ -155,6 +157,11 @@ class CatalogViewModel(
                         seriesName = opf.seriesName,
                         seriesIndex = opf.seriesPosition?.toDouble(),
                     )
+                    // Fire-and-forget upload to /library/v1/items so the server
+                    // can include this book in stats / aggregates. Failures are
+                    // logged inside the uploader; the row stays unsynced and
+                    // the next app-start pass retries.
+                    libraryUploader?.enqueueOne(insertedId)
                 } else {
                     file.delete()
                     coverFile?.delete()

--- a/data/library/build.gradle.kts
+++ b/data/library/build.gradle.kts
@@ -21,6 +21,7 @@ android {
 
 dependencies {
     api(project(":core:model"))
+    implementation(project(":data:local"))
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt
@@ -2,4 +2,5 @@ package io.theficos.ereader.data.library
 
 object LibraryApi {
     const val PATH_STATS = "/library/v1/stats"
+    const val PATH_ITEMS = "/library/v1/items"
 }

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
@@ -3,8 +3,10 @@ package io.theficos.ereader.data.library
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * REST client for the `/library/v1` endpoints on opds-sync.
@@ -13,8 +15,10 @@ import okhttp3.Request
  * same one used by `:data:sync` and `:data:ai`). This client does not add
  * Authorization headers.
  *
- * v0 (PR9) exposes only `getStats`; future additions (`putItem`, `listItems`,
- * `deleteItem`) will move here when Android-side library upload lands.
+ * Exposed verbs: `getStats` (PR9) and `putItem` (this PR, drives the Android
+ * → server upload). `listItems` / `deleteItem` aren't needed yet — the
+ * Android library is treated as the source of truth and tombstone delivery
+ * will land when multi-device delete arrives.
  */
 class LibraryClient(
     private val baseUrlProvider: () -> String?,
@@ -39,6 +43,38 @@ class LibraryClient(
             if (!resp.isSuccessful) throw LibraryHttpException(resp.code, body)
             json.decodeFromString(LibraryStatsResponse.serializer(), body)
         }
+    }
+
+    /**
+     * Upsert a single library item.
+     *
+     * Server semantics:
+     * - 200 with the persisted row on insert OR update (server keys on
+     *   `(user_id, content_hash)` and refreshes `updated_at`).
+     * - 401 → caller needs to re-auth; surfaces as `LibraryHttpException(401)`.
+     * - 409 → `metadata_id` is already attached to a DIFFERENT content_hash for
+     *   this user. PR1's identity-aliases plan will fix this properly; for now
+     *   we surface it so the uploader can skip the row without retrying.
+     *
+     * The wire body wraps the payload as `{"item": {...}}` so a future bulk
+     * endpoint (`{"items": [...]}`) can ship without breaking existing
+     * clients.
+     */
+    suspend fun putItem(payload: LibraryItemRequest): LibraryItemResponse = withContext(Dispatchers.IO) {
+        val bodyJson = json.encodeToString(LibraryItemPutBody.serializer(), LibraryItemPutBody(payload))
+        val req = Request.Builder()
+            .url(resolveBaseUrl() + LibraryApi.PATH_ITEMS)
+            .put(bodyJson.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        http.newCall(req).execute().use { resp ->
+            val body = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) throw LibraryHttpException(resp.code, body)
+            json.decodeFromString(LibraryItemResponse.serializer(), body)
+        }
+    }
+
+    private companion object {
+        val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
     }
 }
 

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
@@ -25,3 +25,63 @@ data class LibraryStatsResponse(
     @SerialName("top_themes") val topThemes: List<TopTheme>,
     @SerialName("themes_caveat") val themesCaveat: String,
 )
+
+/**
+ * Body of `PUT /library/v1/items` — the identity (`content_hash`) travels in
+ * the JSON body, not the path. Mirrors
+ * `server/opds_sync/api/library_schemas.py:LibraryItemRequest`.
+ *
+ * `series_index` is a wire-side double — the server stores it as Postgres
+ * `Numeric` for exactness, but serializes as a JSON number (float-64 is
+ * plenty for the rare 1.5-style novella positions).
+ *
+ * Optional list fields default to empty rather than null because the server
+ * tolerates either, and emitting `[]` keeps the payload self-describing.
+ */
+@Serializable
+data class LibraryItemRequest(
+    @SerialName("content_hash") val contentHash: String,
+    val title: String,
+    val authors: List<String> = emptyList(),
+    @SerialName("metadata_id") val metadataId: String? = null,
+    @SerialName("series_name") val seriesName: String? = null,
+    @SerialName("series_index") val seriesIndex: Double? = null,
+    val isbn: String? = null,
+    val language: String? = null,
+    val subjects: List<String> = emptyList(),
+    @SerialName("opds_href") val opdsHref: String? = null,
+)
+
+/**
+ * Single-item wrapper required by the server. The shape keeps the door open
+ * for a future bulk endpoint shaped `{"items": [...]}` without breaking
+ * clients.
+ */
+@Serializable
+data class LibraryItemPutBody(val item: LibraryItemRequest)
+
+/**
+ * Response body of `PUT /library/v1/items`. Server-owned timestamps are
+ * always present; `deleted_at` is non-null for tombstones (only returned via
+ * `GET ?since=`, never by PUT).
+ *
+ * Datetimes arrive as ISO-8601 with explicit `+00:00`. The current uploader
+ * doesn't parse them — they're kept as strings so the parse cost is paid
+ * only by callers that actually need them.
+ */
+@Serializable
+data class LibraryItemResponse(
+    @SerialName("content_hash") val contentHash: String,
+    val title: String,
+    val authors: List<String> = emptyList(),
+    @SerialName("metadata_id") val metadataId: String? = null,
+    @SerialName("series_name") val seriesName: String? = null,
+    @SerialName("series_index") val seriesIndex: Double? = null,
+    val isbn: String? = null,
+    val language: String? = null,
+    val subjects: List<String> = emptyList(),
+    @SerialName("opds_href") val opdsHref: String? = null,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String,
+    @SerialName("deleted_at") val deletedAt: String? = null,
+)

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
@@ -1,0 +1,153 @@
+package io.theficos.ereader.data.library
+
+import android.util.Log
+import io.theficos.ereader.data.local.db.DocumentDao
+import io.theficos.ereader.data.local.db.DocumentEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Sends downloaded books to `/library/v1/items` so the server-side Library
+ * Stats / catalog can reflect what the user actually has.
+ *
+ * Trigger model (v1, intentionally minimal):
+ * - **App start** — caller invokes [runOnce] from the same scope that fires
+ *   `SyncOrchestrator.runOnce()`. Backfills every doc with `librarySyncedAt
+ *   IS NULL`, which on the first post-update boot is every doc.
+ * - **Post-download** — [CatalogViewModel] calls [enqueueOne] right after the
+ *   row is inserted. Fire-and-forget so the download UI doesn't block.
+ *
+ * Failure handling (each row treated independently):
+ * - **401** aborts the entire batch — the caller's credentials are bad and
+ *   nothing else will succeed either. No `markLibrarySynced` writes for any
+ *   row in this pass.
+ * - Any other HTTP error or network failure logs and CONTINUES to the next
+ *   row. The row stays `librarySyncedAt = NULL`, so the next pass retries.
+ *   No in-uploader retry loop: the next scheduled pass is the retry.
+ * - **409** (metadata_id_conflict) is treated like any other non-401 error:
+ *   logged and skipped. PR1 identity-aliases will fix this properly; until
+ *   then we accept that the row stays "unsynced" forever, which is harmless
+ *   (just a no-op on each pass).
+ */
+class LibraryUploader(
+    private val client: LibraryClient,
+    private val dao: DocumentDao,
+    private val scope: CoroutineScope,
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+) {
+
+    private val singleFlight = Mutex()
+
+    /**
+     * Walk all unsynced documents, PUT each, mark each successful row.
+     *
+     * Single-flight via a Mutex: if app-start and post-download fire at the
+     * same time, the second call waits for the first to drain before running
+     * its own pass. This avoids redundant PUTs without complex coordination.
+     */
+    suspend fun runOnce(): UploadResult = singleFlight.withLock {
+        val unsynced = dao.findUnsyncedToLibrary()
+        if (unsynced.isEmpty()) {
+            return@withLock UploadResult(attempted = 0, succeeded = 0, abortedOnAuth = false)
+        }
+
+        var succeeded = 0
+        for (doc in unsynced) {
+            val payload = doc.toLibraryItemRequest()
+            try {
+                client.putItem(payload)
+                dao.markLibrarySynced(doc.id, nowMillis())
+                succeeded += 1
+            } catch (e: LibraryHttpException) {
+                if (e.code == HTTP_UNAUTHORIZED) {
+                    Log.w(TAG, "401 from /library/v1/items; aborting batch", e)
+                    return@withLock UploadResult(
+                        attempted = succeeded + 1,
+                        succeeded = succeeded,
+                        abortedOnAuth = true,
+                    )
+                }
+                Log.w(
+                    TAG,
+                    "library PUT failed for documentId=${doc.id} (code=${e.code}); will retry on next pass",
+                    e,
+                )
+            } catch (e: Exception) {
+                // Network failures, JSON parse errors, etc. Same policy: leave
+                // the row unsynced and try the next one.
+                Log.w(
+                    TAG,
+                    "library PUT failed for documentId=${doc.id} (${e.javaClass.simpleName}); will retry on next pass",
+                    e,
+                )
+            }
+        }
+
+        UploadResult(
+            attempted = unsynced.size,
+            succeeded = succeeded,
+            abortedOnAuth = false,
+        )
+    }
+
+    /**
+     * Convenience: launch a one-row backfill in the uploader's scope. Used
+     * by the download path so a freshly-landed book hits the server promptly
+     * without bouncing through the next app-start. Fire-and-forget.
+     */
+    fun enqueueOne(@Suppress("UNUSED_PARAMETER") documentId: Long): Job = scope.launch {
+        // Cheap to just run the whole unsynced pass — there's a Mutex
+        // upstream, and the per-row work is gated on `librarySyncedAt IS
+        // NULL`, so this naturally picks up the new row plus any earlier
+        // failures. Keeps the call shape trivial: no `findById` lookup, no
+        // race between insert + enqueue.
+        runOnce()
+    }
+
+    private fun DocumentEntity.toLibraryItemRequest(): LibraryItemRequest =
+        LibraryItemRequest(
+            contentHash = contentHash,
+            title = title,
+            authors = parseAuthors(author),
+            metadataId = metadataId,
+            seriesName = seriesName,
+            seriesIndex = seriesIndex,
+            isbn = null,        // v2: parse from OPF
+            language = null,    // v2: parse from OPF
+            subjects = emptyList(), // v2: parse from OPF
+            opdsHref = downloadUrl,
+        )
+
+    private companion object {
+        const val TAG = "LibraryUploader"
+        const val HTTP_UNAUTHORIZED = 401
+    }
+}
+
+/**
+ * Outcome of a single [LibraryUploader.runOnce] pass.
+ *
+ * - [attempted] counts rows we tried to PUT (including the one that triggered
+ *   the 401 abort, if any).
+ * - [succeeded] counts rows the server accepted.
+ * - [abortedOnAuth] is true iff a 401 short-circuited the batch — caller
+ *   typically wants to surface a re-auth prompt.
+ */
+data class UploadResult(
+    val attempted: Int,
+    val succeeded: Int,
+    val abortedOnAuth: Boolean,
+)
+
+/**
+ * Split `author` strings the way calibre tends to emit them. Calibre joins
+ * multi-author books with " & ", but OPF feeds in the wild also use commas.
+ * Empty / whitespace-only fragments are dropped.
+ */
+internal fun parseAuthors(raw: String?): List<String> {
+    if (raw.isNullOrBlank()) return emptyList()
+    return raw.split(',', '&').map { it.trim() }.filter { it.isNotEmpty() }
+}

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryClientTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryClientTest.kt
@@ -79,4 +79,86 @@ class LibraryClientTest {
             assertThat(e.body).contains("baseUrl not configured")
         }
     }
+
+    // ---- putItem ----
+
+    @Test
+    fun `putItem happyPath wraps payload under item and parses response`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "content_hash":"abc",
+                  "title":"Dune",
+                  "authors":["Frank Herbert"],
+                  "metadata_id":"m1",
+                  "series_name":"Dune",
+                  "series_index":1.0,
+                  "isbn":null,
+                  "language":null,
+                  "subjects":[],
+                  "opds_href":"/opds/dune.epub",
+                  "created_at":"2026-05-17T00:00:00+00:00",
+                  "updated_at":"2026-05-17T00:00:00+00:00",
+                  "deleted_at":null
+                }
+                """.trimIndent()
+            )
+        )
+
+        val out = client.putItem(
+            LibraryItemRequest(
+                contentHash = "abc",
+                title = "Dune",
+                authors = listOf("Frank Herbert"),
+                metadataId = "m1",
+                seriesName = "Dune",
+                seriesIndex = 1.0,
+                opdsHref = "/opds/dune.epub",
+            )
+        )
+
+        assertThat(out.contentHash).isEqualTo("abc")
+        assertThat(out.title).isEqualTo("Dune")
+        assertThat(out.authors).containsExactly("Frank Herbert")
+        assertThat(out.seriesIndex).isEqualTo(1.0)
+
+        val req = server.takeRequest()
+        assertThat(req.method).isEqualTo("PUT")
+        assertThat(req.path).isEqualTo("/library/v1/items")
+        val body = req.body.readUtf8()
+        // Verify the `{"item": {...}}` wrap.
+        assertThat(body).contains("\"item\":")
+        assertThat(body).contains("\"content_hash\":\"abc\"")
+        assertThat(body).contains("\"opds_href\":\"/opds/dune.epub\"")
+    }
+
+    @Test
+    fun `putItem 401 surfaces LibraryHttpException with code 401`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("unauthorized"))
+        try {
+            client.putItem(LibraryItemRequest(contentHash = "h", title = "t"))
+            error("expected throw")
+        } catch (e: LibraryHttpException) {
+            assertThat(e.code).isEqualTo(401)
+        }
+    }
+
+    @Test
+    fun `putItem 409 surfaces LibraryHttpException with code 409`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(409).setBody(
+                """{"detail":{"error":"metadata_id_conflict","existing_content_hash":"other"}}"""
+            )
+        )
+        try {
+            client.putItem(
+                LibraryItemRequest(contentHash = "h", title = "t", metadataId = "m"),
+            )
+            error("expected throw")
+        } catch (e: LibraryHttpException) {
+            assertThat(e.code).isEqualTo(409)
+            assertThat(e.body).contains("metadata_id_conflict")
+        }
+    }
 }

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryUploaderTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryUploaderTest.kt
@@ -1,0 +1,249 @@
+package io.theficos.ereader.data.library
+
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.data.local.db.DocumentDao
+import io.theficos.ereader.data.local.db.DocumentEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class LibraryUploaderTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: LibraryClient
+    private lateinit var dao: FakeDocumentDao
+    private lateinit var scope: CoroutineScope
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = LibraryClient(
+            baseUrlProvider = { server.url("").toString().trimEnd('/') },
+            http = OkHttpClient.Builder().callTimeout(5, TimeUnit.SECONDS).build(),
+        )
+        dao = FakeDocumentDao()
+        // `enqueueOne` launches into this scope; in tests we don't actually
+        // need it to do anything because we drive `runOnce` directly.
+        scope = CoroutineScope(StandardTestDispatcher())
+    }
+
+    @After fun tearDown() = server.shutdown()
+
+    private fun successBody(contentHash: String): String = """
+        {
+          "content_hash":"$contentHash",
+          "title":"t",
+          "authors":[],
+          "metadata_id":null,
+          "series_name":null,
+          "series_index":null,
+          "isbn":null,
+          "language":null,
+          "subjects":[],
+          "opds_href":null,
+          "created_at":"2026-05-17T00:00:00+00:00",
+          "updated_at":"2026-05-17T00:00:00+00:00",
+          "deleted_at":null
+        }
+    """.trimIndent()
+
+    @Test
+    fun `runOnce puts every unsynced doc and marks each synced`() = runTest {
+        dao.rows.addAll(
+            listOf(
+                docEntity(id = 1, contentHash = "h1"),
+                docEntity(id = 2, contentHash = "h2"),
+            )
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody(successBody("h1")))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(successBody("h2")))
+
+        val uploader = LibraryUploader(client = client, dao = dao, scope = scope, nowMillis = { 1000L })
+        val result = uploader.runOnce()
+
+        assertThat(result.attempted).isEqualTo(2)
+        assertThat(result.succeeded).isEqualTo(2)
+        assertThat(result.abortedOnAuth).isFalse()
+        assertThat(dao.synced).containsExactly(1L to 1000L, 2L to 1000L)
+        assertThat(server.requestCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `runOnce continues past a transient failure on the first doc`() = runTest {
+        // DAO orders newest-first (downloadedAt DESC); id=2 was downloaded
+        // later, so it's PUT first and gets the 500 response. id=1 follows
+        // and succeeds.
+        dao.rows.addAll(
+            listOf(
+                docEntity(id = 1, contentHash = "h1", downloadedAt = 100L),
+                docEntity(id = 2, contentHash = "h2", downloadedAt = 200L),
+            )
+        )
+        server.enqueue(MockResponse().setResponseCode(500).setBody("boom"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(successBody("h1")))
+
+        val uploader = LibraryUploader(client = client, dao = dao, scope = scope, nowMillis = { 2000L })
+        val result = uploader.runOnce()
+
+        assertThat(result.attempted).isEqualTo(2)
+        assertThat(result.succeeded).isEqualTo(1)
+        assertThat(result.abortedOnAuth).isFalse()
+        // Only the second-attempted doc (id=1) was marked.
+        assertThat(dao.synced).containsExactly(1L to 2000L)
+    }
+
+    @Test
+    fun `runOnce aborts the whole batch on 401 and marks nothing`() = runTest {
+        dao.rows.addAll(
+            listOf(
+                docEntity(id = 1, contentHash = "h1"),
+                docEntity(id = 2, contentHash = "h2"),
+            )
+        )
+        server.enqueue(MockResponse().setResponseCode(401).setBody("nope"))
+        // Second response intentionally never enqueued — the uploader must not
+        // attempt the second row after a 401.
+
+        val uploader = LibraryUploader(client = client, dao = dao, scope = scope, nowMillis = { 3000L })
+        val result = uploader.runOnce()
+
+        assertThat(result.abortedOnAuth).isTrue()
+        assertThat(result.succeeded).isEqualTo(0)
+        assertThat(dao.synced).isEmpty()
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `runOnce skips rows already marked synced (DAO returns only unsynced)`() = runTest {
+        // Synced row stays in dao.rows but is filtered out by findUnsyncedToLibrary.
+        dao.rows.add(docEntity(id = 1, contentHash = "h1", librarySyncedAt = 999L))
+        dao.rows.add(docEntity(id = 2, contentHash = "h2", librarySyncedAt = null))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(successBody("h2")))
+
+        val uploader = LibraryUploader(client = client, dao = dao, scope = scope, nowMillis = { 4000L })
+        val result = uploader.runOnce()
+
+        assertThat(result.attempted).isEqualTo(1)
+        assertThat(result.succeeded).isEqualTo(1)
+        // Only the unsynced row was PUT and marked.
+        assertThat(dao.synced).containsExactly(2L to 4000L)
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `runOnce with no unsynced rows is a quick no-op`() = runTest {
+        // Empty DAO → no calls, no failures.
+        val uploader = LibraryUploader(client = client, dao = dao, scope = scope)
+        val result = uploader.runOnce()
+
+        assertThat(result.attempted).isEqualTo(0)
+        assertThat(result.succeeded).isEqualTo(0)
+        assertThat(result.abortedOnAuth).isFalse()
+        assertThat(server.requestCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `runOnce skips a 409 (metadata_id_conflict) like any other non-401 and continues`() = runTest {
+        // Per the DAO order (downloadedAt DESC), id=2 is PUT first → 409, id=1
+        // is PUT second → 200.
+        dao.rows.addAll(
+            listOf(
+                docEntity(id = 1, contentHash = "h1", downloadedAt = 100L),
+                docEntity(id = 2, contentHash = "h2", downloadedAt = 200L),
+            )
+        )
+        server.enqueue(
+            MockResponse().setResponseCode(409).setBody(
+                """{"detail":{"error":"metadata_id_conflict"}}"""
+            )
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody(successBody("h1")))
+
+        val uploader = LibraryUploader(client = client, dao = dao, scope = scope, nowMillis = { 5000L })
+        val result = uploader.runOnce()
+
+        assertThat(result.abortedOnAuth).isFalse()
+        assertThat(result.succeeded).isEqualTo(1)
+        // The 409'd row (id=2) is NOT marked synced — it stays in the next pass's queue.
+        assertThat(dao.synced).containsExactly(1L to 5000L)
+    }
+
+    @Test
+    fun `authors are split from a comma-and-ampersand-joined author string`() {
+        assertThat(parseAuthors("Frank Herbert")).containsExactly("Frank Herbert")
+        assertThat(parseAuthors("A & B")).containsExactly("A", "B").inOrder()
+        assertThat(parseAuthors("A, B & C")).containsExactly("A", "B", "C").inOrder()
+        assertThat(parseAuthors(null)).isEmpty()
+        assertThat(parseAuthors("")).isEmpty()
+        assertThat(parseAuthors(" , & ")).isEmpty()
+    }
+}
+
+private fun docEntity(
+    id: Long,
+    contentHash: String,
+    librarySyncedAt: Long? = null,
+    downloadedAt: Long = id,
+): DocumentEntity = DocumentEntity(
+    id = id,
+    metadataId = null,
+    contentHash = contentHash,
+    title = "t",
+    author = null,
+    downloadUrl = "u",
+    localPath = "p",
+    coverPath = null,
+    downloadedAt = downloadedAt,
+    seriesName = null,
+    seriesIndex = null,
+    librarySyncedAt = librarySyncedAt,
+)
+
+/**
+ * Minimal in-memory stand-in for [DocumentDao]. Only the methods the uploader
+ * uses are implemented; the rest throw so accidental future calls are loud.
+ */
+private class FakeDocumentDao : DocumentDao {
+    val rows: MutableList<DocumentEntity> = mutableListOf()
+    val synced: MutableList<Pair<Long, Long>> = mutableListOf()
+
+    override suspend fun findUnsyncedToLibrary(): List<DocumentEntity> =
+        rows.filter { it.librarySyncedAt == null }
+            .sortedWith(compareByDescending<DocumentEntity> { it.downloadedAt }.thenByDescending { it.id })
+
+    override suspend fun markLibrarySynced(id: Long, at: Long) {
+        synced.add(id to at)
+        rows.replaceAll { row -> if (row.id == id) row.copy(librarySyncedAt = at) else row }
+    }
+
+    // ---- everything else is unused in these tests ----
+
+    override suspend fun insert(doc: DocumentEntity): Long = throw notImplemented("insert")
+    override suspend fun update(doc: DocumentEntity): Unit = throw notImplemented("update")
+    override suspend fun findByMetadataId(id: String): DocumentEntity? = throw notImplemented("findByMetadataId")
+    override suspend fun findByContentHash(hash: String): DocumentEntity? = throw notImplemented("findByContentHash")
+    override suspend fun findById(id: Long): DocumentEntity? = throw notImplemented("findById")
+    override fun observeAll(): Flow<List<DocumentEntity>> = flowOf(emptyList())
+    override fun observeSeriesContinuationCandidates(
+        startedThreshold: Double,
+        maxItems: Int,
+    ): Flow<List<DocumentEntity>> = flowOf(emptyList())
+    override suspend fun deleteById(id: Long): Int = throw notImplemented("deleteById")
+    override suspend fun deleteAll(): Unit = throw notImplemented("deleteAll")
+
+    private fun notImplemented(name: String) =
+        UnsupportedOperationException("FakeDocumentDao.$name not implemented for this test")
+}

--- a/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/6.json
+++ b/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/6.json
@@ -1,0 +1,239 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "7a5b51f7a1bd3b21a7abacf95c6fb94e",
+    "entities": [
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `metadataId` TEXT, `contentHash` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `downloadUrl` TEXT NOT NULL, `localPath` TEXT NOT NULL, `coverPath` TEXT, `downloadedAt` INTEGER NOT NULL, `seriesName` TEXT, `seriesIndex` REAL, `librarySyncedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "librarySyncedAt",
+            "columnName": "librarySyncedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_documents_metadataId",
+            "unique": true,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_documents_contentHash",
+            "unique": true,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_documents_seriesName_seriesIndex",
+            "unique": false,
+            "columnNames": [
+              "seriesName",
+              "seriesIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_documents_seriesName_seriesIndex` ON `${TABLE_NAME}` (`seriesName`, `seriesIndex`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `documentId` INTEGER NOT NULL, `locator` TEXT NOT NULL, `percent` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `finishedAt` INTEGER, FOREIGN KEY(`documentId`) REFERENCES `documents`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locator",
+            "columnName": "locator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percent",
+            "columnName": "percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_documentId",
+            "unique": true,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_progress_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "documents",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `lastPulledAt` INTEGER NOT NULL, PRIMARY KEY(`tableName`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPulledAt",
+            "columnName": "lastPulledAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7a5b51f7a1bd3b21a7abacf95c6fb94e')"
+    ]
+  }
+}

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentDao.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentDao.kt
@@ -83,4 +83,16 @@ interface DocumentDao {
 
     @Query("DELETE FROM documents")
     suspend fun deleteAll()
+
+    /**
+     * Rows that haven't been uploaded to `/library/v1/items` yet. The uploader
+     * walks these on each app start and after every new download. Returns
+     * newest-first so the user-facing book they just downloaded reaches the
+     * server before the long tail of pre-existing backlog.
+     */
+    @Query("SELECT * FROM documents WHERE librarySyncedAt IS NULL ORDER BY downloadedAt DESC, id DESC")
+    suspend fun findUnsyncedToLibrary(): List<DocumentEntity>
+
+    @Query("UPDATE documents SET librarySyncedAt = :at WHERE id = :id")
+    suspend fun markLibrarySynced(id: Long, at: Long)
 }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
@@ -27,4 +27,14 @@ data class DocumentEntity(
     val downloadedAt: Long,
     val seriesName: String? = null,
     val seriesIndex: Double? = null,
+    /**
+     * When this row was last successfully PUT to `/library/v1/items`.
+     * `null` means "not yet synced" — the upload pass picks these up.
+     * Existing rows backfill via the 5→6 migration as null, so the first
+     * post-update run uploads everything.
+     *
+     * Wall-clock millis (System.currentTimeMillis) — used only as a
+     * presence marker; we never compare it against server timestamps.
+     */
+    val librarySyncedAt: Long? = null,
 )

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [DocumentEntity::class, ProgressEntity::class, SyncStateEntity::class],
-    version = 5,
+    version = 6,
     exportSchema = true,
 )
 abstract class EReaderDatabase : RoomDatabase() {
@@ -63,9 +63,22 @@ abstract class EReaderDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Adds nullable `librarySyncedAt` to `documents`. The `/library/v1/items`
+         * uploader treats `NULL` as "not yet uploaded", so this migration leaves
+         * the column null for every existing row — the next app start backfills
+         * the entire library to the server. No backfill SQL needed; the absence
+         * of a value IS the signal.
+         */
+        internal val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE documents ADD COLUMN librarySyncedAt INTEGER")
+            }
+        }
+
         fun build(context: Context): EReaderDatabase =
             Room.databaseBuilder(context, EReaderDatabase::class.java, "ereader.db")
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
                 .build()
     }
 }

--- a/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
@@ -81,5 +81,32 @@ class MigrationTest {
         }
     }
 
+    @Test fun `migrate 5 to 6 adds librarySyncedAt column defaulting to null`() {
+        helper.createDatabase(DB, 5).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, localPath, coverPath, downloadedAt, seriesName, seriesIndex) " +
+                    "VALUES (9, 'm9', 'h9', 'Pre-PR title', NULL, 'u', 'p', NULL, 19, NULL, NULL)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(DB, 6, true, EReaderDatabase.MIGRATION_5_6).use { db ->
+            // Existing row survives with NULL librarySyncedAt — that's the
+            // signal the uploader uses to backfill.
+            db.query("SELECT librarySyncedAt FROM documents WHERE id=9").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.isNull(0)).isTrue()
+            }
+            // New rows can write a non-null librarySyncedAt and read it back.
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (10, 'm10', 'h10', 'Post-PR title', NULL, 'u', 'p', NULL, 20, NULL, NULL, 12345)"
+            )
+            db.query("SELECT librarySyncedAt FROM documents WHERE id=10").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getLong(0)).isEqualTo(12345L)
+            }
+        }
+    }
+
     private companion object { const val DB = "migration-test.db" }
 }


### PR DESCRIPTION
## Gap

`/library/v1/stats` (PR #26) and the PUT/GET/DELETE endpoints at `/library/v1/items` have been live on opds-sync for two releases, but no Android client has ever posted a row. The Library Stats screen therefore returns zero `total_books / finished_count / in_progress_count` even when the user has dozens of downloaded books, and `top_authors` is empty.

## What ships

- **`LibraryClient.putItem`** — wraps `PUT /library/v1/items`. Body is `{"item": {...}}` per the server contract. 401 / 409 surface as `LibraryHttpException` so callers can react (re-auth, skip).
- **`LibraryItemRequest / LibraryItemResponse / LibraryItemPutBody`** DTOs mirror `server/opds_sync/api/library_schemas.py`. `series_index` is `Double?` on the wire (server emits float64).
- **`LibraryUploader`** — picks up every `documents` row where `librarySyncedAt IS NULL`, PUTs each, marks `librarySyncedAt = now()` on success. Single-flighted via a `Mutex` so app-start + post-download triggers don't double-PUT. A single 401 aborts the batch (caller handles re-auth); 5xx / network / 409 / other errors log and skip — the row stays unsynced and the next pass retries. No retries inside the uploader itself.
- **Room migration 5 → 6** — adds nullable `librarySyncedAt INTEGER` to `documents`. Existing rows default to `NULL`, so the first post-install run uploads the entire library. DAO gets `findUnsyncedToLibrary()` + `markLibrarySynced(id, at)`.
- **Triggers**:
  - **App start** (`EReaderApp.onCreate`) — fire-and-forget `runOnce()` on a process-lifetime `SupervisorJob` scope. Backfills everything.
  - **Post-download** (`CatalogViewModel.download` success path) — calls `libraryUploader.enqueueOne(insertedId)` so a fresh book reaches the server promptly.

## Scope cuts (intentional)

- **v1 fields only**: `content_hash`, `title`, `authors` (split from `documents.author` on `,` / `&`), `metadata_id`, `series_name`, `series_index`, `opds_href`. `isbn`, `language`, `subjects` left null — they need OPF parsing which is punted to v2.
- **No listItems / no tombstones**: server is treated as an upstream stats sink; deletes on Android don't propagate yet. Acceptable until multi-device delete becomes a real ask.
- **No per-user gating on logout**: a credential swap will re-upload everything under the new user. Documented; not a v1 problem since the relation that ties items to users lives server-side.
- **No standalone WorkManager job for upload**: the existing `SyncWorker` only wraps `SyncOrchestrator.runOnce()`; rather than reshape that wrapper, the v1 trigger model is "app start + post-download". If we observe that the app-start backfill is too unreliable in practice (e.g. users who only open the app briefly), the upload can be appended to the existing worker — but the v1 trigger model is sufficient for the stated goal.

## Autonomous decisions

The brief flagged three open questions; I made these calls:

1. **OPF parse for `isbn` / `language` / `subjects`** → PUNTED TO V2. v1 keeps the wire payload to the fields already on `DocumentEntity`.
2. **Post-download UI** → FIRE-AND-FORGET. Matches the existing progress-sync pattern; download progress UI never waits on the upload.
3. **Per-user gating on logout** → ACCEPTABLE for v1. Re-upload after a credential swap is fine.

## Validation

- `./gradlew :data:library:test --stacktrace` — pass (7 client + 7 uploader + 2 DTO tests)
- `./gradlew :data:local:test --stacktrace` — pass (incl. new 5→6 migration test)
- `./gradlew test --stacktrace` — full sweep passes
- `./gradlew assembleDebug --stacktrace` — pass
- `./gradlew lint --stacktrace` — pass (no new findings)

## Files of note

- `data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt` — the new uploader
- `data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt` — `putItem` added alongside `getStats`
- `data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt` — `MIGRATION_5_6`
- `app/src/main/java/io/theficos/ereader/EReaderApp.kt` — app-start backfill trigger