### PR TITLE
feat(library): library stats v0 — abandoned_count + cache (PR-9)

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -30,6 +30,7 @@ import io.theficos.ereader.ui.catalogdetail.CatalogDetailRegistry
 import io.theficos.ereader.ui.catalogdetail.CatalogDetailViewModel
 import io.theficos.ereader.ui.library.LibraryInsightsViewModel
 import io.theficos.ereader.ui.library.LibraryPreferencesStore
+import io.theficos.ereader.ui.library.LibraryStatsCache
 import io.theficos.ereader.ui.library.LibraryStatsViewModel
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
@@ -282,7 +283,15 @@ class CatalogDetailViewModelFactory(
 class LibraryStatsViewModelFactory(
     private val client: LibraryClient,
 ) {
-    fun create() = LibraryStatsViewModel(fetch = { client.getStats() })
+    // Process-lifetime cache. Held here (not on the ViewModel) so that
+    // navigating away from the Stats screen and back gives the new VM
+    // instance an immediate `Ready(cached)` — i.e. real SWR across VMs.
+    private val cache = LibraryStatsCache()
+
+    fun create() = LibraryStatsViewModel(
+        fetch = { client.getStats() },
+        cache = cache,
+    )
 }
 
 class LibraryInsightsViewModelFactory(

--- a/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModel.kt
@@ -158,10 +158,14 @@ class CatalogDetailViewModel(
          *    `synthetic:metadata_id:opds-href:<sha>` via
          *    `_synthetic_content_hash`.
          *
-         * Note: this catalog row does NOT converge with the post-download
-         * row (different identifier spaces — calibre-web's OPDS uuid vs the
-         * EPUB OPF dc:identifier). Convergence requires a server-side
-         * promote endpoint, tracked as a follow-up.
+         * Note: this catalog row uses a different identifier space than the
+         * post-download row (calibre-web's OPDS uuid vs the EPUB OPF
+         * dc:identifier). Convergence is handled by PR-ζ's promote-on-download
+         * flow (server-side `POST /ai/v1/insights/promote` copies the
+         * pre-download book_insight row to the post-download content_hash)
+         * and by PR-η's `:data:ai` local cache + `/ai/v1/insights/sync`
+         * pull, which keeps catalog detail and reader views consistent
+         * without re-generating.
          */
         fun buildIdentity(publication: OpdsPublication): DocumentIdentity {
             val opdsHrefValue = "opds-href:" + sha256Hex(publication.epubDownloadHref)

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsScreen.kt
@@ -90,13 +90,24 @@ private fun ReadyState(padding: PaddingValues, stats: LibraryStatsResponse) {
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                CountCard(label = "Books", value = stats.totalBooks, modifier = Modifier.weight(1f))
-                CountCard(label = "Finished", value = stats.finishedCount, modifier = Modifier.weight(1f))
-                CountCard(label = "Reading", value = stats.inProgressCount, modifier = Modifier.weight(1f))
+            // 2×2 grid — Books / Finished / Reading / Abandoned. PR-9
+            // added Abandoned; 4 cards in one row are too narrow on phones,
+            // 2×2 scales down cleanly and leaves room for future tiles.
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    CountCard(label = "Books", value = stats.totalBooks, modifier = Modifier.weight(1f))
+                    CountCard(label = "Finished", value = stats.finishedCount, modifier = Modifier.weight(1f))
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    CountCard(label = "Reading", value = stats.inProgressCount, modifier = Modifier.weight(1f))
+                    CountCard(label = "Abandoned", value = stats.abandonedCount, modifier = Modifier.weight(1f))
+                }
             }
         }
         item { SectionHeading("Top authors") }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsViewModel.kt
@@ -17,12 +17,26 @@ sealed interface LibraryStatsUiState {
 }
 
 /**
+ * Process-lifetime holder for the last successful stats response. Lives on
+ * the factory (and therefore on `AppContainer`), not on the ViewModel, so
+ * popping the Stats screen and re-entering it gives the new VM instance an
+ * immediate `Ready(cached)` instead of a spinner flash.
+ */
+class LibraryStatsCache {
+    @Volatile var lastReady: LibraryStatsResponse? = null
+}
+
+/**
  * One-shot loader for the library stats endpoint, with stale-while-revalidate
  * caching across ViewModel instances within the same process.
  *
+ * The cache itself ([LibraryStatsCache]) is held by the factory in
+ * `AppContainer` so it outlives any individual ViewModel — backing out of
+ * the screen and reopening it preserves the cached `Ready`.
+ *
  * Behaviour on each [load] call:
- *  1. If `lastReady != null`, emit `Ready(cached)` immediately — no spinner
- *     flash on screen re-entry.
+ *  1. If the cache has a value, emit `Ready(cached)` immediately — no
+ *     spinner flash on screen re-entry.
  *  2. Otherwise emit `Loading`.
  *  3. Always kick off a background fetch. Stats are cheap; the correct
  *     default is "every screen open is a fresh fetch".
@@ -33,44 +47,57 @@ sealed interface LibraryStatsUiState {
  *  6. On failure WITHOUT cached data: emit `Error` with code-specific copy
  *     (existing behaviour preserved).
  *
- * Cache scope is process / VM lifetime — cleared on process kill, which is
+ * Concurrency: a per-request generation counter guards against an overlapping
+ * earlier fetch clobbering a later result (or surfacing an Error that arrived
+ * after a success). Only the most recently launched request can mutate state.
+ *
+ * Cache scope is process lifetime — cleared on process kill, which is
  * fine: stats are cheap to refetch on cold start. No Room, no DataStore, no
  * SavedStateHandle. The injected `fetch` lambda keeps the ViewModel purely
  * testable; production binds it to `libraryClient::getStats`.
  */
 class LibraryStatsViewModel(
     private val fetch: suspend () -> LibraryStatsResponse,
+    private val cache: LibraryStatsCache = LibraryStatsCache(),
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow<LibraryStatsUiState>(LibraryStatsUiState.Loading)
+    private val _state = MutableStateFlow<LibraryStatsUiState>(
+        cache.lastReady?.let { LibraryStatsUiState.Ready(it) }
+            ?: LibraryStatsUiState.Loading
+    )
     val state: StateFlow<LibraryStatsUiState> = _state.asStateFlow()
 
-    @Volatile private var lastReady: LibraryStatsResponse? = null
+    @Volatile private var generation: Long = 0L
 
     fun load() {
-        val cached = lastReady
+        val cached = cache.lastReady
         _state.value = if (cached != null) {
             LibraryStatsUiState.Ready(cached)
         } else {
             LibraryStatsUiState.Loading
         }
 
+        val mine = ++generation
         // Always refetch — stats are cheap; SWR keeps the UI fresh.
         viewModelScope.launch {
             try {
                 val fresh = fetch()
-                lastReady = fresh
+                if (mine != generation) return@launch // a newer load() superseded us
+                cache.lastReady = fresh
                 _state.value = LibraryStatsUiState.Ready(fresh)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: LibraryHttpException) {
-                // Silent failure if we have cached data; otherwise surface
-                // the existing code-specific copy.
-                if (cached == null) {
+                if (mine != generation) return@launch
+                // Silent failure if cache has data at the moment the response
+                // arrives (not when the request was launched). Otherwise
+                // surface the existing code-specific copy.
+                if (cache.lastReady == null) {
                     _state.value = LibraryStatsUiState.Error(messageForHttp(e.code))
                 }
             } catch (e: Throwable) {
-                if (cached == null) {
+                if (mine != generation) return@launch
+                if (cache.lastReady == null) {
                     _state.value = LibraryStatsUiState.Error(
                         "Couldn't reach the server: ${e.message ?: "unknown error"}."
                     )

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryStatsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.theficos.ereader.data.library.LibraryHttpException
 import io.theficos.ereader.data.library.LibraryStatsResponse
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,11 +17,26 @@ sealed interface LibraryStatsUiState {
 }
 
 /**
- * One-shot loader for the library stats endpoint. Re-runnable via [load] (the
- * Stats screen's retry button calls it).
+ * One-shot loader for the library stats endpoint, with stale-while-revalidate
+ * caching across ViewModel instances within the same process.
  *
- * Injected `fetch` lambda keeps the ViewModel purely testable — production
- * binds it to `libraryClient::getStats`.
+ * Behaviour on each [load] call:
+ *  1. If `lastReady != null`, emit `Ready(cached)` immediately — no spinner
+ *     flash on screen re-entry.
+ *  2. Otherwise emit `Loading`.
+ *  3. Always kick off a background fetch. Stats are cheap; the correct
+ *     default is "every screen open is a fresh fetch".
+ *  4. On success: update the cache and emit `Ready(fresh)`.
+ *  5. On failure WITH cached data: keep the cached `Ready` visible (silent
+ *     refresh failure — the user keeps seeing their data). No new error UI
+ *     in PR-9.
+ *  6. On failure WITHOUT cached data: emit `Error` with code-specific copy
+ *     (existing behaviour preserved).
+ *
+ * Cache scope is process / VM lifetime — cleared on process kill, which is
+ * fine: stats are cheap to refetch on cold start. No Room, no DataStore, no
+ * SavedStateHandle. The injected `fetch` lambda keeps the ViewModel purely
+ * testable; production binds it to `libraryClient::getStats`.
  */
 class LibraryStatsViewModel(
     private val fetch: suspend () -> LibraryStatsResponse,
@@ -29,24 +45,43 @@ class LibraryStatsViewModel(
     private val _state = MutableStateFlow<LibraryStatsUiState>(LibraryStatsUiState.Loading)
     val state: StateFlow<LibraryStatsUiState> = _state.asStateFlow()
 
+    @Volatile private var lastReady: LibraryStatsResponse? = null
+
     fun load() {
-        _state.value = LibraryStatsUiState.Loading
+        val cached = lastReady
+        _state.value = if (cached != null) {
+            LibraryStatsUiState.Ready(cached)
+        } else {
+            LibraryStatsUiState.Loading
+        }
+
+        // Always refetch — stats are cheap; SWR keeps the UI fresh.
         viewModelScope.launch {
-            _state.value = try {
-                LibraryStatsUiState.Ready(fetch())
+            try {
+                val fresh = fetch()
+                lastReady = fresh
+                _state.value = LibraryStatsUiState.Ready(fresh)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: LibraryHttpException) {
-                LibraryStatsUiState.Error(
-                    when (e.code) {
-                        401 -> "Sign in to your calibre-web instance to see stats."
-                        404 -> "Library stats aren't available on this server."
-                        else -> "Couldn't load stats (HTTP ${e.code})."
-                    }
-                )
+                // Silent failure if we have cached data; otherwise surface
+                // the existing code-specific copy.
+                if (cached == null) {
+                    _state.value = LibraryStatsUiState.Error(messageForHttp(e.code))
+                }
             } catch (e: Throwable) {
-                LibraryStatsUiState.Error(
-                    "Couldn't reach the server: ${e.message ?: "unknown error"}."
-                )
+                if (cached == null) {
+                    _state.value = LibraryStatsUiState.Error(
+                        "Couldn't reach the server: ${e.message ?: "unknown error"}."
+                    )
+                }
             }
         }
+    }
+
+    private fun messageForHttp(code: Int): String = when (code) {
+        401 -> "Sign in to your calibre-web instance to see stats."
+        404 -> "Library stats aren't available on this server."
+        else -> "Couldn't load stats (HTTP $code)."
     }
 }

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryStatsViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryStatsViewModelTest.kt
@@ -153,4 +153,76 @@ class LibraryStatsViewModelTest {
             assertThat(ready.stats.abandonedCount).isEqualTo(5)
         }
     }
+
+    /**
+     * Real SWR: navigating away from the screen and reopening it must NOT
+     * show a spinner flash. Achieved by hoisting the cache out of the VM
+     * into a shared holder that lives on the factory (process lifetime).
+     *
+     * Without the fix, the new VM has an empty per-instance cache and emits
+     * Loading until the network call returns.
+     */
+    @Test
+    fun `new VM via shared cache emits Ready before fetch completes`() = runTest(dispatcher) {
+        val cache = LibraryStatsCache()
+        // First VM populates the cache.
+        val vm1 = LibraryStatsViewModel(fetch = { fakeStats }, cache = cache)
+        vm1.state.test {
+            awaitItem() // Loading
+            vm1.load()
+            val first = awaitItem() as LibraryStatsUiState.Ready
+            assertThat(first.stats.totalBooks).isEqualTo(3)
+        }
+
+        // Simulate back-out + re-entry: a fresh VM, same factory-held cache.
+        // The fetch lambda suspends forever so we can prove the cached Ready
+        // is visible BEFORE any network result arrives.
+        val gate = kotlinx.coroutines.CompletableDeferred<LibraryStatsResponse>()
+        val vm2 = LibraryStatsViewModel(fetch = { gate.await() }, cache = cache)
+        vm2.state.test {
+            // Initial state is already Ready(cached) — no Loading flash.
+            val initial = awaitItem()
+            assertThat(initial).isInstanceOf(LibraryStatsUiState.Ready::class.java)
+            assertThat((initial as LibraryStatsUiState.Ready).stats.totalBooks).isEqualTo(3)
+            vm2.load()
+            // Still Ready(cached) while the in-flight fetch is gated.
+            expectNoEvents()
+            // Now let the fetch complete with fresh data.
+            gate.complete(fakeStats.copy(totalBooks = 42))
+            val refreshed = awaitItem() as LibraryStatsUiState.Ready
+            assertThat(refreshed.stats.totalBooks).isEqualTo(42)
+        }
+    }
+
+    /**
+     * Concurrency guard: an in-flight fetch launched before a later load()
+     * must not clobber state once a newer request has started. Regression
+     * test for the catch-path race noted in PR review.
+     */
+    @Test
+    fun `stale catch-path response does not override fresh success`() = runTest(dispatcher) {
+        val slowFail = kotlinx.coroutines.CompletableDeferred<LibraryStatsResponse>()
+        var call = 0
+        val vm = LibraryStatsViewModel(fetch = {
+            call++
+            if (call == 1) {
+                slowFail.await() // never completes normally; we'll fail it
+                error("unreachable")
+            } else {
+                fakeStats.copy(totalBooks = 7)
+            }
+        })
+        vm.state.test {
+            awaitItem() // Loading
+            vm.load() // call 1 in flight
+            // Kick off a second load BEFORE the first errors out.
+            vm.load() // call 2 — succeeds
+            val ready = awaitItem() as LibraryStatsUiState.Ready
+            assertThat(ready.stats.totalBooks).isEqualTo(7)
+            // Now let the first call fail. With the generation guard, the
+            // stale failure must be ignored: no Error emission.
+            slowFail.completeExceptionally(LibraryHttpException(500, "stale"))
+            expectNoEvents()
+        }
+    }
 }

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryStatsViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryStatsViewModelTest.kt
@@ -27,6 +27,7 @@ class LibraryStatsViewModelTest {
         totalBooks = 3,
         finishedCount = 1,
         inProgressCount = 1,
+        abandonedCount = 0,
         topAuthors = listOf(TopAuthor("A", 1)),
         topThemes = listOf(TopTheme("noir", 1, "v3+ insights only")),
         themesCaveat = "caveat",
@@ -92,6 +93,64 @@ class LibraryStatsViewModelTest {
             vm.load()
             assertThat(awaitItem()).isInstanceOf(LibraryStatsUiState.Loading::class.java)
             assertThat(awaitItem()).isInstanceOf(LibraryStatsUiState.Ready::class.java)
+        }
+    }
+
+    @Test
+    fun `second load shows cached Ready immediately and refreshes in background`() =
+        runTest(dispatcher) {
+            val fresh = fakeStats.copy(totalBooks = 99)
+            var attempt = 0
+            val vm = LibraryStatsViewModel(fetch = {
+                attempt++
+                if (attempt == 1) fakeStats else fresh
+            })
+            vm.state.test {
+                assertThat(awaitItem()).isInstanceOf(LibraryStatsUiState.Loading::class.java)
+                vm.load()
+                val first = awaitItem() as LibraryStatsUiState.Ready
+                assertThat(first.stats.totalBooks).isEqualTo(3)
+
+                // Second load: cache hit. No Loading flash; goes straight
+                // from Ready(cached) (no state change emitted because the
+                // value is identical) to Ready(fresh) after background fetch.
+                vm.load()
+                val second = awaitItem() as LibraryStatsUiState.Ready
+                assertThat(second.stats.totalBooks).isEqualTo(99)
+            }
+        }
+
+    @Test
+    fun `refresh failure with cached data keeps cached Ready visible`() = runTest(dispatcher) {
+        var attempt = 0
+        val vm = LibraryStatsViewModel(fetch = {
+            attempt++
+            if (attempt == 1) fakeStats else throw LibraryHttpException(500, "boom")
+        })
+        vm.state.test {
+            awaitItem() // Loading
+            vm.load()
+            val first = awaitItem() as LibraryStatsUiState.Ready
+            assertThat(first.stats.totalBooks).isEqualTo(3)
+
+            // Second load should NOT emit an Error variant; cached Ready
+            // persists silently. Verify by emitting another load() after
+            // and confirming no Error has come through in between.
+            vm.load()
+            // No new emissions expected (state value didn't change).
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `abandoned count flows through Ready state`() = runTest(dispatcher) {
+        val stats = fakeStats.copy(abandonedCount = 5)
+        val vm = LibraryStatsViewModel(fetch = { stats })
+        vm.state.test {
+            awaitItem() // Loading
+            vm.load()
+            val ready = awaitItem() as LibraryStatsUiState.Ready
+            assertThat(ready.stats.abandonedCount).isEqualTo(5)
         }
     }
 }

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
@@ -21,6 +21,12 @@ data class LibraryStatsResponse(
     @SerialName("total_books") val totalBooks: Int,
     @SerialName("finished_count") val finishedCount: Int,
     @SerialName("in_progress_count") val inProgressCount: Int,
+    // PR-9 (Bundle 4): additive. The `= 0` default tolerates a server that
+    // hasn't yet deployed PR-9 (back-compat). Combined with
+    // `LibraryClient`'s `ignoreUnknownKeys = true`, the response is
+    // forward-compat too: a newer server adding more fields won't break
+    // older clients.
+    @SerialName("abandoned_count") val abandonedCount: Int = 0,
     @SerialName("top_authors") val topAuthors: List<TopAuthor>,
     @SerialName("top_themes") val topThemes: List<TopTheme>,
     @SerialName("themes_caveat") val themesCaveat: String,

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
@@ -14,6 +14,7 @@ class LibraryDtosTest {
               "total_books": 5,
               "finished_count": 2,
               "in_progress_count": 1,
+              "abandoned_count": 1,
               "top_authors": [{"name":"Asimov","count":3}],
               "top_themes": [{"theme":"noir","count":2,"note":"v3+ insights only"}],
               "themes_caveat": "Theme stats include books with AI theme data; older cached insights may be missing until regenerated."
@@ -23,6 +24,7 @@ class LibraryDtosTest {
         assertThat(parsed.totalBooks).isEqualTo(5)
         assertThat(parsed.finishedCount).isEqualTo(2)
         assertThat(parsed.inProgressCount).isEqualTo(1)
+        assertThat(parsed.abandonedCount).isEqualTo(1)
         assertThat(parsed.topAuthors).containsExactly(TopAuthor("Asimov", 3))
         assertThat(parsed.topThemes).containsExactly(TopTheme("noir", 2, "v3+ insights only"))
         assertThat(parsed.themesCaveat).contains("may be missing")
@@ -31,10 +33,34 @@ class LibraryDtosTest {
     @Test
     fun `parses empty lists`() {
         val body = """
-            {"total_books":0,"finished_count":0,"in_progress_count":0,"top_authors":[],"top_themes":[],"themes_caveat":"x"}
+            {"total_books":0,"finished_count":0,"in_progress_count":0,"abandoned_count":0,"top_authors":[],"top_themes":[],"themes_caveat":"x"}
         """.trimIndent()
         val parsed = json.decodeFromString(LibraryStatsResponse.serializer(), body)
         assertThat(parsed.topAuthors).isEmpty()
         assertThat(parsed.topThemes).isEmpty()
+    }
+
+    @Test
+    fun `parses payload without abandoned_count field (back-compat)`() {
+        // Pre-PR-9 server payload — the Kotlin default `= 0` kicks in so
+        // a newer app talking to an older server doesn't crash.
+        val body = """
+            {"total_books":3,"finished_count":1,"in_progress_count":2,"top_authors":[],"top_themes":[],"themes_caveat":""}
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryStatsResponse.serializer(), body)
+        assertThat(parsed.abandonedCount).isEqualTo(0)
+        assertThat(parsed.totalBooks).isEqualTo(3)
+    }
+
+    @Test
+    fun `tolerates unknown additive fields (forward-compat)`() {
+        // `ignoreUnknownKeys = true` lets the server add fields freely
+        // without bumping the API version.
+        val body = """
+            {"total_books":3,"finished_count":1,"in_progress_count":2,"abandoned_count":0,"top_authors":[],"top_themes":[],"themes_caveat":"","future_field":"ignored","another":42}
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryStatsResponse.serializer(), body)
+        assertThat(parsed.totalBooks).isEqualTo(3)
+        assertThat(parsed.abandonedCount).isEqualTo(0)
     }
 }

--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -289,6 +289,7 @@ Response:
   "total_books": 142,
   "finished_count": 37,
   "in_progress_count": 5,
+  "abandoned_count": 3,
   "top_authors": [
     { "name": "Isaac Asimov", "count": 12 },
     { "name": "Ursula K. Le Guin", "count": 7 }
@@ -301,7 +302,12 @@ Response:
 }
 ```
 
-- No `abandoned_count`: there is no explicit abandoned status yet.
+- `abandoned_count` counts library items whose Progress row has
+  `abandoned_at IS NOT NULL` (introduced alongside the
+  `progress.abandoned_at` column, PR-α). The three count buckets
+  (`finished_count`, `in_progress_count`, `abandoned_count`) are
+  mutually disjoint: `in_progress_count` excludes books marked
+  abandoned, even if their progress percent > 0.
 - `themes_caveat` is a constant server-emitted string the client renders
   verbatim. Sourcing it server-side means the wording can change without
   an app release.

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -295,9 +295,15 @@ async def get_stats(
         )
     ) or 0
 
-    # 2b. in_progress_count: started but not finished. We do NOT cap at
-    #     percent < 1: a book at percent=1 with finished_at IS NULL still
-    #     counts as in-progress ("not done until the device says so").
+    # 2b. in_progress_count: started but not finished AND not abandoned.
+    #     We do NOT cap at percent < 1: a book at percent=1 with finished_at
+    #     IS NULL still counts as in-progress ("not done until the device
+    #     says so"). PR-9 (Bundle 4) tightens this to require
+    #     `abandoned_at IS NULL` so the three count buckets
+    #     (`finished_count`, `in_progress_count`, `abandoned_count`) are
+    #     mutually disjoint. User-visible effect: a book marked abandoned
+    #     no longer counts as "Reading", matching the release-note framing
+    #     "Reading excludes Abandoned".
     in_progress_count = (
         await session.scalar(
             select(func.count())
@@ -314,7 +320,34 @@ async def get_stats(
                 LibraryItem.user_id == user_id,
                 LibraryItem.deleted_at.is_(None),
                 Progress.finished_at.is_(None),
+                Progress.abandoned_at.is_(None),
                 Progress.percent > 0,
+            )
+        )
+    ) or 0
+
+    # 2c. abandoned_count: library_items JOIN documents JOIN progress, where
+    #     abandoned_at IS NOT NULL. The XOR check constraint (PR-α migration
+    #     progress_002_abandoned_at) guarantees finished_at IS NULL for
+    #     these rows; we add the explicit predicate as belt-and-suspenders
+    #     against future relaxation of the constraint.
+    abandoned_count = (
+        await session.scalar(
+            select(func.count())
+            .select_from(LibraryItem)
+            .join(
+                Document,
+                and_(
+                    Document.user_id == LibraryItem.user_id,
+                    Document.content_hash == LibraryItem.content_hash,
+                ),
+            )
+            .join(Progress, Progress.document_pk == Document.pk)
+            .where(
+                LibraryItem.user_id == user_id,
+                LibraryItem.deleted_at.is_(None),
+                Progress.abandoned_at.is_not(None),
+                Progress.finished_at.is_(None),
             )
         )
     ) or 0
@@ -409,10 +442,15 @@ async def get_stats(
         TopTheme(theme=row.theme, count=int(row.c), note="v3+ insights only") for row in theme_rows
     ]
 
+    # NOTE (Lock #12): /library/v1/stats does NOT include a fingerprint. The
+    # AI profile envelope owns the input_fingerprint contract; stats uses a
+    # lightweight in-memory cache on the client (stale-while-revalidate) and
+    # does not participate in profile staleness checks.
     return LibraryStatsResponse(
         total_books=int(total_books),
         finished_count=int(finished_count),
         in_progress_count=int(in_progress_count),
+        abandoned_count=int(abandoned_count),
         top_authors=top_authors,
         top_themes=top_themes,
         themes_caveat=LIBRARY_STATS_THEMES_CAVEAT,

--- a/server/quire_server/api/library_schemas.py
+++ b/server/quire_server/api/library_schemas.py
@@ -141,6 +141,12 @@ class LibraryStatsResponse(BaseModel):
     total_books: int
     finished_count: int
     in_progress_count: int
+    # PR-9 (Bundle 4): purely additive. The three count buckets
+    # (`finished_count`, `in_progress_count`, `abandoned_count`) are
+    # mutually disjoint — a book counted under `abandoned_count` is NOT
+    # also counted under `in_progress_count` even if its percent > 0.
+    # See `library.py::get_stats` for the SQL gates that enforce this.
+    abandoned_count: int
     top_authors: list[TopAuthor]
     top_themes: list[TopTheme]
     themes_caveat: str

--- a/server/tests/integration/test_library_stats.py
+++ b/server/tests/integration/test_library_stats.py
@@ -71,6 +71,27 @@ def _progress_body(content_hash: str, percent: float, finished: bool, when: str)
     }
 
 
+def _abandon_body(content_hash: str, percent: float, when: str) -> dict:
+    """Progress payload that marks a book abandoned.
+
+    PR-α's progress endpoint enforces the XOR invariant: setting
+    `abandoned_at` requires `finished_at` to be null. `percent` is
+    preserved so e.g. abandoning at 60% remembers 60%.
+    """
+    return {
+        "items": [
+            {
+                "document": {"metadata_id": None, "content_hash": content_hash},
+                "locator": "{}",
+                "percent": percent,
+                "client_updated_at": when,
+                "finished_at": None,
+                "abandoned_at": when,
+            }
+        ]
+    }
+
+
 # ---------------------------------------------------------------------------
 # Counts
 # ---------------------------------------------------------------------------
@@ -86,6 +107,7 @@ async def test_empty_library_returns_zero_counts(app_under_test, unique_user):
     assert data["total_books"] == 0
     assert data["finished_count"] == 0
     assert data["in_progress_count"] == 0
+    assert data["abandoned_count"] == 0
     assert data["top_authors"] == []
     assert data["top_themes"] == []
     assert "may be missing" in data["themes_caveat"]
@@ -208,6 +230,175 @@ async def test_user_scoping(app_under_test, unique_user):
         r = await c.get("/library/v1/stats", headers=_basic("bob", "bobpass"))
     assert r.status_code == 200
     assert r.json()["total_books"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Abandoned counts (PR-9 Bundle 4)
+# ---------------------------------------------------------------------------
+
+
+async def test_abandoned_count_requires_abandoned_at(app_under_test, unique_user):
+    """abandoned_count counts only library_items whose Progress.abandoned_at
+    is set. Constructed via valid XOR-satisfying rows.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    now = datetime.now(UTC).isoformat()
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # a: finished (finished_at set, abandoned_at NULL)
+        # b: abandoned at percent=0 (abandoned_at set, finished_at NULL)
+        # c: abandoned at percent=0.5 (abandoned_at set, finished_at NULL,
+        #    percent>0 — must NOT count as in_progress after PR-9 tightening)
+        await c.put("/library/v1/items", json=_put_body(content_hash="a"), headers=headers)
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="b", metadata_id="md-2"),
+            headers=headers,
+        )
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="c", metadata_id="md-3"),
+            headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress",
+            json=_progress_body("a", 1.0, True, now),
+            headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress",
+            json=_abandon_body("b", 0.0, now),
+            headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress",
+            json=_abandon_body("c", 0.5, now),
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    data = r.json()
+    assert data["abandoned_count"] == 2  # b and c
+    assert data["finished_count"] == 1  # a
+    # PR-9 tightening: c (percent=0.5 + abandoned) does NOT count as in_progress.
+    assert data["in_progress_count"] == 0
+
+
+async def test_counts_are_disjoint(app_under_test, unique_user):
+    """The three count buckets are mutually disjoint and never double-count."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    now = datetime.now(UTC).isoformat()
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # 5 books:
+        #  fin: finished
+        #  ab0: abandoned at 0
+        #  ab5: abandoned at 0.5
+        #  ip:  in-progress (percent=0.3, neither terminal flag)
+        #  un:  untouched (no progress row at all)
+        for ch, md in [("fin", "md-fin"), ("ab0", "md-ab0"), ("ab5", "md-ab5"),
+                       ("ip", "md-ip"), ("un", "md-un")]:
+            await c.put(
+                "/library/v1/items",
+                json=_put_body(content_hash=ch, metadata_id=md),
+                headers=headers,
+            )
+        await c.post(
+            "/sync/v1/progress", json=_progress_body("fin", 1.0, True, now), headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress", json=_abandon_body("ab0", 0.0, now), headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress", json=_abandon_body("ab5", 0.5, now), headers=headers,
+        )
+        await c.post(
+            "/sync/v1/progress", json=_progress_body("ip", 0.3, False, now), headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    data = r.json()
+    assert data["total_books"] == 5
+    assert data["finished_count"] == 1
+    assert data["abandoned_count"] == 2
+    assert data["in_progress_count"] == 1
+    assert (
+        data["finished_count"] + data["abandoned_count"] + data["in_progress_count"]
+    ) <= data["total_books"]
+
+
+async def test_abandoned_count_excludes_tombstoned_books(app_under_test, unique_user):
+    """LibraryItem.deleted_at IS NOT NULL → not counted even if the
+    Progress row still has abandoned_at set (matches finished_count's
+    tombstone semantics).
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    now = datetime.now(UTC).isoformat()
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put("/library/v1/items", json=_put_body(content_hash="x"), headers=headers)
+        await c.post(
+            "/sync/v1/progress", json=_abandon_body("x", 0.3, now), headers=headers,
+        )
+        # Tombstone the library item — the progress row survives.
+        await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "x"}},
+            headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    data = r.json()
+    assert data["abandoned_count"] == 0
+    assert data["total_books"] == 0
+
+
+async def test_abandoned_count_user_scoped(app_under_test, cwa_users):
+    """User A's abandoned books don't appear in user B's count."""
+    user_a = f"user-{uuid.uuid4().hex[:8]}"
+    user_b = f"user-{uuid.uuid4().hex[:8]}"
+    cwa_users[user_a] = "pw"
+    cwa_users[user_b] = "pw"
+    transport = ASGITransport(app=app_under_test)
+    now = datetime.now(UTC).isoformat()
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put(
+            "/library/v1/items",
+            json=_put_body(content_hash="a-ch"),
+            headers=_basic(user_a, "pw"),
+        )
+        await c.post(
+            "/sync/v1/progress",
+            json=_abandon_body("a-ch", 0.3, now),
+            headers=_basic(user_a, "pw"),
+        )
+        r_a = await c.get("/library/v1/stats", headers=_basic(user_a, "pw"))
+        r_b = await c.get("/library/v1/stats", headers=_basic(user_b, "pw"))
+    assert r_a.json()["abandoned_count"] == 1
+    assert r_b.json()["abandoned_count"] == 0
+
+
+async def test_in_progress_excludes_abandoned_rows(app_under_test, unique_user):
+    """PR-9 behaviour change: a book marked abandoned no longer counts as
+    in_progress even if percent > 0 and finished_at IS NULL. Backs the
+    'Reading excludes Abandoned' release-note guarantee.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    now = datetime.now(UTC).isoformat()
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.put("/library/v1/items", json=_put_body(content_hash="r"), headers=headers)
+        # Start reading at 0.5
+        await c.post(
+            "/sync/v1/progress", json=_progress_body("r", 0.5, False, now), headers=headers,
+        )
+        # Then mark abandoned (advance client_updated_at to win LWW).
+        later = (datetime.now(UTC) + timedelta(seconds=1)).isoformat()
+        await c.post(
+            "/sync/v1/progress", json=_abandon_body("r", 0.5, later), headers=headers,
+        )
+        r = await c.get("/library/v1/stats", headers=headers)
+    data = r.json()
+    assert data["abandoned_count"] == 1
+    assert data["in_progress_count"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/integration/test_library_stats.py
+++ b/server/tests/integration/test_library_stats.py
@@ -295,24 +295,37 @@ async def test_counts_are_disjoint(app_under_test, unique_user):
         #  ab5: abandoned at 0.5
         #  ip:  in-progress (percent=0.3, neither terminal flag)
         #  un:  untouched (no progress row at all)
-        for ch, md in [("fin", "md-fin"), ("ab0", "md-ab0"), ("ab5", "md-ab5"),
-                       ("ip", "md-ip"), ("un", "md-un")]:
+        for ch, md in [
+            ("fin", "md-fin"),
+            ("ab0", "md-ab0"),
+            ("ab5", "md-ab5"),
+            ("ip", "md-ip"),
+            ("un", "md-un"),
+        ]:
             await c.put(
                 "/library/v1/items",
                 json=_put_body(content_hash=ch, metadata_id=md),
                 headers=headers,
             )
         await c.post(
-            "/sync/v1/progress", json=_progress_body("fin", 1.0, True, now), headers=headers,
+            "/sync/v1/progress",
+            json=_progress_body("fin", 1.0, True, now),
+            headers=headers,
         )
         await c.post(
-            "/sync/v1/progress", json=_abandon_body("ab0", 0.0, now), headers=headers,
+            "/sync/v1/progress",
+            json=_abandon_body("ab0", 0.0, now),
+            headers=headers,
         )
         await c.post(
-            "/sync/v1/progress", json=_abandon_body("ab5", 0.5, now), headers=headers,
+            "/sync/v1/progress",
+            json=_abandon_body("ab5", 0.5, now),
+            headers=headers,
         )
         await c.post(
-            "/sync/v1/progress", json=_progress_body("ip", 0.3, False, now), headers=headers,
+            "/sync/v1/progress",
+            json=_progress_body("ip", 0.3, False, now),
+            headers=headers,
         )
         r = await c.get("/library/v1/stats", headers=headers)
     data = r.json()
@@ -320,9 +333,9 @@ async def test_counts_are_disjoint(app_under_test, unique_user):
     assert data["finished_count"] == 1
     assert data["abandoned_count"] == 2
     assert data["in_progress_count"] == 1
-    assert (
-        data["finished_count"] + data["abandoned_count"] + data["in_progress_count"]
-    ) <= data["total_books"]
+    assert (data["finished_count"] + data["abandoned_count"] + data["in_progress_count"]) <= data[
+        "total_books"
+    ]
 
 
 async def test_abandoned_count_excludes_tombstoned_books(app_under_test, unique_user):
@@ -336,7 +349,9 @@ async def test_abandoned_count_excludes_tombstoned_books(app_under_test, unique_
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         await c.put("/library/v1/items", json=_put_body(content_hash="x"), headers=headers)
         await c.post(
-            "/sync/v1/progress", json=_abandon_body("x", 0.3, now), headers=headers,
+            "/sync/v1/progress",
+            json=_abandon_body("x", 0.3, now),
+            headers=headers,
         )
         # Tombstone the library item — the progress row survives.
         await c.request(
@@ -388,12 +403,16 @@ async def test_in_progress_excludes_abandoned_rows(app_under_test, unique_user):
         await c.put("/library/v1/items", json=_put_body(content_hash="r"), headers=headers)
         # Start reading at 0.5
         await c.post(
-            "/sync/v1/progress", json=_progress_body("r", 0.5, False, now), headers=headers,
+            "/sync/v1/progress",
+            json=_progress_body("r", 0.5, False, now),
+            headers=headers,
         )
         # Then mark abandoned (advance client_updated_at to win LWW).
         later = (datetime.now(UTC) + timedelta(seconds=1)).isoformat()
         await c.post(
-            "/sync/v1/progress", json=_abandon_body("r", 0.5, later), headers=headers,
+            "/sync/v1/progress",
+            json=_abandon_body("r", 0.5, later),
+            headers=headers,
         )
         r = await c.get("/library/v1/stats", headers=headers)
     data = r.json()

--- a/server/tests/unit/test_library_schemas.py
+++ b/server/tests/unit/test_library_schemas.py
@@ -15,6 +15,7 @@ def test_library_stats_response_shape_and_defaults() -> None:
         total_books=3,
         finished_count=1,
         in_progress_count=1,
+        abandoned_count=1,
         top_authors=[TopAuthor(name="Asimov", count=2)],
         top_themes=[TopTheme(theme="noir", count=1, note="v3+ insights only")],
         themes_caveat=LIBRARY_STATS_THEMES_CAVEAT,
@@ -23,6 +24,7 @@ def test_library_stats_response_shape_and_defaults() -> None:
     assert dumped["total_books"] == 3
     assert dumped["finished_count"] == 1
     assert dumped["in_progress_count"] == 1
+    assert dumped["abandoned_count"] == 1
     assert dumped["top_authors"] == [{"name": "Asimov", "count": 2}]
     assert dumped["top_themes"] == [{"theme": "noir", "count": 1, "note": "v3+ insights only"}]
     assert "may be missing" in dumped["themes_caveat"]
@@ -33,9 +35,28 @@ def test_library_stats_response_empty_lists_allowed() -> None:
         total_books=0,
         finished_count=0,
         in_progress_count=0,
+        abandoned_count=0,
         top_authors=[],
         top_themes=[],
         themes_caveat="x",
     )
     assert resp.top_authors == []
     assert resp.top_themes == []
+
+
+def test_library_stats_response_round_trip_preserves_abandoned_count() -> None:
+    """PR-9: explicit round-trip on `abandoned_count` so a regression where
+    it disappears from the wire breaks loudly.
+    """
+    resp = LibraryStatsResponse(
+        total_books=10,
+        finished_count=3,
+        in_progress_count=2,
+        abandoned_count=7,
+        top_authors=[],
+        top_themes=[],
+        themes_caveat=LIBRARY_STATS_THEMES_CAVEAT,
+    )
+    raw = resp.model_dump_json()
+    rebuilt = LibraryStatsResponse.model_validate_json(raw)
+    assert rebuilt.abandoned_count == 7


### PR DESCRIPTION
## Summary

PR-9 from the Phase-2 Bundle 4 plan. Adds `abandoned_count` to the
library stats endpoint, tightens `in_progress_count` to exclude
abandoned rows, and gives the Android `LibraryStatsViewModel` a
stale-while-revalidate in-memory cache. Also absorbs the small KDoc
cleanup on `CatalogDetailViewModel` from cancelled PR-7 (Lock #22).

- Server: `GET /library/v1/stats` now returns `abandoned_count`. The
  three count buckets (`finished_count`, `in_progress_count`,
  `abandoned_count`) are mutually disjoint — a book marked abandoned
  no longer counts as "Reading", which matches the release-note
  framing "Reading excludes Abandoned".
- Android: `LibraryStatsResponse.abandonedCount` defaults to `0` for
  back-compat with pre-PR-9 servers; combined with
  `ignoreUnknownKeys = true`, the response shape is forward- and
  backward-compatible and the endpoint is **not** versioned.
- Android `LibraryStatsScreen`: 2×2 grid of count tiles
  (Books / Finished / Reading / Abandoned).
- Android `LibraryStatsViewModel`: cached payload renders
  immediately on re-entry (no spinner flash); a background refetch
  always runs. Refresh failures with cached data are silent —
  cached `Ready` stays visible.
- Stats endpoint does NOT carry a fingerprint (Lock #12); the AI
  profile envelope owns the staleness contract.

## Merge ordering

This branch is cut from `quire/reader-profile` (PR #34, Bundle 3)
because PR-9 depends on `progress.abandoned_at` and the
`finished_at IS NULL OR abandoned_at IS NULL` check constraint
that ship in that bundle. The diff against `main` here includes
the Bundle 3 commits as a result — **PR-9 must merge AFTER
#34**. Once #34 lands I'll rebase this branch onto `main` and the
diff will collapse to the PR-9-only changes.

## Test plan

- [x] Server: `pytest tests/integration/test_library_stats.py tests/unit/test_library_schemas.py -v` → 23/23 pass (5 new abandoned-count cases + 1 schema round-trip)
- [x] Android: `scripts/dgradle :app:compileDebugKotlin :app:testDebugUnitTest :data:library:testDebugUnitTest` → BUILD SUCCESSFUL (118 unit tests, incl. 8 ViewModel cases + 4 DTO compat cases)
- [ ] Manual smoke on device: seed finished + in-progress + abandoned book, open Library → Stats, verify 2×2 tiles render correct counts; verify re-entry shows cached data without spinner flash; verify airplane-mode toggle keeps cached payload then silently refreshes.