### PR TITLE
ci(android): reset+re-apply bump instead of rebase on push race

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -78,13 +78,23 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-            git add gradle.properties
-            git commit -m ":bookmark: chore: release v$NEW_NAME"
-            git tag "v$NEW_NAME"
-            # A docs-only / server-only merge can land on main between our
-            # checkout and our push, leaving HEAD non-fast-forward. Rebase
-            # onto the latest main and retry; the bump commit only touches
-            # gradle.properties so conflicts here are not expected.
+
+            # If another main push lands between our checkout and our push
+            # (or between two consecutive bump runs), HEAD is non-fast-forward.
+            # The naive `git rebase` strategy conflicts when both bump commits
+            # mutate the same `VERSION_NAME=` line — that's unrecoverable
+            # without manual resolution. Instead, on rejection we reset hard
+            # to the latest main, re-apply the bump on top, and retry. The
+            # bump value is derived from GITHUB_RUN_NUMBER which is stable
+            # across retries, so we always end up with a unique tag.
+            apply_bump() {
+              sed -i "s/^VERSION_NAME=.*/VERSION_NAME=$NEW_NAME/" gradle.properties
+              sed -i "s/^VERSION_CODE=.*/VERSION_CODE=$NEW_CODE/" gradle.properties
+              git add gradle.properties
+              git commit -m ":bookmark: chore: release v$NEW_NAME"
+              git tag -f "v$NEW_NAME"
+            }
+            apply_bump
             attempts=0
             until git push origin "HEAD:$GITHUB_REF" "v$NEW_NAME"; do
               attempts=$((attempts + 1))
@@ -92,9 +102,11 @@ jobs:
                 echo "release bump push failed after $attempts attempts" >&2
                 exit 1
               fi
-              echo "release bump push rejected; rebasing and retrying ($attempts)…"
+              echo "release bump push rejected; resetting + re-applying bump ($attempts)…"
               git fetch origin "$GITHUB_REF"
-              git rebase "origin/${GITHUB_REF#refs/heads/}"
+              git tag -d "v$NEW_NAME" 2>/dev/null || true
+              git reset --hard "origin/${GITHUB_REF#refs/heads/}"
+              apply_bump
             done
 
             VERSION="$NEW_NAME"


### PR DESCRIPTION
## Summary

PR #38's rebase-retry fix handled simple non-fast-forward push races, but it falls apart when the intervening commit on `main` is **also** a release-bump commit. Both mutate the same `VERSION_NAME=` line in `gradle.properties` → rebase hits an unrecoverable conflict.

Hit this twice today (PRs #39 + #40 in rapid succession). PR #39's `.141` bump landed; PR #40's `.142` bump never merged its commit, only an orphan tag (now cleaned up).

**Fix:** on push rejection, hard-reset to the latest `main` and re-apply the bump on top. `NEW_NAME` is derived from `GITHUB_RUN_NUMBER` which is stable across retries, so the resulting tag is unique either way.

## Known limitation (not addressed in this PR)

If the bump commit's history includes changes to `.github/workflows/*`, the **tag push** still gets rejected because `GITHUB_TOKEN` lacks `workflows: write`. A future PR could either:
- Add a `RELEASE_TOKEN` PAT secret and use it for the bump push, or
- Skip the bump entirely on workflow-touching commits.

This PR itself touches the workflow file, so its own tag push may need manual creation after merge. Operator note: `git tag v<NEW> <release-commit> && git push origin v<NEW>` from a normal user account bypasses the GITHUB_TOKEN check.

## Test plan

- [ ] Land this. Subsequent non-workflow PRs should produce clean releases.
- [ ] If this PR itself fails its tag push, manually create the tag from the orphan release commit.