### PR TITLE
:arrow_up: chore(ci): bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -42,18 +42,18 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: "21"
-      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
         with:
           packages: "platform-tools platforms;android-34 build-tools;34.0.0"
-      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+      - uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5
       - id: version
         name: Compute version
         env:
@@ -100,7 +100,7 @@ jobs:
         run: ./gradlew lint --stacktrace
       - name: Upload debug APK
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: app-debug-${{ env.VERSION_NAME }}
           path: app/build/outputs/apk/debug/*.apk
@@ -117,19 +117,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: v${{ needs.build.outputs.version }}
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: "21"
-      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
         with:
           packages: "platform-tools platforms;android-34 build-tools;34.0.0"
-      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+      - uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5
       - name: Decode keystore
         if: env.KEYSTORE_B64 != ''
         run: echo "$KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/release.keystore"
@@ -143,7 +143,7 @@ jobs:
           QUIRE_RELEASE_KEY_PASSWORD: ${{ secrets.QUIRE_RELEASE_KEY_PASSWORD }}
         run: ./gradlew :app:assembleRelease --stacktrace
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: v${{ needs.build.outputs.version }}
           files: app/build/outputs/apk/release/*.apk

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -29,24 +29,24 @@ jobs:
       matrix:
         language: [java-kotlin, python]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        uses: github/codeql-action/init@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           languages: ${{ matrix.language }}
       - if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: "21"
       - if: matrix.language == 'java-kotlin'
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
         with:
           packages: "platform-tools platforms;android-34 build-tools;34.0.0"
       - if: matrix.language == 'java-kotlin'
         run: ./gradlew assembleDebug -x test --stacktrace
       - if: matrix.language == 'python'
-        uses: github/codeql-action/autobuild@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
-      - uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        uses: github/codeql-action/autobuild@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
+      - uses: github/codeql-action/analyze@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4

--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -36,8 +36,8 @@ jobs:
       OPDS_SYNC_PROGRESS_ENABLED: ${{ matrix.mode != 'ai_only' && 'true' || 'false' }}
       OPDS_SYNC_AI_ENABLED: ${{ matrix.mode != 'sync_only' && 'true' || 'false' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Set up Python
         run: uv python install 3.12
       - name: Install
@@ -58,14 +58,14 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: server
           push: true
@@ -88,18 +88,18 @@ jobs:
       packages: read
       security-events: write
     steps:
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+      - uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/opds-sync:${{ github.sha }}
           format: sarif
           output: trivy.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-      - uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+      - uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: trivy.sarif


### PR DESCRIPTION
## Why

GitHub is deprecating the Node 20 runtime. Any action still pinned to a Node 20 release will be auto-dismissed. This PR upgrades every action in our three workflows to the lowest major that runs on Node 24, keeping the bump conservative to minimize breakage.

## Bumps

| Action                          | From      | To         |
|---------------------------------|-----------|------------|
| `actions/checkout`              | v4        | v5         |
| `actions/setup-java`            | v4        | v5         |
| `actions/upload-artifact`       | v4        | v5         |
| `astral-sh/setup-uv`            | v3        | v8.1.0     |
| `docker/setup-buildx-action`    | v3        | v4         |
| `docker/login-action`           | v3        | v4         |
| `docker/build-push-action`      | v6        | v7         |
| `android-actions/setup-android` | v3        | v4         |
| `gradle/actions/setup-gradle`   | v4        | v5         |
| `github/codeql-action`          | v3        | v4         |
| `aquasecurity/trivy-action`     | v0.35.0   | v0.36.0    |
| `softprops/action-gh-release`   | v2        | v3         |

All pins remain SHA-pinned with a trailing `# vN` comment for human review (matching the existing style).

## Compatibility notes

- `actions/upload-artifact@v5` no longer supports multiple artifacts with the same name in one workflow. We upload exactly one (`app-debug-${{ env.VERSION_NAME }}` in `android-ci.yaml`), so this is moot.
- `actions/checkout@v5` keeps `fetch-depth`/`fetch-tags` semantics; the release job that depends on `fetch-tags: true` is unaffected.
- `gradle/actions/setup-gradle@v5` retains the no-input form we use; cache-related defaults haven't changed for our usage.
- `github/codeql-action@v4` is a runtime-only bump for `init`/`autobuild`/`analyze`/`upload-sarif`; no analysis-config schema change at this major.
- `softprops/action-gh-release@v3` keeps `tag_name`, `files`, and `generate_release_notes` inputs.

## Test plan

- [ ] `server-ci` matrix (full/sync_only/ai_only) green on this PR.
- [ ] `codeql` (java-kotlin + python) green on this PR — exercises the v4 codeql-action.
- [ ] `android-ci` (build job) green on this PR — exercises checkout/setup-java/setup-android/setup-gradle at the new majors. The `release` job is `main`-only and will be exercised on merge.