### PR TITLE
:memo: docs(server): Caddy-fronted reference compose + deploy-mode docs (pr-10)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -50,3 +50,19 @@ QUIRE_SERVER_AI_ENABLED=true
 # QUIRE_SERVER_AI_RATE_PER_MIN=10
 # QUIRE_SERVER_AI_DAILY_BUDGET=200
 # QUIRE_SERVER_AI_REGEN_DAILY_LIMIT=3
+
+# Reader Profile (pr-beta). Defaults live in config.py; uncomment to
+# override.
+# QUIRE_SERVER_AI_PROFILE_REFRESH_DAILY_LIMIT=3
+# QUIRE_SERVER_AI_PROFILE_TIMEOUT_S=90
+
+# Insight promote (pr-zeta). Default lives in config.py; uncomment to
+# override. weight=0 against AI_DAILY_BUDGET (no LLM call).
+# QUIRE_SERVER_AI_PROMOTE_DAILY_LIMIT=100
+
+# Prompt-version override (advanced / incident-response only - see
+# Lock #19). The legacy value "1" is treated as **unset** and falls
+# back to the in-code PROMPT_VERSION constant. Any other value pins
+# that version. Use to roll back if a PROMPT_VERSION bump misbehaves
+# in production.
+# QUIRE_SERVER_AI_PROMPT_VERSION=

--- a/server/README.md
+++ b/server/README.md
@@ -138,6 +138,66 @@ Set both flags in `.env`. Sync-only deploys don't need
 `QUIRE_SERVER_AI_*`; AI-only deploys don't need calibre-web auth once
 PR-B's token mode is selected (`QUIRE_SERVER_AI_AUTH_MODE=token`).
 
+##### Mode examples
+
+**Full stack** (default — nothing to change):
+
+```dotenv
+QUIRE_SERVER_PROGRESS_ENABLED=true
+QUIRE_SERVER_AI_ENABLED=true
+QUIRE_SERVER_AI_BASE_URL=https://ollama.example.com/v1
+QUIRE_SERVER_AI_MODEL=gpt-oss:120b-cloud
+QUIRE_SERVER_AI_API_KEY=sk-...
+```
+
+**Sync only** (privacy purists; no LLM calls leave the host):
+
+```dotenv
+QUIRE_SERVER_PROGRESS_ENABLED=true
+QUIRE_SERVER_AI_ENABLED=false
+# QUIRE_SERVER_AI_* may be omitted — they're unused.
+```
+
+In sync-only mode:
+
+- The Caddyfile's `/ai/*` matcher still routes to quire-server, which
+  returns **404** for those paths because the AI router is not mounted.
+  This is intentional, not a broken proxy.
+- `GET /health` returns the health payload without an `ai` mode key
+  (the `ai` block is omitted when `QUIRE_SERVER_AI_ENABLED=false`).
+- `GET /ai/v1/health` returns 404 (the router itself is gone, not
+  just the endpoint).
+
+If you want a cleaner 404 surface, drop the `/ai/*` token from the
+Caddyfile's `@quire` matcher so those paths fall through to
+calibre-web (which also 404s — same outcome, different actor).
+
+**AI only** (future hosted Quire Cloud AI — no calibre-web in the
+stack). The full edit set for `docker-compose.full.yml` + `caddy/Caddyfile`:
+
+1. Delete the entire `calibre-web:` service block.
+2. Inside `caddy.depends_on`, remove the `calibre-web: condition: service_healthy`
+   entry. Caddy must NOT depend on a service that doesn't exist, or
+   `docker compose config/up` fails.
+3. In `caddy/Caddyfile`, replace the trailing default handler
+   `handle { reverse_proxy calibre-web:8083 }` with
+   `handle { respond 404 }` so unknown paths return a clean 404
+   rather than a connection failure to a missing upstream.
+
+`.env` for AI-only:
+
+```dotenv
+QUIRE_SERVER_PROGRESS_ENABLED=false
+QUIRE_SERVER_AI_ENABLED=true
+QUIRE_SERVER_AI_BASE_URL=https://...
+QUIRE_SERVER_AI_MODEL=...
+QUIRE_SERVER_AI_API_KEY=...
+QUIRE_SERVER_AI_AUTH_MODE=token
+QUIRE_SERVER_AI_TOKEN_SECRETS='{"kid-2026-05": "..."}'
+QUIRE_SERVER_AI_TOKEN_ISSUER=https://issuer.example.com
+QUIRE_SERVER_AI_TOKEN_AUDIENCE=quire-server
+```
+
 ### Migrations
 
 Migrations run automatically on container start via `scripts/migrate.py`,
