### PR TITLE
feat(catalog): prefer library identity for already-owned books (insight unification)

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -3,6 +3,7 @@ package io.theficos.ereader.di
 import android.content.Context
 import io.theficos.ereader.auth.CalibreCredentialStore
 import io.theficos.ereader.core.model.Document
+import io.theficos.ereader.core.model.DocumentIdentity
 import io.theficos.ereader.data.ai.AiClient
 import io.theficos.ereader.data.ai.AiRepository
 import io.theficos.ereader.data.ai.CatalogInsightStash
@@ -199,6 +200,15 @@ class AppContainer(context: Context) {
             registry = catalogDetailRegistry,
             insightStash = catalogInsightStash,
             subjectProvider = ::currentSubject,
+            // When the user opens catalog detail for a book they already own,
+            // resolve to the library-side identity so the insight cache hits
+            // the same `book_insights` row the reader/library detail uses
+            // (no PR-ζ promote needed — promote only fires on fresh download).
+            localIdentityResolver = { href ->
+                documentRepository.findByDownloadUrl(href)?.identity?.takeIf { id ->
+                    id.metadataId != null || id.contentHash != null
+                }
+            },
         )
 
     private suspend fun readOpfBytes(doc: Document): ByteArray? = withContext(Dispatchers.IO) {
@@ -262,6 +272,9 @@ class CatalogDetailViewModelFactory(
     private val registry: CatalogDetailRegistry,
     private val insightStash: CatalogInsightStash? = null,
     private val subjectProvider: () -> String? = { null },
+    /** Maps an OPDS `epubDownloadHref` to the LIBRARY identity when the
+     *  user already owns the book, else returns null. */
+    private val localIdentityResolver: suspend (String) -> DocumentIdentity? = { null },
 ) {
     /**
      * Look up the [OpdsPublication] by nav key and build the viewmodel.
@@ -276,6 +289,7 @@ class CatalogDetailViewModelFactory(
             ai = ai,
             insightStash = insightStash,
             subjectProvider = subjectProvider,
+            localIdentityResolver = localIdentityResolver,
         )
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModel.kt
@@ -58,6 +58,16 @@ class CatalogDetailViewModel(
     private val ai: CatalogAiPort,
     private val insightStash: CatalogInsightStash? = null,
     private val subjectProvider: () -> String? = { null },
+    /**
+     * Optional resolver that maps the catalog row's `epubDownloadHref` to
+     * the LIBRARY-side identity when the user already owns the book. When
+     * non-null AND the user owns the book, we use that identity instead of
+     * the synthetic `opds-href:<sha>` one — keeps catalog and library views
+     * hitting the same `book_insights` row even when no download (and hence
+     * no PR-ζ promote) ever happened. Returns null when the book is not in
+     * the local library or when the local row has no canonical identity.
+     */
+    private val localIdentityResolver: suspend (String) -> DocumentIdentity? = { null },
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(CatalogDetailState(publication = publication))
@@ -79,7 +89,12 @@ class CatalogDetailViewModel(
             return
         }
 
-        val identity = buildIdentity(publication)
+        // Already-owned books: re-use the library identity so the catalog
+        // view hits the same `book_insights` row the reader/library detail
+        // sees. Falls through to the synthetic `opds-href:<sha>` for genuine
+        // pre-download catalog browsing.
+        val identity = localIdentityResolver(publication.epubDownloadHref)
+            ?: buildIdentity(publication)
         val bundle = MetadataBundle(title = publication.title, author = publication.author)
 
         val cached = runCatching { ai.getCachedInsight(identity) }.getOrNull()

--- a/app/src/test/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/catalogdetail/CatalogDetailViewModelTest.kt
@@ -293,6 +293,69 @@ class CatalogDetailViewModelTest {
         }
     }
 
+    @Test
+    fun `localIdentityResolver hit overrides the synthetic opds-href identity`() = runTest {
+        // Already-owned book: the library has a row at the EPUB's dc:identifier.
+        // The catalog view should look up under THAT identity so it hits the
+        // same `book_insights` row the reader/library detail sees.
+        val libraryIdentity = DocumentIdentity(
+            metadataId = "{7c97d6d5-3c82-41f7-91a6-1bc9fad3b0af}",
+            contentHash = "0ccc17241b8ca70b7c459c994b331678",
+        )
+        fakeAi.configFlow.value = AiConfig(configured = true)
+        fakeAi.prefsFlow.value = AiPreferences(aiEnabled = true, style = AiStyle())
+        fakeAi.cached = null
+        fakeAi.lookupResult = response
+
+        val vm = CatalogDetailViewModel(
+            publication = publication,
+            ai = fakeAi,
+            localIdentityResolver = { href ->
+                assertThat(href).isEqualTo(publication.epubDownloadHref)
+                libraryIdentity
+            },
+        )
+
+        vm.state.test {
+            var s = awaitItem()
+            while (s.insight !is InsightUiState.Loaded) s = awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        val sent = fakeAi.lastLookupIdentity!!
+        assertThat(sent.metadataId).isEqualTo(libraryIdentity.metadataId)
+        assertThat(sent.contentHash).isEqualTo(libraryIdentity.contentHash)
+        // Crucially, the catalog synthetic identity was NOT used.
+        assertThat(sent.metadataId).doesNotContain("opds-href:")
+    }
+
+    @Test
+    fun `localIdentityResolver miss falls through to the synthetic opds-href identity`() = runTest {
+        // Genuine pre-download browse: the user does not own the book locally.
+        // Resolver returns null. We expect the existing PR-ζ behavior — synthetic
+        // identity, all alias hints, recordStashIfPossible runs.
+        fakeAi.configFlow.value = AiConfig(configured = true)
+        fakeAi.prefsFlow.value = AiPreferences(aiEnabled = true, style = AiStyle())
+        fakeAi.cached = null
+        fakeAi.lookupResult = response
+
+        val vm = CatalogDetailViewModel(
+            publication = publication,
+            ai = fakeAi,
+            localIdentityResolver = { null },
+        )
+
+        vm.state.test {
+            var s = awaitItem()
+            while (s.insight !is InsightUiState.Loaded) s = awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        val sent = fakeAi.lastLookupIdentity!!
+        assertThat(sent.metadataId).startsWith("opds-href:")
+        assertThat(sent.opdsHref).isEqualTo(sent.metadataId)
+    }
+
     private class FakeAi : CatalogAiPort {
         override val configFlow = MutableStateFlow<AiConfig?>(null)
         override val prefsFlow = MutableStateFlow<AiPreferences?>(null)

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryUploaderTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryUploaderTest.kt
@@ -235,6 +235,7 @@ private class FakeDocumentDao : DocumentDao {
     override suspend fun update(doc: DocumentEntity): Unit = throw notImplemented("update")
     override suspend fun findByMetadataId(id: String): DocumentEntity? = throw notImplemented("findByMetadataId")
     override suspend fun findByContentHash(hash: String): DocumentEntity? = throw notImplemented("findByContentHash")
+    override suspend fun findByDownloadUrl(url: String): DocumentEntity? = throw notImplemented("findByDownloadUrl")
     override suspend fun findById(id: Long): DocumentEntity? = throw notImplemented("findById")
     override fun observeAll(): Flow<List<DocumentEntity>> = flowOf(emptyList())
     override fun observeSeriesContinuationCandidates(

--- a/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
@@ -38,6 +38,18 @@ class DocumentRepository(private val dao: DocumentDao) {
     suspend fun findById(id: Long): Document? = dao.findById(id)?.toDomain()
 
     /**
+     * Lookup an already-downloaded document by the OPDS `downloadUrl` we
+     * stamped on it at download time. Used by the catalog detail view to
+     * detect "user already owns this book" so the insight lookup can target
+     * the LIBRARY identity (EPUB `dc:identifier` + content hash) instead of
+     * the catalog's synthetic `opds-href:<sha>` identity — keeps both views
+     * hitting the same `book_insights` row without needing a server-side
+     * promote (which only fires on fresh downloads).
+     */
+    suspend fun findByDownloadUrl(url: String): Document? =
+        dao.findByDownloadUrl(url)?.toDomain()
+
+    /**
      * Removes the row (cascade-deletes any [progress] row via FK), then best-effort
      * deletes the local EPUB file. The DB delete is the source of truth — if the
      * file unlink fails (e.g. already missing), the document is still gone from

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentDao.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentDao.kt
@@ -21,6 +21,9 @@ interface DocumentDao {
     @Query("SELECT * FROM documents WHERE contentHash = :hash LIMIT 1")
     suspend fun findByContentHash(hash: String): DocumentEntity?
 
+    @Query("SELECT * FROM documents WHERE downloadUrl = :url LIMIT 1")
+    suspend fun findByDownloadUrl(url: String): DocumentEntity?
+
     @Query("SELECT * FROM documents WHERE id = :id LIMIT 1")
     suspend fun findById(id: Long): DocumentEntity?
 


### PR DESCRIPTION
## The bug

For a book the user already owns, the catalog and library views generated **separate** insights instead of sharing one.

Verified live against the production DB:

| | catalog (i) hits | library (i) hits | matches? |
|---|---|---|---|
| **Fresh download** | `opds-href:<sha>` → PR-ζ promote copies to library id | EPUB `dc:identifier` | ✅ same row |
| **Already-owned book** | `opds-href:<sha>` | EPUB `dc:identifier` | ❌ two rows |

The PR-ζ promote flow only fires on **download** — for books already in the library, no download happens, no promote runs, identities stay decoupled. Catalog and library each generate (and pay LLM cost for) their own copy.

## The fix

`CatalogDetailViewModel` now takes an optional `localIdentityResolver: suspend (String) -> DocumentIdentity?` mapping `epubDownloadHref → library identity`. Production wires it through a new `DocumentRepository.findByDownloadUrl(href)`. On a hit, the library identity is used in the lookup; on a miss (real pre-download browse), the existing PR-ζ synthetic-identity + stash flow is preserved.

Net behavior:
- **Already-owned**: catalog (i) now hits the same `book_insights` row the library (i) hits → no duplicate generation
- **Pre-download**: unchanged — synthetic identity + stash + promote-on-download still work end-to-end

## Files

- `data/local/.../db/DocumentDao.kt`: `findByDownloadUrl(url)` query
- `data/local/.../DocumentRepository.kt`: `findByDownloadUrl(url)` wrapper
- `app/.../ui/catalogdetail/CatalogDetailViewModel.kt`: new `localIdentityResolver` param + load() short-circuit
- `app/.../di/AppContainer.kt`: wire `DocumentRepository::findByDownloadUrl` into the factory
- Tests: 2 new — resolver-hit overrides synthetic, resolver-miss falls through

## Test plan

- [x] Unit tests pass (`scripts/dgradle :app:testDebugUnitTest :data:local:testDebugUnitTest`)
- [ ] Manual: open catalog (i) on a book already in library → confirm same insight surfaces. Open library (i) → confirms cache hit (no "generating insight").
- [ ] Manual: open catalog (i) on a NEW book → existing PR-ζ behavior preserved (synthetic id, generates fresh, download promotes).