### PR TITLE
ci(android): rebase + retry release-bump push on race

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -81,7 +81,21 @@ jobs:
             git add gradle.properties
             git commit -m ":bookmark: chore: release v$NEW_NAME"
             git tag "v$NEW_NAME"
-            git push origin "HEAD:$GITHUB_REF" "v$NEW_NAME"
+            # A docs-only / server-only merge can land on main between our
+            # checkout and our push, leaving HEAD non-fast-forward. Rebase
+            # onto the latest main and retry; the bump commit only touches
+            # gradle.properties so conflicts here are not expected.
+            attempts=0
+            until git push origin "HEAD:$GITHUB_REF" "v$NEW_NAME"; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 5 ]; then
+                echo "release bump push failed after $attempts attempts" >&2
+                exit 1
+              fi
+              echo "release bump push rejected; rebasing and retrying ($attempts)…"
+              git fetch origin "$GITHUB_REF"
+              git rebase "origin/${GITHUB_REF#refs/heads/}"
+            done
 
             VERSION="$NEW_NAME"
           else


### PR DESCRIPTION
## Summary

During the Phase-2 batch merge of PRs #34, #35, #36, #37, the android-ci release-bump push lost two commits (and left dangling tags `v2026.05.21.126`, `v2026.05.21.129`) because of a race:

- PR #34 (code) triggers android-ci → it checks out main, bumps `gradle.properties`, commits + tags
- Meanwhile PR #35 (docs-only) merges to main — its push doesn't trigger android-ci (path filter), so it doesn't queue behind the existing run via the `concurrency.group`
- PR #34's run tries to push and gets a non-fast-forward rejection
- Result: tag pushed (orphan), commit lost, main stays on the old version

This PR wraps the bump-push in a small rebase-and-retry loop. The bump commit only touches `gradle.properties`, so conflicts at rebase time are not a realistic concern.

The dangling tags from the Phase-2 batch have already been deleted manually.

## Test plan

- [ ] Merge this PR — its own android-ci run will be the first to exercise the new push loop and will cut a clean release covering the entire Phase-2 batch.