### PR TITLE
docs: add CLA + CONTRIBUTING (Phase 0, task F-3)

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,126 @@
+# Quire Contributor License Agreement
+
+**Version:** 1.0
+**Effective:** 2026-05-22
+
+Thank you for contributing to Quire. This Contributor License Agreement
+("Agreement") documents the rights You grant to the maintainer of Quire so that
+Your contributions can be accepted, maintained, distributed, and — if needed in
+the future — licensed under AGPL-3.0-or-later for all or part of the Project,
+including the `server/` subtree.
+
+By signing this Agreement as described in Section 8, You agree to its terms for
+every Contribution You Submit to the Project, now and in the future, unless and
+until You withdraw the Agreement in writing to the maintainer.
+
+## 1. Definitions
+
+**"You"** means the individual submitting a Contribution. If You are submitting
+on behalf of a legal entity (e.g., as part of Your employment), "You" includes
+that entity, and You represent that You are authorized to bind it.
+
+**"We"** or **"Maintainer"** means Vito Fico, in his personal capacity as
+maintainer of Quire, and any successor, assignee, or legal entity that Vito
+Fico (or his estate) later designates in writing to own or maintain the
+Project. If maintainership is transferred, this Agreement transfers with it.
+
+**"Project"** means Quire, including the Android application, the Python
+server, and related documentation, tests, build files, assets, configuration,
+and infrastructure, in any branch or fork maintained by Us.
+
+**"Contribution"** means any code, documentation, test, configuration, asset,
+patch, pull request, or other copyrightable material that You intentionally
+Submit to Us for inclusion in the Project. A communication is not a
+Contribution if You clearly mark it "Not a Contribution."
+
+**"Submit"** means sending a Contribution to Us through GitHub, email, the
+issue tracker, source control, or another channel used by the Project.
+
+## 2. Copyright Grant
+
+You retain ownership of Your Contributions.
+
+You grant Us a perpetual, worldwide, non-exclusive, royalty-free, fully
+paid-up, irrevocable, transferable license, with the right to sublicense
+through multiple tiers, to use, reproduce, modify, prepare derivative works of,
+publicly display, publicly perform, distribute, and otherwise make available
+Your Contributions, alone or as part of the Project or works derived from the
+Project.
+
+## 3. Patent Grant
+
+If Your Contribution would otherwise infringe patent claims that You own or
+control, You grant Us a perpetual, worldwide, non-exclusive, royalty-free,
+fully paid-up, irrevocable, transferable patent license, with the right to
+sublicense through multiple tiers, to make, have made, use, sell, offer for
+sale, import, and otherwise transfer Your Contribution alone or as part of the
+Project or works derived from the Project.
+
+This patent license applies only to patent claims necessarily infringed by
+Your Contribution alone or by Your Contribution combined with the Project to
+which it was Submitted.
+
+## 4. Allowed Outbound Licenses
+
+We may license Your Contributions, and Project material containing Your
+Contributions, under either or both of:
+
+- the license or licenses that apply to the relevant Project material on the
+  date You Submit the Contribution — currently Apache License 2.0 for the
+  entire Project; and
+- GNU Affero General Public License version 3.0, or GNU Affero General Public
+  License version 3.0 or any later version published by the Free Software
+  Foundation ("AGPL-3.0-or-later"), for all or any part of the Project,
+  including the `server/` subtree.
+
+This Agreement does not by itself change the Project's outbound license. Quire
+remains Apache-2.0 unless a file, subtree, or future release states otherwise.
+Section 4 only preserves Our option to relicense.
+
+## 5. Your Representations
+
+You represent that:
+
+- You have the legal authority to enter into this Agreement.
+- You own the rights needed to grant the licenses in this Agreement, or You
+  have received permission from the rights holder to do so.
+- If You are contributing as part of Your employment or on behalf of a legal
+  entity, You are authorized to Submit the Contribution under this Agreement
+  and to bind that entity to it.
+- Your Contribution does not knowingly include third-party material unless
+  that material is clearly identified and is provided under a license
+  compatible with the Project's then-current licensing and with the outbound
+  licenses listed in Section 4.
+
+## 6. No Obligation
+
+We are not required to accept, use, publish, or maintain any Contribution.
+
+## 7. Disclaimer
+
+Your Contributions are provided "AS IS", without warranties or conditions of
+any kind, including warranties of title, non-infringement, merchantability, or
+fitness for a particular purpose.
+
+## 8. Electronic Signature
+
+You sign this Agreement by commenting **exactly** the following text on a
+Quire pull request, in plain text (no quotes, no Markdown formatting):
+
+```
+I have read the Quire Contributor License Agreement and I hereby sign the CLA
+```
+
+Your signature is recorded by the Maintainer — currently via manual review of
+the PR comment thread before merge — and may be archived (GitHub username, user
+ID, PR number, commit SHA, timestamp) indefinitely for Project legal records.
+Pull request comments are public; the metadata above is already public via the
+comment itself.
+
+## 9. Versioning
+
+This is version 1.0 of the Quire CLA. If the Maintainer changes the CLA text
+materially, the version number will be incremented and a correspondingly
+versioned signature phrase will be adopted (e.g., "…version 2.0 of the Quire
+Contributor License Agreement…"), so previous signatures remain attached to
+the version of the CLA that was in force when they were given.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,33 @@ participates in the cache key.
 
 By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Contributor License Agreement
+
+Before a pull request from any contributor other than the maintainer
+can be merged, every such contributor on the PR must sign the [Quire
+Contributor License Agreement](CLA.md) by posting a new comment on the
+PR containing **exactly**:
+
+```
+I have read the Quire Contributor License Agreement and I hereby sign the CLA
+```
+
+The maintainer reviews PR comments before merge and will not merge a PR
+until every required signer has commented the phrase above. Automation
+bots that don't author copyrightable changes (`dependabot[bot]`,
+`github-actions[bot]`, `renovate[bot]`) are implicitly exempt.
+
+The CLA does **not** change Quire's outbound license. Quire remains
+Apache-2.0 unless a specific file, subtree, or future release states
+otherwise. What the CLA does is grant the maintainer the option to also
+license accepted contributions under AGPL-3.0-or-later for parts of the
+Project (notably the `server/` subtree) in the future, without needing
+to re-collect permission from every past contributor. See `CLA.md` §4.
+
 ## License
 
