### PR TITLE
docs: refresh README + sync-api after Phase-2 ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,23 @@ OpenLibrary to ground the generated insights with citations. The
 generated insight is cached server-side per book and reused across all
 of that user's devices and other opted-in users on the same instance.
 
-Surfaces in the app today: book-detail cards (summary, author, series,
-themes, content advisory, sources); a catalog detail screen that
-previews the same insight cards before download via an `info` icon on
-each catalog tile; and a library Stats screen (totals, top authors,
-top themes) backed by `GET /library/v1/stats`.
+Surfaces in the app today:
+
+- **Book-detail cards** — summary, author, series, themes, craft notes,
+  comparative anchors, discussion prompts, content advisory, sources.
+- **Catalog detail screen** — previews the same insight cards before
+  download via an `info` icon on each catalog tile. Once the EPUB is
+  downloaded the cached catalog insight is promoted onto the canonical
+  identity so the book-detail screen shows it immediately.
+- **Library Stats** — totals, finished / in-progress / abandoned counts,
+  top authors, top themes, backed by `GET /library/v1/stats`.
+- **Library Insights** — a per-user reader profile (narrative, in-library
+  recommendations, OpenLibrary discovery recommendations, AI-suggested
+  reads), refreshed on demand from the screen. Backed by
+  `GET /ai/v1/profile` + `POST /ai/v1/profile/refresh`. A "Delete
+  profile" action in Settings wipes the cached row.
+- **Abandoned book UX** — books you've marked abandoned drop out of
+  Library by default; a "Show abandoned" toggle reveals them.
 
 For configuration details see [`server/README.md`](server/README.md).
 
@@ -118,7 +130,11 @@ full stack with calibre-web + quire-server + TLS behind one base URL).
 
 **Shipped:** OPDS catalog browsing and search, EPUB rendering with
 Readium, local reading progress, progress sync (server + Android
-client), single-credential auth via calibre-web Basic.
+client), single-credential auth via calibre-web Basic, per-user library
+mirror with stats (`GET /library/v1/stats`), optional AI book insights
+(schema v4: themes, craft notes, comparative anchors, discussion
+prompts), optional AI reader profile with in-library and OpenLibrary
+discovery recommendations, abandoned-book status.
 
 **Planned:** bookmarks sync, calibre-web read-only consumer plugin.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -405,10 +405,12 @@ accidental version emission.
 
 `GET /library/v1/stats` returns a per-user roll-up of the
 `library_items` mirror joined with `book_insights` / `book_themes`:
-`total_books`, `finished_count`, `in_progress_count`, `top_authors`,
-`top_themes`, and a constant server-emitted `themes_caveat` string the
-client renders verbatim. There is no `abandoned_count` until an
-explicit abandoned status exists. Mode-gated on
+`total_books`, `finished_count`, `in_progress_count`, `abandoned_count`,
+`top_authors`, `top_themes`, and a constant server-emitted
+`themes_caveat` string the client renders verbatim. `abandoned_count`
+counts library items whose `progress.abandoned_at IS NOT NULL`; the
+three count buckets are mutually disjoint (in-progress excludes books
+marked abandoned even if their percent > 0). Mode-gated on
 `QUIRE_SERVER_PROGRESS_ENABLED` (lives next to the existing
 `/library/v1/items` router).
 
