### PR TITLE
:white_check_mark: test(android): wire Compose UI test infra + example screen tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,4 +115,19 @@ dependencies {
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.room.testing)
+
+    // Compose UI test harness — runs screen-level tests under Robolectric so
+    // `scripts/dgradle :app:testDebugUnitTest` can exercise composables
+    // without an emulator. `ui-test-manifest` ships the ComponentActivity
+    // stub the harness needs to host content; it has to be on the unit-test
+    // classpath alongside `ui-test-junit4`.
+    //
+    // Tests that depend on these live in `src/testDebug/` so they only build
+    // and run against the debug variant — keeps `:app:testReleaseUnitTest`
+    // (which CI runs alongside the debug one) from trying to compile against
+    // `debugImplementation`-scoped deps and failing.
+    testImplementation(platform(libs.compose.bom))
+    testImplementation(libs.compose.ui.test)
+    testImplementation(libs.compose.ui.test.junit4)
+    debugImplementation(libs.compose.ui.test.manifest)
 }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryInsightsScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryInsightsScreen.kt
@@ -59,7 +59,33 @@ fun LibraryInsightsScreen(
 ) {
     LaunchedEffect(Unit) { viewModel.reload() }
     val state by viewModel.state.collectAsState()
+    LibraryInsightsScreenContent(
+        state = state,
+        onBack = onBack,
+        onOpenBook = onOpenBook,
+        onOpenWeb = onOpenWeb,
+        onOpenSettings = onOpenSettings,
+        onRefresh = { viewModel.refresh() },
+    )
+}
 
