### PR TITLE
fix(ui): preserve selected tab across detail-screen navigation

### DIFF
--- a/app/src/main/java/io/theficos/ereader/ui/main/MainScaffold.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/main/MainScaffold.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 
@@ -30,7 +30,10 @@ fun MainScaffold(
     initial: Tab = Tab.LIBRARY,
     content: @Composable (Tab, PaddingValues) -> Unit,
 ) {
-    var current by remember { mutableStateOf(initial) }
+    // rememberSaveable so the selected tab survives a navigation push to a
+    // detail screen + popBackStack: returning from catalog-detail should land
+    // back on the Catalog tab, not reset to the default LIBRARY.
+    var current by rememberSaveable { mutableStateOf(initial) }
     Scaffold(
         bottomBar = {
             NavigationBar(


### PR DESCRIPTION
## The bug

Tap a catalog item → catalog detail opens → tap back → land on the **Library** tab instead of the Catalog tab the user was on.

## Root cause

\`MainScaffold\` used \`var current by remember { mutableStateOf(initial) }\` for the bottom-nav state. When a detail screen is pushed and then popped, the root composable re-enters composition and \`remember\` returns a fresh \`mutableStateOf(initial)\` → tab resets to default (\`Tab.LIBRARY\`).

## Fix

Swap \`remember\` → \`rememberSaveable\`. The tab state now survives:
- Detail-screen push + pop (the reported bug)
- Configuration changes (rotation)
- Process death recovery

Enum has a default \`Saver\` so no custom saver needed.

## Test plan

- [x] Compiles
- [ ] Manual: Catalog → tap book → back → still on Catalog tab
- [ ] Manual: Library → tap book detail → back → still on Library tab
- [ ] Manual: Rotate phone with Catalog tab selected → still on Catalog