@@ -473,7 +475,49 @@ for the reference implementation.
 - **Library Stats screen (PR9).** New `LibraryStatsScreen` +
   `LibraryStatsViewModel` reached from the library menu's "Stats"
   entry. Lives in the new `:data:library` Android module (the
-  `library/v1` HTTP client), which today exposes only `getStats`.
+  `library/v1` HTTP client), which today exposes only `getStats`. The
+  stats response includes `abandoned_count`; the view-model holds a
+  factory-scoped SWR cache with a generation guard so quick re-entries
+  return the cached tile instantly without losing the in-flight refresh.
+
+### Reader Profile (Bundle 3)
+
+Per-user generated profile that summarizes a reader's habits and
+recommends further reads. Server-side: a new `reader_profiles` table
+keyed on `(tenant_id, subject)` with `payload JSONB`, mirrored
+top-level `schema_version`, and a 16-hex-char `input_fingerprint` over
+the underlying `ReaderStats` snapshot (Lock #12). The cache namespace
+is separate from `book_insights` — a distinct
+`READER_PROFILE_PROMPT_VERSION` constant governs its own invalidation
+ladder. `progress.abandoned_at` (migration `progress_002`) feeds the
+abandoned bucket in `ReaderStats` and the Library Stats roll-up.
+
+Three endpoints expose it: `GET /ai/v1/profile` (cache-only read; 404
+if none), `POST /ai/v1/profile/refresh` (budgeted regenerate; daily
+limit `QUIRE_SERVER_AI_PROFILE_REFRESH_DAILY_LIMIT`, default 3;
+process-local singleflight per `(tenant_id, subject)`), and
+`DELETE /ai/v1/profile` (idempotent erase). The refresh path computes
+`ReaderStats` from progress + library data, walks OpenLibrary author
+bibliographies for discovery candidates (capped at 5 authors per call,
+positive TTL 30d / negative 24h), and asks the model for a narrative
+plus rationales. Below a configurable book-count floor it
+short-circuits to a stats-only payload at weight 0.
+
+Android surfaces it as a Library Insights screen
+(`LibraryInsightsScreen` + `LibraryInsightsViewModel`) reached from the
+library menu. The view-model pulls `/ai/v1/profile` and
+`/library/v1/stats` concurrently on entry, falls through to
+`POST /ai/v1/profile/refresh` on `no_profile`, and uses
+`/ai/v1/config.progress_supported` (default `true` for older deploys)
+to hide the screen entirely on AI-only deploys where the refresh path
+would 503. Settings adds a "Delete profile" button bound to the
+`DELETE` endpoint. The library list adds a "Show abandoned" toggle
+backed by `LibraryPreferencesStore`; rows whose progress is abandoned
+drop out by default.
+
+Room schema bumps from 7 to 8 (`MIGRATION_7_8`) to add
+`progress.abandonedAt` plus a new `bookInsights` table (Bundle 2)
+caching inspect-insight reads so the audit screen renders offline.
 
 #### Catalog identity vs post-download EPUB identity
 
@@ -492,12 +536,13 @@ the EPUB body produces a real `metadata_id` (from the OPF
 identifier space than the synthetic `opds-href:<sha>`. The cache row
 that served the catalog preview and the cache row that serves the
 book-detail screen after download can therefore be two distinct
-rows for what is materially the same book. A future
-`POST /ai/v1/insights/promote` endpoint could unify them by
-upgrading the catalog row's canonical to the post-download
-identifiers and reconciling via the alias table. Not built today —
-double-spend on cold catalogs is rare enough that paying for the
-second generation when the user actually downloads is acceptable.
+rows for what is materially the same book. `POST /ai/v1/insights/promote`
+(Bundle 2, PR-ζ) bridges them: when the Android catalog flow finishes
+downloading an EPUB it calls promote with `from=<catalog identity>` and
+`to=<downloaded canonical>`, so the cached catalog insight is copied
+onto the post-download row without firing the model. Lineage flows
+through `previous_insight_ids` and `insight_identity_aliases` (anchor
+source `promoted_on_download`).
 
 ## Decision log
 

--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -74,9 +74,20 @@ the implementation.
 | `DELETE` | `/library/v1/items` | yes | Soft-delete one library item by `content_hash` |
 | `GET` | `/library/v1/stats` | yes | Per-user library roll-up: totals + top authors + top themes |
 | `GET` | `/ai/v1/health` | none | AI provider + retrieval reachability snapshot (mode-gated on `QUIRE_SERVER_AI_ENABLED`) |
+| `GET` | `/ai/v1/config` | yes | User-visible AI configuration |
+| `GET`/`PUT` | `/ai/v1/preferences` | yes | Per-user opt-in + tone/language |
+| `POST` | `/ai/v1/insights/lookup` | yes | Book insight: cache hit or synchronous generation |
+| `POST` | `/ai/v1/insights/get` | yes | Cache-only read; 404 on miss |
+| `POST` | `/ai/v1/insights/regenerate` | yes | Force a fresh insight (audit-only retention of previous row) |
+| `POST` | `/ai/v1/insights/invalidate` | yes | Drop the cached insight for the caller's current cache key |
+| `POST` | `/ai/v1/insights/promote` | yes | Copy a catalog-side insight onto the downloaded canonical identity |
+| `GET` | `/ai/v1/insights/sync` | yes | Bulk pull of the caller's owned-book insights with tuple cursor |
+| `GET` | `/ai/v1/profile` | yes | Cached reader profile (narrative + recommendations); 404 if never refreshed |
+| `POST` | `/ai/v1/profile/refresh` | yes | Recompute the reader profile (budgeted) |
+| `DELETE` | `/ai/v1/profile` | yes | Wipe the caller's reader profile row |
 
-Currently shipped: health probes and progress. The rest are designed; see
-phasing in the project README.
+`/sync/v1/documents/alias` and `/sync/v1/bookmarks` are designed but not
+shipped. Everything else above is on `main`.
 
 ## Document references
 
@@ -689,6 +700,51 @@ Audit: emits a structured stdout line `event=ai.promote ...` with the source
 and copy ids, latency, and outcome. PR-ζ does NOT write an
 `ai_generation_log` row (Lock #11 amendment); PR-β extends the audit-log
 schema and the promote path begins persisting at that point.
+
+### `GET /ai/v1/profile`
+
+Cache-only read of the caller's `reader_profiles` row. **Weight = 0** — no
+LLM call, no budget charge. Requires opt-in.
+
+```http
+GET /ai/v1/profile
+Authorization: Basic ...
+```
+
+Response: the same `ReaderProfilePayload` documented for
+`POST /ai/v1/profile/refresh` (stats, narrative, in-library /
+discovery / ai-suggested recommendations, `input_fingerprint`).
+
+| Status | Body | Meaning |
+|--------|------|---------|
+| `200` | `ReaderProfilePayload` | Cached row returned verbatim. |
+| `404` | `{"detail":"no_profile"}` | No row yet — client should call refresh. |
+| `404` | `{"detail":"ai_disabled"}` | AI disabled or unconfigured on this deploy. |
+| `409` | `{"detail":"ai_not_opted_in"}` | Caller has not opted in. |
+| `503` | `{"error":"profile_requires_progress_data"}` | `PROGRESS_ENABLED=false`. |
+
+The Android Library Insights screen calls this on first paint and falls
+through to `POST /ai/v1/profile/refresh` on a `no_profile` 404.
+
+### `DELETE /ai/v1/profile`
+
+Erase the caller's `reader_profiles` row. Idempotent: returns `204` whether
+or not a row existed. **Weight = 0**. Wired to the Settings "Delete
+profile" action; recommended after toggling opt-out so a stale cached
+profile cannot resurface if the user opts back in later.
+
+```http
+DELETE /ai/v1/profile
+Authorization: Basic ...
+```
+
+| Status | Meaning |
+|--------|---------|
+| `204` | Row deleted (or no-op if none existed). |
+| `404` | `{"detail":"ai_disabled"}` on AI-disabled deploys. |
+
+This endpoint does not require opt-in — a user who has opted out can
+still purge a previously-generated row.
 
 ### `GET /ai/v1/insights/sync`
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -23,6 +23,10 @@ https://github.com/vitofico/quire
 Optional AI features (off by default): when your Quire Server administrator
 configures an AI endpoint (such as a self-hosted Ollama or a third-party
 provider) and you opt in from Settings, Quire shows generated book
-insights — author, summary, series, themes — grounded with citations
-from Wikipedia and OpenLibrary. No AI request leaves your network until
-you explicitly opt in.
+insights — author, summary, series, themes, craft notes, comparative
+anchors, and book-club style discussion prompts — grounded with
+citations from Wikipedia and OpenLibrary. A separate Library Insights
+screen builds a personal reader profile from your finished books and
+suggests further reads (both from your own library and via OpenLibrary
+discovery). No AI request leaves your network until you explicitly opt
+in, and a single tap in Settings deletes the cached profile.


### PR DESCRIPTION
## Summary

Phase 2 shipped a meaningful chunk of new surface (Reader Profile, Library Insights, abandoned-book status, catalog-download promote, book insight depth v4, server rename). The user-facing docs trailed the code. This PR is the last in the Phase-2 batch and brings them back in line.

**Merge order:** this PR should land **last** in the Phase-2 batch — after #34, #35, and #36. PRs #34 and #36 both add the \`POST /ai/v1/profile/refresh\` subsection and the \`abandoned_count\` / \`progress_supported\` field deltas to \`docs/sync-api.md\`; this PR intentionally leaves those alone so it doesn't conflict. The pieces this PR adds are net-new and complementary.

## Files touched

- \`README.md\` — feature list + roadmap mention Reader Profile, Library Insights, abandoned UX, insight depth v4 fields, and catalog promote; stats blurb references \`abandoned_count\`.
- \`docs/sync-api.md\` — endpoints table fills in the AI rows that were never added (lookup / get / regenerate / invalidate / promote / insights/sync / profile + profile/refresh + profile delete); new \`GET /ai/v1/profile\` and \`DELETE /ai/v1/profile\` subsections sit next to the refresh doc landing in #34/#36.
- \`docs/architecture.md\` — drops the stale "no \`abandoned_count\`" line and the "future promote endpoint" caveat; new "Reader Profile (Bundle 3)" subsection covers \`reader_profiles\`, the three endpoints, the Android screen, Settings delete, "Show abandoned" toggle, and Room 7→8 migration.
- \`fastlane/metadata/android/en-US/full_description.txt\` — adds Library Insights / per-user reader profile under the optional-AI paragraph.

## What's deliberately not in scope

- \`server/README.md\` is handled by #35 (Caddy / deploy modes).
- \`docs/release.md\` rename note is accurate as-is for the dual-tag cycle.
- No Phase-3 speculation — only documents what's shipped on main once #32, #33, #34, #35, #36 are in.

## Test plan

- [ ] All internal links resolve (\`docs/architecture.md\`, \`docs/development.md\`, \`docs/sync-api.md\`, \`server/README.md\`) — verified via grep.
- [ ] Existing \`architecture.md\` anchors referenced by \`sync-api.md\` are untouched.
- [ ] Markdown renders cleanly on GitHub (visual check post-merge).