+/**
+ * Stateless overload — drives the screen straight off a [LibraryInsightsUiState]
+ * value so unit/UI tests can render any state without constructing a real
+ * [LibraryInsightsViewModel] (whose deps include AiRepository, LibraryClient,
+ * ProgressDao, …). Production wiring goes through the VM-flavored
+ * `LibraryInsightsScreen` above.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LibraryInsightsScreenContent(
+    state: LibraryInsightsUiState,
+    onBack: () -> Unit,
+    onOpenBook: (DocumentIdentity) -> Unit,
+    onOpenWeb: (String) -> Unit,
+    onOpenSettings: () -> Unit,
+    onRefresh: () -> Unit,
+) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -76,19 +102,19 @@ fun LibraryInsightsScreen(
             is LibraryInsightsUiState.Disabled ->
                 DisabledScreen(padding, s, onOpenSettings = onOpenSettings)
             is LibraryInsightsUiState.Empty ->
-                EmptyScreen(padding, s, onGenerate = { viewModel.refresh() })
+                EmptyScreen(padding, s, onGenerate = onRefresh)
             is LibraryInsightsUiState.Loading ->
                 LoadingScreen(padding, s)
             is LibraryInsightsUiState.Loaded ->
                 LoadedScreen(
                     padding = padding,
                     loaded = s,
-                    onRefresh = { viewModel.refresh() },
+                    onRefresh = onRefresh,
                     onOpenBook = onOpenBook,
                     onOpenWeb = onOpenWeb,
                 )
             is LibraryInsightsUiState.Error ->
-                ErrorScreen(padding, s, onRetry = { viewModel.refresh() })
+                ErrorScreen(padding, s, onRetry = onRefresh)
         }
     }
 }

--- a/app/src/testDebug/java/io/theficos/ereader/ui/library/LibraryScreensComposeTest.kt
+++ b/app/src/testDebug/java/io/theficos/ereader/ui/library/LibraryScreensComposeTest.kt
@@ -1,0 +1,86 @@
+package io.theficos.ereader.ui.library
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import io.theficos.ereader.data.library.LibraryStatsResponse
+import io.theficos.ereader.data.library.TopAuthor
+import io.theficos.ereader.data.library.TopTheme
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Smoke tests for the Compose UI test harness. The point is to prove that
+ * `scripts/dgradle :app:testDebugUnitTest` can render Material 3 composables
+ * under Robolectric and query the resulting semantics tree — not to lock in
+ * every pixel of these screens.
+ *
+ * Robolectric is required even with `createComposeRule()` because Compose's
+ * test rule indirectly touches Android framework classes (Looper,
+ * Choreographer, etc.) that a plain JVM JUnit run can't satisfy. SDK 33
+ * matches the rest of the app's Robolectric-running tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class LibraryScreensComposeTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun libraryInsights_disabled_aiOff_rendersOptInCopyAndSettingsCta() {
+        composeRule.setContent {
+            LibraryInsightsScreenContent(
+                state = LibraryInsightsUiState.Disabled.AiOff,
+                onBack = {},
+                onOpenBook = {},
+                onOpenWeb = {},
+                onOpenSettings = {},
+                onRefresh = {},
+            )
+        }
+
+        composeRule
+            .onNodeWithText(LibraryInsightsUiState.Disabled.AiOff.message)
+            .assertIsDisplayed()
+        composeRule.onNodeWithText("Open AI settings").assertIsDisplayed()
+        composeRule.onNodeWithText("Library insights").assertIsDisplayed()
+    }
+
+    @Test
+    fun libraryStats_ready_rendersAbandonedTileWithCount() {
+        val stats = LibraryStatsResponse(
+            totalBooks = 10,
+            finishedCount = 4,
+            inProgressCount = 2,
+            abandonedCount = 3,
+            topAuthors = listOf(TopAuthor("Ursula K. Le Guin", 4)),
+            topThemes = listOf(TopTheme("science_fiction", 5, "v3+ insights only")),
+            themesCaveat = "Themes are AI-derived",
+        )
+
+        // Block the background fetch on a never-completed deferred so the VM
+        // keeps the `Ready(cached)` we seeded via the cache — no flakiness
+        // from a parallel fetch() racing with the assertions.
+        val never = CompletableDeferred<LibraryStatsResponse>()
+        val cache = LibraryStatsCache().apply { lastReady = stats }
+        val vm = LibraryStatsViewModel(
+            fetch = { never.await() },
+            cache = cache,
+        )
+
+        composeRule.setContent {
+            LibraryStatsScreen(viewModel = vm, onBack = {})
+        }
+
+        composeRule.onNodeWithText("Library stats").assertIsDisplayed()
+        composeRule.onNodeWithText("Abandoned").assertIsDisplayed()
+        // Abandoned count (3) + top-author count (4) both render; spot-check both.
+        composeRule.onNodeWithText("3").assertIsDisplayed()
+        composeRule.onNodeWithText("Ursula K. Le Guin").assertIsDisplayed()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,9 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+compose-ui-test = { module = "androidx.compose.ui:ui-test" }
+compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
## Summary
- Adds `androidx.compose.ui:ui-test{,-junit4,-manifest}` to `:app`'s test classpath so `scripts/dgradle :app:testDebugUnitTest` can render Compose screens under Robolectric — no emulator needed. PR-γ (Insights) and PR-9 (Stats) both left screen-level tests as nice-to-have because this harness wasn't configured.
- Refactors `LibraryInsightsScreen` to expose an internal stateless `LibraryInsightsScreenContent` overload so tests can drive any `LibraryInsightsUiState` without constructing the VM (which pulls in `AiRepository`, `LibraryClient`, `ProgressDao`, …). Production wiring is unchanged.
- Adds `LibraryScreensComposeTest` with two example tests proving the harness works:
  - `libraryInsights_disabled_aiOff_…` — renders the AI-off opt-in copy and "Open AI settings" CTA from `Disabled.AiOff`.
  - `libraryStats_ready_rendersAbandonedTileWithCount` — renders `LibraryStatsScreen` via a fake VM seeded with `LibraryStatsResponse(abandonedCount = 3, …)` and asserts the Abandoned tile + count are displayed.

## Notes
- Reuses the existing `compose-bom` (2024.09.02) — no new version pin.
- `ui-test-manifest` goes on `debugImplementation` because the harness needs its `ComponentActivity` stub on the debug variant classpath.
- Used SDK 33 in `@Config` to match the rest of the app's Robolectric tests.
- Tests took ~16s for the first render under Robolectric (Compose materializes the entire tree); subsequent assertions are fast.

## Test plan
- [x] `scripts/dgradle :app:testDebugUnitTest --tests 'io.theficos.ereader.ui.library.LibraryScreensComposeTest'` → 2 tests, 0 failures.
- [ ] CI `android-ci` green on this branch.