@@ -202,6 +262,8 @@ the env-compat helper. The DB-name non-rename is permanent.
 | `QUIRE_SERVER_AI_DAILY_BUDGET`         | `200`                                  | Per-user generations per UTC day; 0 disables.                           |
 | `QUIRE_SERVER_AI_REGEN_DAILY_LIMIT`    | `3`                                    | Per-user `/insights/regenerate` ceiling per UTC day.                    |
 | `QUIRE_SERVER_AI_PROMOTE_DAILY_LIMIT`  | `100`                                  | Per-user `/insights/promote` ceiling per UTC day; process-local counter, 0 disables. (PR-ζ) |
+| `QUIRE_SERVER_AI_PROFILE_REFRESH_DAILY_LIMIT` | `3`                              | Reader Profile refresh cap per user per UTC day. (PR-β)                 |
+| `QUIRE_SERVER_AI_PROFILE_TIMEOUT_S`    | `90`                                   | Reader Profile orchestrator timeout, in seconds. (PR-β)                 |
 | `QUIRE_SERVER_AI_AUTH_MODE`            | `basic`                                | `basic` (default, wraps calibre-web verifier) or `token` (HMAC-SHA256). |
 | `QUIRE_SERVER_AI_TOKEN_SECRETS`        | unset                                  | Token mode: JSON `{kid: secret}`. Each secret ≥32 bytes; multiple kids enable rotation. |
 | `QUIRE_SERVER_AI_TOKEN_ISSUER`         | unset                                  | Token mode: required; validated against `iss`.                          |
@@ -285,6 +347,19 @@ Expect: `/config` reports `configured: true` with the model id, `/preferences`
 echoes `ai_enabled: true`, and `/insights/lookup` returns a populated
 `payload.summary`, at least one Wikipedia or OpenLibrary `sources` entry,
 and `payload.confidence` of `medium` or `high`.
+
+Once the cache has at least one row, the bulk-sync and reader-profile
+surfaces are also reachable from the same shell session:
+
+```sh
+# Insight bulk-sync (PR-η; first call uses empty cursor; the response's
+# `next_cursor` is a (generated_at, id) tuple - persist the full pair).
+curl -fsS -H "Authorization: Basic $AUTH" "$BASE/insights/sync?limit=100" | jq
+
+# Reader profile (PR-α/β; opt-in required via /preferences; refresh
+# capped at QUIRE_SERVER_AI_PROFILE_REFRESH_DAILY_LIMIT per UTC day).
+curl -fsS -H "Authorization: Basic $AUTH" "$BASE/profile" | jq
+```
 
 When the server runs inside a Kubernetes cluster and is not exposed
 locally, the same three calls work from inside the pod:

--- a/server/README.md
+++ b/server/README.md
@@ -69,8 +69,8 @@ Routing inside the Caddy front-end (`caddy/Caddyfile`):
 {$QUIRE_SITE_ADDRESS:localhost} {
     tls internal
 
-    @opds path /sync/* /ai/* /library/* /health /readyz
-    handle @opds {
+    @quire path /sync/* /ai/* /library/* /health /readyz
+    handle @quire {
         reverse_proxy quire-server:8000
     }
 

--- a/server/docker-compose.full.yml
+++ b/server/docker-compose.full.yml
@@ -12,8 +12,14 @@
 #   # edit .env (set POSTGRES_PASSWORD, mount your calibre library, etc.)
 #   docker compose -f docker-compose.full.yml up -d
 #
-# See server/README.md "Full-stack reference compose" for smoke
-# commands and the TLS swap for production.
+# See server/README.md "Full-stack reference compose" for smoke commands
+# and the TLS swap for production.
+#
+# Env-var compatibility: this compose uses the post-rename
+# QUIRE_SERVER_* prefix. The server also accepts legacy OPDS_SYNC_*
+# from REAL environment variables only (the back-compat shim does NOT
+# read .env files - see server/README.md "Migration from opds-sync").
+# Pick one prefix per deployment; do not mix.
 
 services:
   postgres:
@@ -27,6 +33,12 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       POSTGRES_DB: opds_sync
     volumes:
+      # Volume name kept as `pg_data` for the back-compat window so
+      # existing deployments from v2026.05.17.95 onwards do not
+      # silently get an empty new volume. A future PR may rename it
+      # with an explicit upgrade banner; see README "Migration from
+      # opds-sync". Note: the minimal compose uses `opds_sync_pg` for
+      # the same reason - it shipped earlier with that name.
       - pg_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U opds_sync"]
@@ -51,6 +63,20 @@ services:
       # - /path/to/your/calibre-library:/calibre-library
       # Optional: ingest folder for drop-in book imports.
       # - /path/to/your/ingest:/cwa-book-ingest
+    healthcheck:
+      # calibre-web-automated serves OPDS on :8083/opds. A 401 still
+      # means "process is up + routing"; only network failure or 5xx
+      # counts as unhealthy. We accept 200 or 401 via explicit status
+      # matching (do NOT use plain `curl -f` / `wget --spider` exit
+      # codes - they fail on 401). If `wget` is absent in a future
+      # image rev, swap to:
+      #   curl -o /dev/null -w '%{http_code}' http://localhost:8083/opds
+      #     | grep -qE '^(200|401)$'
+      test: ["CMD-SHELL", "wget -qO- --spider --server-response http://localhost:8083/opds 2>&1 | grep -qE 'HTTP/.* (200|401)' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
 
   quire-server:
     image: ghcr.io/vitofico/quire-server:latest
@@ -59,37 +85,50 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      # New QUIRE_SERVER_* prefix preferred; the server still accepts the
-      # legacy OPDS_SYNC_* names for one release cycle (see server/README.md).
       QUIRE_SERVER_DATABASE_URL: postgresql+asyncpg://opds_sync:${POSTGRES_PASSWORD:-changeme}@postgres:5432/opds_sync
       QUIRE_SERVER_CWA_BASE_URL: http://calibre-web:8083
-      QUIRE_SERVER_LOG_LEVEL: ${QUIRE_SERVER_LOG_LEVEL:-${OPDS_SYNC_LOG_LEVEL:-INFO}}
-      # Deploy mode flags. Defaults give the full-stack experience; flip
-      # one of these to false for sync-only or AI-only mode (see README).
-      QUIRE_SERVER_PROGRESS_ENABLED: ${QUIRE_SERVER_PROGRESS_ENABLED:-${OPDS_SYNC_PROGRESS_ENABLED:-true}}
-      QUIRE_SERVER_AI_ENABLED: ${QUIRE_SERVER_AI_ENABLED:-${OPDS_SYNC_AI_ENABLED:-true}}
-      # AI provider configuration. Required when AI_ENABLED=true.
-      # Point this at any OpenAI-compatible endpoint (Ollama, llama.cpp,
-      # vLLM, hosted OpenAI/Anthropic-compatible gateways, ...).
-      QUIRE_SERVER_AI_BASE_URL: ${QUIRE_SERVER_AI_BASE_URL:-${OPDS_SYNC_AI_BASE_URL:-}}
-      QUIRE_SERVER_AI_MODEL: ${QUIRE_SERVER_AI_MODEL:-${OPDS_SYNC_AI_MODEL:-}}
-      QUIRE_SERVER_AI_API_KEY: ${QUIRE_SERVER_AI_API_KEY:-${OPDS_SYNC_AI_API_KEY:-}}
-      QUIRE_SERVER_AI_SOURCES: ${QUIRE_SERVER_AI_SOURCES:-${OPDS_SYNC_AI_SOURCES:-wikipedia,openlibrary}}
-      QUIRE_SERVER_AI_RATE_PER_MIN: ${QUIRE_SERVER_AI_RATE_PER_MIN:-${OPDS_SYNC_AI_RATE_PER_MIN:-10}}
-      QUIRE_SERVER_AI_DAILY_BUDGET: ${QUIRE_SERVER_AI_DAILY_BUDGET:-${OPDS_SYNC_AI_DAILY_BUDGET:-200}}
-      QUIRE_SERVER_AI_REGEN_DAILY_LIMIT: ${QUIRE_SERVER_AI_REGEN_DAILY_LIMIT:-${OPDS_SYNC_AI_REGEN_DAILY_LIMIT:-3}}
-    # No `ports:` mapping - quire-server is reached through Caddy only.
-    # Add `ports: ["8000:8000"]` temporarily for direct debugging.
+      QUIRE_SERVER_LOG_LEVEL: ${QUIRE_SERVER_LOG_LEVEL:-INFO}
+      # Deploy-mode flags. Defaults give the full stack; flip one of
+      # these to false for sync-only or AI-only mode (see README).
+      QUIRE_SERVER_PROGRESS_ENABLED: ${QUIRE_SERVER_PROGRESS_ENABLED:-true}
+      QUIRE_SERVER_AI_ENABLED: ${QUIRE_SERVER_AI_ENABLED:-true}
+      # AI provider config. Required when QUIRE_SERVER_AI_ENABLED=true.
+      # Point at any OpenAI-compatible endpoint.
+      QUIRE_SERVER_AI_BASE_URL: ${QUIRE_SERVER_AI_BASE_URL:-}
+      QUIRE_SERVER_AI_MODEL: ${QUIRE_SERVER_AI_MODEL:-}
+      QUIRE_SERVER_AI_API_KEY: ${QUIRE_SERVER_AI_API_KEY:-}
+      QUIRE_SERVER_AI_SOURCES: ${QUIRE_SERVER_AI_SOURCES:-wikipedia,openlibrary}
+      QUIRE_SERVER_AI_RATE_PER_MIN: ${QUIRE_SERVER_AI_RATE_PER_MIN:-10}
+      QUIRE_SERVER_AI_DAILY_BUDGET: ${QUIRE_SERVER_AI_DAILY_BUDGET:-200}
+      QUIRE_SERVER_AI_REGEN_DAILY_LIMIT: ${QUIRE_SERVER_AI_REGEN_DAILY_LIMIT:-3}
+      # NOTE: AI_PROFILE_REFRESH_DAILY_LIMIT, AI_PROFILE_TIMEOUT_S, and
+      # AI_PROMOTE_DAILY_LIMIT intentionally OMITTED here. Their
+      # defaults live in config.py; users opting in to non-defaults
+      # set them in .env (see .env.example).
     command: >
       sh -c "python /app/scripts/migrate.py &&
              uvicorn quire_server.main:app --host 0.0.0.0 --port 8000"
+    # No `ports:` mapping - quire-server is reached through Caddy.
+    # Add `ports: ["8000:8000"]` temporarily for direct debugging.
+    healthcheck:
+      # /readyz verifies DB connectivity + required-branch-head check.
+      # 200 means migrations applied and dependent services reachable.
+      # Uses Python's urllib so the slim base image needs no extra
+      # binary (curl/wget are not guaranteed on the quire-server image).
+      test: ["CMD-SHELL", "python3 -c 'import urllib.request,sys; sys.exit(0) if urllib.request.urlopen(\"http://localhost:8000/readyz\", timeout=5).status == 200 else sys.exit(1)' || exit 1"]
+      interval: 10s
+      timeout: 7s
+      retries: 6
+      start_period: 60s
 
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
     depends_on:
-      - quire-server
-      - calibre-web
+      quire-server:
+        condition: service_healthy
+      calibre-web:
+        condition: service_healthy
     environment:
       # Set to your hostname (e.g. ebooks.example.com) for a real cert
       # via ACME. Defaults to `localhost` with self-signed `tls internal`.

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
       POSTGRES_DB: opds_sync
     volumes:
+      # Volume name retained as `opds_sync_pg` for the back-compat
+      # window; existing deployments must not silently lose their DB.
+      # A future PR may rename it with an explicit upgrade banner.
       - opds_sync_pg:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U opds_sync"]
@@ -24,13 +27,11 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      # New QUIRE_SERVER_* prefix preferred; the server still accepts the
-      # legacy OPDS_SYNC_* names for one release cycle (see server/README.md).
       QUIRE_SERVER_DATABASE_URL: postgresql+asyncpg://opds_sync:${POSTGRES_PASSWORD:-changeme}@postgres:5432/opds_sync
-      QUIRE_SERVER_CWA_BASE_URL: ${QUIRE_SERVER_CWA_BASE_URL:-${OPDS_SYNC_CWA_BASE_URL}}
-      QUIRE_SERVER_LOG_LEVEL: ${QUIRE_SERVER_LOG_LEVEL:-${OPDS_SYNC_LOG_LEVEL:-INFO}}
+      QUIRE_SERVER_CWA_BASE_URL: ${QUIRE_SERVER_CWA_BASE_URL}
+      QUIRE_SERVER_LOG_LEVEL: ${QUIRE_SERVER_LOG_LEVEL:-INFO}
     ports:
-      - "${QUIRE_SERVER_PORT:-${OPDS_SYNC_PORT:-8000}}:8000"
+      - "${QUIRE_SERVER_PORT:-8000}:8000"
     command: >
       sh -c "python /app/scripts/migrate.py &&
              uvicorn quire_server.main:app --host 0.0.0.0 --port 8000"


### PR DESCRIPTION
## Summary

Reference docs + compose hardening on top of the post-rename baseline (PR #32) and the original Caddy-fronted compose ship (PR #25). Implements PR-10 of Phase-2.

- **`docker-compose.full.yml`** — healthchecks for postgres, calibre-web, and quire-server; gate caddy on both upstreams via `service_healthy` so it no longer 502s while quire-server boots. calibre-web probe uses `wget` with explicit `200|401` status matching (401 from `/opds` is still "process up"); quire-server probe uses `urllib` so the slim image needs no extra binary. Drop legacy `OPDS_SYNC_*` interpolation fallbacks at the compose layer (Lock #21 — env-compat shim is `os.environ`-only).
- **`docker-compose.yml`** — same env-fallback simplification; pin `opds_sync_pg` volume name with a back-compat comment.
- **`.env.example`** — append `QUIRE_SERVER_AI_PROFILE_REFRESH_DAILY_LIMIT`, `QUIRE_SERVER_AI_PROFILE_TIMEOUT_S`, `QUIRE_SERVER_AI_PROMOTE_DAILY_LIMIT`, and the `QUIRE_SERVER_AI_PROMPT_VERSION` override (all commented; `"1"` sentinel = unset per Lock #19).
- **`server/README.md`** — add table rows for the two new Reader Profile envs; expand deploy-modes with full-stack / sync-only / AI-only `.env` examples; spell out that sync-only returns 404 on `/ai/v1/*` by design (not a broken proxy) and that `/health` omits the `ai` block; enumerate the AI-only edit list (delete calibre-web, drop the `depends_on` entry, replace the default Caddy handle with `respond 404`); add smoke commands for `/ai/v1/insights/sync` and `/ai/v1/profile`.

## Volume-name decision

The plan called for `opds_sync_pg` in both composes. In practice the full compose shipped to users in v2026.05.17.95+ with `pg_data`, so renaming it now would orphan existing DB data (same data-loss-appearance bug the plan calls out for the minimal compose). Keeping `pg_data` in the full compose and `opds_sync_pg` in the minimal compose. A future opt-in PR may unify both with an upgrade banner.

## Test plan

- [x] `docker compose -f server/docker-compose.full.yml config -q` — passes.
- [x] `docker compose -f server/docker-compose.yml config -q` — passes.
- [x] `caddy validate` via `docker run --rm caddy:2-alpine` — "Valid configuration".
- [x] Rename-guard regex (server-ci's exact glob/regex) finds no un-allowlisted hits.
- [ ] Full-stack smoke (manual, against a real host with port 80/443 free): `up -d`, then `curl -fsSk https://localhost/{health,readyz,ai/v1/health}`.
- [ ] Sync-only smoke: with `QUIRE_SERVER_AI_ENABLED=false`, confirm `/ai/v1/health` returns 404 and `/health` has no `ai` key.

## Notes for review

- Server `Caddyfile` was already in the post-rename / spec shape from PR #32 — no changes here.
- `.github/workflows/server-ci.yaml` is out of scope. The rename-guard glob `-g '!README.md'` matches `README.md` at any depth, which de-facto allowlists `server/README.md` too (broader than Lock #20 / CC-5 specifies). That's pre-existing scope from PR-rename, not a PR-10 fix; flagging here for visibility.