-By submitting a contribution you agree it is licensed under the
-project's [LICENSE](LICENSE) (Apache-2.0).
+Quire is licensed under [Apache-2.0](LICENSE). By Submitting a
+contribution You agree it is provided under Apache-2.0 and under the
+terms of [the Quire CLA](CLA.md), which (per CLA §4) also lets the
+maintainer license it under AGPL-3.0-or-later for parts of the Project
+in the future.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ Dockerfile            Reproducible Android build environment (linux/amd64)
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md). TL;DR: gitmoji + conventional
 commits, `scripts/dgradle test` and `cd server && uv run pytest` must
-pass, no telemetry / analytics PRs.
+pass, no telemetry / analytics PRs. External contributors also need to
+sign the [Quire CLA](CLA.md) on the PR before it can be merged — see
+CONTRIBUTING.md for the one-line comment.
 
 ## Security
 


### PR DESCRIPTION
**Phase 0, task F-3 — CLA + CONTRIBUTING (text only; no workflow)**

Adds a Harmony-style Contributor License Agreement that grants the maintainer the option to relicense contributions under AGPL-3.0-or-later in the future (notably the `server/` subtree) without re-collecting permission from past contributors. Outbound license stays Apache-2.0.

## What this PR does
- Adds `CLA.md` (Harmony-style v1.0). Section 8 documents the PR-comment signing phrase.
- Updates `CONTRIBUTING.md` with a Contributor License Agreement section describing manual signing (paste the phrase on the PR, maintainer eyeballs before merge).
- Adds a one-liner CLA mention in `README.md`.

## What this PR deliberately does NOT do
- **No GitHub Actions workflow.** F-3's original draft used CLA Assistant Lite + a private signatures repo + a fine-grained PAT. After a sole-author / no-external-PRs-yet reality check, the automation was deemed overkill for now. The text alone preserves the relicensing option; signing is verified by maintainer eyeballing PR comments at merge time. Automation can be added in a future PR if contributor volume grows.

## Verification
- `pre-commit` runs locally pass.
- No CI workflow added, so no new GH Actions burden.

Closes the F-3 scope of the Phase 0 plan.