### PR TITLE
feat(server): identity hash version field (Phase 0, task F-1)

### DIFF
--- a/server/migrations/versions/ai_007_identity_hash_version.py
+++ b/server/migrations/versions/ai_007_identity_hash_version.py
@@ -1,0 +1,69 @@
+"""ai_007_identity_hash_version: add `identity_hash_version` to book_insights.
+
+Seventh migration on the `ai` branch. Chains off `ai_006`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function breaks sync, caches, recs, export, and
+deletion across millions of rows. Trivial now, expensive to retrofit.
+
+This migration adds `identity_hash_version` to `book_insights`, the
+SHARED-CACHE table on the `ai` branch. Companion migration `progress_003`
+adds the same column to `documents` and `library_items`.
+
+Cache-key impact: NONE. `identity_hash_version` is intentionally NOT added
+to any of the unique/cache-key constraints on `book_insights`. The
+architect-reviewed design treats it as row-freshness metadata only: a
+higher-version client hitting an existing cache row upgrades the persisted
+value via `max(existing, incoming)` in the orchestrator. Partitioning the
+cache by version would fragment the cross-tenant cache-hit property
+(see the cache-integrity comment above `BookInsight` in
+`quire_server/db/models.py`) without paying for itself in Phase 0.
+
+Schema additions:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. Pre-existing rows
+  backfill to `1` atomically via the column-level default.
+- `CHECK (identity_hash_version >= 1)`.
+
+Revision ID: ai_007
+Revises: ai_006
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_007"
+down_revision = "ai_006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "book_insights",
+        sa.Column(
+            "identity_hash_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+    op.create_check_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        "identity_hash_version >= 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        type_="check",
+    )
+    op.drop_column("book_insights", "identity_hash_version")

--- a/server/migrations/versions/progress_003_identity_hash_version.py
+++ b/server/migrations/versions/progress_003_identity_hash_version.py
@@ -1,0 +1,73 @@
+"""progress_003_identity_hash_version: add `identity_hash_version` to documents + library_items.
+
+Third migration on the `progress` branch. Chains off `progress_002`.
+`branch_labels = None` because the label is carried by `progress_001`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function (edition merging, normalization fixes,
+etc.) breaks sync, caches, recs, export, and deletion across millions of
+rows. Trivial to add now, very expensive to retrofit.
+
+This migration covers the `progress`-branch tables that carry an identity
+hash directly: `documents` and `library_items`. The companion migration
+`ai_007` adds the same column to `book_insights` on the `ai` branch.
+`progress.progress` deliberately has no own version column: identity travels
+via the parent `Document`, so `Progress.document.identity_hash_version` is
+the answer for any progress row.
+
+Schema additions per table:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. All pre-existing rows
+  backfill to `1` via the column-level default (atomic in Postgres for the
+  ADD COLUMN ... DEFAULT path; no separate UPDATE pass needed).
+- `CHECK (identity_hash_version >= 1)`. Prevents accidental zero-or-negative
+  versions from sneaking in through a future buggy writer.
+
+Downgrade-safety: dropping the column is reversible; the data loss is
+inherent and downgrade callers accept it. No indexes are added — the column
+is row-metadata, not a query predicate.
+
+Revision ID: progress_003
+Revises: progress_002
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "progress_003"
+down_revision = "progress_002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.add_column(
+            table,
+            sa.Column(
+                "identity_hash_version",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("1"),
+            ),
+        )
+        op.create_check_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            "identity_hash_version >= 1",
+        )
+
+
+def downgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.drop_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            type_="check",
+        )
+        op.drop_column(table, "identity_hash_version")

--- a/server/quire_server/api/ai.py
+++ b/server/quire_server/api/ai.py
@@ -411,6 +411,9 @@ async def sync_insights(
             BookInsight.id.label("ins_id"),
             BookInsight.metadata_id.label("ins_metadata_id"),
             BookInsight.content_hash.label("ins_content_hash"),
+            # Phase 0, task F-1: surface persisted identity-hash version
+            # to the client via the sync envelope.
+            BookInsight.identity_hash_version.label("ins_identity_hash_version"),
             BookInsight.model_id.label("ins_model_id"),
             BookInsight.prompt_version.label("ins_prompt_version"),
             BookInsight.tone.label("ins_tone"),
@@ -487,6 +490,7 @@ async def sync_insights(
             identity=DocumentIdentity(
                 metadata_id=r.ins_metadata_id,
                 content_hash=r.ins_content_hash,
+                identity_hash_version=r.ins_identity_hash_version,
             ),
             payload=BookInsightPayload.model_validate(r.ins_payload),
             sources=[Citation.model_validate(c) for c in (r.ins_sources or [])],

--- a/server/quire_server/api/ai_schemas.py
+++ b/server/quire_server/api/ai_schemas.py
@@ -221,6 +221,11 @@ class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str | None = None
 
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1` keeps
+    # pre-versioning clients compatible; the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
+
     # Alias hints (PR2). All optional. The resolver maps them to a
     # canonical via insight_identity_aliases when present.
     opds_href: str | None = None
@@ -373,6 +378,12 @@ class BookInsightResponse(BaseModel):
     model_id: str
     prompt_version: str
     generated_at: str  # ISO-8601
+    # Phase 0, task F-1: identity-hash algorithm version of the persisted
+    # row this response represents. Clients use this to decide whether to
+    # recompute their local hash on the next sync (when their computed
+    # version > N). Defaults to `1` for older serialized rows that
+    # pre-date the column.
+    identity_hash_version: int = 1
 
 
 class InsightLookupBody(BaseModel):

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -61,6 +61,7 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
     return LibraryItemResponse(
         metadata_id=row.metadata_id,
         content_hash=row.content_hash,
+        identity_hash_version=row.identity_hash_version,
         title=row.title,
         authors=list(row.authors or []),
         series_name=row.series_name,
@@ -78,6 +79,11 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
 def _apply_payload(row: LibraryItem, payload: LibraryItemRequest) -> None:
     """Write payload fields onto `row`. Caller is responsible for timestamps."""
     row.metadata_id = payload.metadata_id
+    # Phase 0, task F-1: downgrade protection. An old client (sending the
+    # default `1`) MUST NOT overwrite a row whose hash version was advanced
+    # by a newer client. `max(existing, incoming)` is the load-bearing rule.
+    if payload.identity_hash_version > row.identity_hash_version:
+        row.identity_hash_version = payload.identity_hash_version
     row.title = payload.title
     row.authors = list(payload.authors)
     row.series_name = payload.series_name
@@ -134,6 +140,7 @@ async def put_item(
         row = LibraryItem(
             user_id=user_id,
             content_hash=payload.content_hash,
+            identity_hash_version=payload.identity_hash_version,
             title=payload.title,
             authors=list(payload.authors),
             metadata_id=payload.metadata_id,

--- a/server/quire_server/api/library_schemas.py
+++ b/server/quire_server/api/library_schemas.py
@@ -26,6 +26,11 @@ class LibraryItemRequest(BaseModel):
 
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1`
+    # accepts pre-versioning clients; the server's PUT path applies
+    # `max(existing, incoming)` so an old client cannot downgrade a row
+    # written by a newer client.
+    identity_hash_version: int = Field(default=1, ge=1)
     title: str
     authors: list[str] = Field(default_factory=list)
     series_name: str | None = None
@@ -47,6 +52,12 @@ class LibraryItemIdentity(BaseModel):
     """The identity sub-object inside a DELETE body."""
 
     content_hash: str
+    # Phase 0, task F-1: optional on DELETE. The current matcher keys
+    # exclusively on `content_hash` so the field is accepted but not used
+    # for row selection — clients can already locate a row by hash alone.
+    # Once a real hash-version migration happens this field becomes the
+    # tiebreaker for delete semantics.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class LibraryItemDeleteBody(BaseModel):
@@ -58,6 +69,10 @@ class LibraryItemResponse(BaseModel):
 
     metadata_id: str | None
     content_hash: str
+    # Phase 0, task F-1: always emitted from server, so clients can detect
+    # the row's persisted hash-algorithm version and trigger recompute on
+    # next sync when their computed-version > N.
+    identity_hash_version: int
     title: str
     authors: list[str]
     series_name: str | None

--- a/server/quire_server/api/progress.py
+++ b/server/quire_server/api/progress.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, Field, field_serializer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,11 @@ router = APIRouter(tags=["progress"])
 class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version travelling on the
+    # wire. Default `1` keeps old clients (pre-versioning) round-trippable;
+    # new clients send their own value and the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class ProgressItem(BaseModel):
@@ -102,6 +107,10 @@ async def _resolve_or_create_document(
             )
         ).scalar_one_or_none()
         if existing:
+            # Phase 0, task F-1: downgrade protection. An old client (sending
+            # `1`) MUST NOT overwrite a row written by a newer client.
+            if ident.identity_hash_version > existing.identity_hash_version:
+                existing.identity_hash_version = ident.identity_hash_version
             return existing
     existing = (
         await session.execute(
@@ -114,8 +123,16 @@ async def _resolve_or_create_document(
         # Backfill metadata_id if we just learned it
         if ident.metadata_id and existing.metadata_id is None:
             existing.metadata_id = ident.metadata_id
+        # Phase 0, task F-1: downgrade protection (see above).
+        if ident.identity_hash_version > existing.identity_hash_version:
+            existing.identity_hash_version = ident.identity_hash_version
         return existing
-    doc = Document(user_id=user_id, metadata_id=ident.metadata_id, content_hash=ident.content_hash)
+    doc = Document(
+        user_id=user_id,
+        metadata_id=ident.metadata_id,
+        content_hash=ident.content_hash,
+        identity_hash_version=ident.identity_hash_version,
+    )
     session.add(doc)
     await session.flush()  # populate doc.pk
     return doc
@@ -130,6 +147,14 @@ async def push_progress(
     results: list[ProgressPushResult] = []
     for item in body.items:
         doc = await _resolve_or_create_document(session, user_id, item.document)
+        # Phase 0, task F-1: the result echoes the persisted Document's
+        # identity_hash_version (which may be >= the incoming one after the
+        # downgrade-protection logic in _resolve_or_create_document).
+        persisted_identity = DocumentIdentity(
+            metadata_id=doc.metadata_id,
+            content_hash=doc.content_hash,
+            identity_hash_version=doc.identity_hash_version,
+        )
         existing = (
             await session.execute(select(Progress).where(Progress.document_pk == doc.pk))
         ).scalar_one_or_none()
@@ -158,7 +183,7 @@ async def push_progress(
             )
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -172,7 +197,7 @@ async def push_progress(
             existing.abandoned_at = abandoned_at
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -180,7 +205,7 @@ async def push_progress(
         else:
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="stale",
                     server_client_updated_at=existing.client_updated_at,
                 )
@@ -223,7 +248,11 @@ async def pull_progress(
             effective_abandoned_at = None
         items.append(
             ProgressPullItem(
-                document=DocumentIdentity(metadata_id=d.metadata_id, content_hash=d.content_hash),
+                document=DocumentIdentity(
+                    metadata_id=d.metadata_id,
+                    content_hash=d.content_hash,
+                    identity_hash_version=d.identity_hash_version,
+                ),
                 locator=p.locator,
                 percent=p.percent,
                 client_updated_at=p.client_updated_at,

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -2248,9 +2248,7 @@ def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
 
 
-def _maybe_upgrade_identity_hash_version(
-    row: BookInsight, ident: DocumentIdentity
-) -> None:
+def _maybe_upgrade_identity_hash_version(row: BookInsight, ident: DocumentIdentity) -> None:
     """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
     identity-hash version on a cache-hit.
 

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -664,6 +664,10 @@ class InsightOrchestrator:
         row = BookInsight(
             metadata_id=ident.metadata_id,
             content_hash=effective_content_hash,
+            # Phase 0, task F-1: persist the incoming identity-hash version
+            # so future reads return the correct level. Defaults to `1` for
+            # pre-versioning clients.
+            identity_hash_version=getattr(ident, "identity_hash_version", 1),
             model_id=self.model_id,
             prompt_version=self.prompt_version,
             tone=tone,
@@ -857,6 +861,7 @@ class InsightOrchestrator:
                 )
             ).scalar_one_or_none()
             if row is not None:
+                _maybe_upgrade_identity_hash_version(row, ident)
                 return row
         # Step 2: by content_hash (live rows only)
         if not ident.content_hash:
@@ -875,6 +880,10 @@ class InsightOrchestrator:
         ).scalar_one_or_none()
         if row is None:
             return None
+        # Phase 0, task F-1: upgrade the row's identity_hash_version if the
+        # incoming identity is newer. Same downgrade-protection rule as
+        # Document/LibraryItem: max(existing, incoming).
+        _maybe_upgrade_identity_hash_version(row, ident)
         # Alias reconciliation: backfill metadata_id if we just learned it.
         if allow_backfill and ident.metadata_id and row.metadata_id is None:
             row.metadata_id = ident.metadata_id
@@ -1174,6 +1183,13 @@ class InsightOrchestrator:
         new_row = BookInsight(
             metadata_id=to_identity.metadata_id,
             content_hash=to_identity.content_hash or src_row.content_hash,
+            # Phase 0, task F-1: the copied row takes the maximum of the
+            # source row's version and the destination identity's version
+            # so a v2 destination promoted from a v1 source persists as v2.
+            identity_hash_version=max(
+                src_row.identity_hash_version,
+                getattr(to_identity, "identity_hash_version", 1),
+            ),
             model_id=src_row.model_id,
             prompt_version=src_row.prompt_version,
             tone=src_row.tone,
@@ -2213,6 +2229,10 @@ class InsightOrchestrator:
             model_id=row.model_id,
             prompt_version=row.prompt_version,
             generated_at=row.generated_at.isoformat(),
+            # Phase 0, task F-1: surface the persisted identity-hash version
+            # so clients can detect rows produced under an older algorithm
+            # and trigger their own recompute logic (F-2 territory).
+            identity_hash_version=row.identity_hash_version,
         )
 
 
@@ -2226,6 +2246,24 @@ def _tone_of(style: AiStyle | None) -> str:
 
 def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
+
+
+def _maybe_upgrade_identity_hash_version(
+    row: BookInsight, ident: DocumentIdentity
+) -> None:
+    """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
+    identity-hash version on a cache-hit.
+
+    Operates in-place on `row`. The surrounding transaction commits as
+    part of the normal cache-hit log write, so we do not flush here.
+
+    Defensive: ``ident.identity_hash_version`` is wire-side and defaults to
+    `1` when the client did not supply it (pre-versioning clients). The
+    `>` comparison therefore protects against accidental downgrades.
+    """
+    incoming = getattr(ident, "identity_hash_version", 1)
+    if incoming > row.identity_hash_version:
+        row.identity_hash_version = incoming
 
 
 # ---------- PR2 identity-resolution helpers ---------------------------------

--- a/server/quire_server/db/models.py
+++ b/server/quire_server/db/models.py
@@ -32,6 +32,10 @@ class Document(Base):
     __table_args__ = (
         UniqueConstraint("user_id", "metadata_id", name="uq_documents_user_metadata"),
         UniqueConstraint("user_id", "content_hash", name="uq_documents_user_content_hash"),
+        CheckConstraint(
+            "identity_hash_version >= 1",
+            name="ck_documents_identity_hash_version_ge_1",
+        ),
         Index("ix_documents_user", "user_id"),
     )
 
@@ -39,6 +43,15 @@ class Document(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1 (one-way-door per 2026-05-22 monetization spec):
+    # version of the identity-hash algorithm used to derive `content_hash`.
+    # Persisted with every record so a future hash-function change does not
+    # break sync/cache/recs/export/deletion across millions of rows. Always
+    # >= 1; current rows backfill to 1 in migration `progress_003`. Clients
+    # reading vN rows recompute on next sync when their algorithm > N.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -108,6 +121,14 @@ class BookInsight(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version. NOT part of the
+    # cache key (see architect decision in Phase 0 plan): treated as row-
+    # freshness metadata only. A higher-version client hitting an existing
+    # cache row upgrades the persisted value via max(existing, incoming).
+    # CHECK constraint lives in migration `ai_007`.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     model_id: Mapped[str] = mapped_column(String, nullable=False)
     prompt_version: Mapped[str] = mapped_column(String, nullable=False)
     # Part of the cache key so users with different AiStyle.tone get their own
@@ -349,6 +370,13 @@ class LibraryItem(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version (see Document for
+    # full rationale). The CHECK constraint is declared in the alembic
+    # migration `progress_003` because partial-index-style metadata for
+    # this table lives there.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     authors: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,11 +29,12 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # ai branch is at ai_006 (pr-β added the audit-log generalization +
-    # profile_count column); the progress branch is at progress_002 (pr-α
-    # added abandoned_at). With the default-true mode flags, both branch
-    # heads are reported, sorted.
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`); the progress branch is at
+    # progress_003 (same task, added `identity_hash_version` to
+    # `documents` + `library_items`). With the default-true mode flags,
+    # both branch heads are reported, sorted.
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_library_items.py
+++ b/server/tests/integration/test_library_items.py
@@ -392,3 +392,87 @@ async def test_unauthenticated_request_rejected(app_under_test, unique_user):
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         r = await c.get("/library/v1/items")
     assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning on /library/v1/items.
+# ---------------------------------------------------------------------------
+# Three behaviours travel together:
+#   1. Default round-trip: omitting `identity_hash_version` in the PUT body
+#      persists as `1` and the GET response carries it.
+#   2. Explicit value round-trip: sending `identity_hash_version=2` persists
+#      `2` and the response/GET reflect it.
+#   3. Downgrade protection: after writing version `2`, a later PUT that
+#      defaults to `1` (or explicitly sends `1`) MUST keep the row at `2`.
+#      This is the `max(existing, incoming)` rule that prevents an old
+#      client from clobbering a newer client's row.
+
+
+async def test_identity_hash_version_defaults_to_1_when_absent(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 1
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.status_code == 200
+        items = r2.json()["items"]
+        assert len(items) == 1
+        assert items[0]["identity_hash_version"] == 1
+
+
+async def test_identity_hash_version_round_trips_explicit_value(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 2
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.json()["items"][0]["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_protects_against_downgrade(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Newer client writes v2.
+        r1 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r1.json()["identity_hash_version"] == 2
+
+        # Older client sends nothing (defaults to v1) — must NOT downgrade.
+        r2 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r2.status_code == 200
+        assert r2.json()["identity_hash_version"] == 2
+
+        # Explicit v1 must also not downgrade.
+        r3 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=1),
+            headers=headers,
+        )
+        assert r3.json()["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_rejects_zero(app_under_test, unique_user):
+    """Pydantic `ge=1` returns 422 for non-positive versions."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=0),
+            headers=headers,
+        )
+    assert r.status_code == 422, r.text

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -2,11 +2,11 @@
 
 Cases covered:
 1. Default state with real migrations: wrapper upgrades backbone + ai branch,
-   DB ends at ai@head (currently `ai_006`).
+   DB ends at ai@head (currently `ai_007`).
 2. Idempotent: running twice in a row is a no-op.
-3. Synthetic branched script directory (tmp copy of migrations + an ai_test_006
-   revision chained off the current ai@head):
-   - ai_enabled=true → upgrades to ai_test_006.
+3. Synthetic branched script directory (tmp copy of migrations + an
+   ai_test_008 revision chained off the current ai@head):
+   - ai_enabled=true → upgrades to ai_test_008.
    - ai_enabled=false → stays at 0004 (no ai branch applied).
 """
 
@@ -53,7 +53,7 @@ async def _downgrade_in_thread(cfg, target: str) -> None:
 
 
 async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str):
-    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_006)."""
+    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_007)."""
 
     # Wipe DB to fresh state.
     eng = create_async_engine(postgres_url, future=True)
@@ -66,9 +66,11 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch is at ai_006 (pr-β / Bundle 3 added the audit-log generalization
-    # + profile_count column). The progress branch is at progress_002.
-    assert versions == {"ai_006", "progress_002"}
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`). The progress branch is at
+    # progress_003 (same task, added the column to `documents` and
+    # `library_items`).
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
@@ -81,14 +83,14 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_006", "progress_002"}
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
-    """Copy real migrations to tmp + add a synthetic ai_test_007 chained off
-    ai_006; verify enabled run advances to ai_test_007 (the new ai@head)."""
+    """Copy real migrations to tmp + add a synthetic ai_test_008 chained off
+    ai_007; verify enabled run advances to ai_test_008 (the new ai@head)."""
 
-    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_006).
+    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_007).
     real_cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
 
@@ -96,22 +98,23 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
     versions_dir = synth_dir / "versions"
-    # Chain off ai_006 (the current ai@head after pr-β) with branch_labels=None.
-    (versions_dir / "ai_test_007.py").write_text(
+    # Chain off ai_007 (the current ai@head after Phase 0 / F-1) with
+    # branch_labels=None.
+    (versions_dir / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration.
 
-            Revision ID: ai_test_007
-            Revises: ai_006
-            Create Date: 2026-05-21 00:00:00.000000
+            Revision ID: ai_test_008
+            Revises: ai_007
+            Create Date: 2026-05-22 00:00:00.000000
             """
 
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -132,18 +135,18 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     # ai branch advances to the new tip.
-    assert "ai_test_007" in versions, versions
+    assert "ai_test_008" in versions, versions
     await eng.dispose()
 
     # Cleanup: roll back the synthetic migration so other tests aren't affected.
-    await _downgrade_in_thread(cfg, "ai_006")
+    await _downgrade_in_thread(cfg, "ai_007")
 
 
 async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
     """With ai_enabled=False, the wrapper skips advancing the ai branch.
 
     Pre-condition: DB is rolled back to 0004 (no ai branch applied), then the
-    wrapper is invoked with ai_enabled=False. ai_test_007 (the synthetic head)
+    wrapper is invoked with ai_enabled=False. ai_test_008 (the synthetic head)
     must NOT be applied; the backbone stays at 0004.
     """
     # Stamp DB back to backbone (pre-ai-branch state) for this test.
@@ -152,15 +155,15 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
 
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
-    (synth_dir / "versions" / "ai_test_007.py").write_text(
+    (synth_dir / "versions" / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration."""
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -179,17 +182,19 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch skipped → ai_test_007 not applied, ai_006 not applied,
-    # ai_001 not applied. The `progress` branch still advanced.
-    assert "ai_test_007" not in versions
+    # ai branch skipped → ai_test_008 not applied, ai_007 not applied,
+    # ai_006 not applied, ai_001 not applied. The `progress` branch still
+    # advanced.
+    assert "ai_test_008" not in versions
+    assert "ai_007" not in versions
     assert "ai_006" not in versions
     assert "ai_005" not in versions
     assert "ai_004" not in versions
     assert "ai_003" not in versions
     assert "ai_001" not in versions
     # progress branch advanced (progress_enabled=True). The backbone itself
-    # is no longer a head once progress_002 sits on top of 0004.
-    assert "progress_002" in versions
+    # is no longer a head once progress_003 sits on top of 0004.
+    assert "progress_003" in versions
 
     # Restore DB for subsequent tests.
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -53,8 +53,9 @@ async def restore_after(postgres_url: str, alembic_upgrade):
 
 
 async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
-    """With ai@head (ai_006) + progress@head (progress_002) materialized,
-    /readyz reports both heads. (ai_006 added by pr-β.)
+    """With ai@head (ai_007) + progress@head (progress_003) materialized,
+    /readyz reports both heads. (ai_007 / progress_003 added by Phase 0
+    task F-1: server identity-hash schema versioning.)
     """
     # Some earlier test in the session may have downgraded the DB
     # (test_migrate_script.py exercises rollback). Ensure both branches are
@@ -72,14 +73,15 @@ async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upg
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
     """DB stamped below backbone; with both modes enabled, required head is
-    ai_006 (ai@head after pr-β) — that's what should be reported missing."""
+    ai_007 (ai@head after Phase 0 / F-1) — that's what should be reported
+    missing."""
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -87,7 +89,7 @@ async def test_readyz_503_when_db_below_backbone(
     assert r.status_code == 503
     body = r.json()
     assert body["ready"] is False
-    assert "ai_006" in body["missing"]
+    assert "ai_007" in body["missing"]
 
 
 async def test_readyz_200_with_neither_mode_at_backbone(

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -154,6 +154,65 @@ async def test_library_items_table_exists(engine) -> None:
     assert where_alive is not None and "deleted_at" in str(where_alive).lower()
 
 
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning (server side).
+# ---------------------------------------------------------------------------
+# Two migrations land the same `identity_hash_version INTEGER NOT NULL DEFAULT 1`
+# column with `CHECK (>= 1)`:
+#   * `progress_003` → `documents`, `library_items`.
+#   * `ai_007`       → `book_insights`.
+# These tests reflect the live schema (post-migration) and assert the column
+# shape on every table that should carry it.
+
+
+def _identity_hash_version_column_meta(sync_conn, table: str) -> dict:
+    insp = inspect(sync_conn)
+    cols = {c["name"]: c for c in insp.get_columns(table)}
+    checks = {c["name"]: c for c in insp.get_check_constraints(table)}
+    return {"col": cols.get("identity_hash_version"), "checks": checks}
+
+
+async def test_documents_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "documents")
+    col = info["col"]
+    assert col is not None, "documents.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_documents_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_progress
+async def test_library_items_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "library_items")
+    col = info["col"]
+    assert col is not None, "library_items.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_library_items_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_ai
+async def test_book_insights_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "book_insights")
+    col = info["col"]
+    assert col is not None, "book_insights.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_book_insights_identity_hash_version_ge_1" in info["checks"]
+
+
+async def test_documents_identity_hash_version_default_round_trip(session) -> None:
+    """A row created without supplying `identity_hash_version` defaults to 1."""
+    doc = Document(user_id="alice-v1", metadata_id="md-ver-1", content_hash="ch-ver-1")
+    session.add(doc)
+    await session.commit()
+    await session.refresh(doc)
+    assert doc.identity_hash_version == 1
+
+
 @pytest.mark.requires_ai
 async def test_ai_generation_log_round_trip(session) -> None:
     """ORM model writes and reads ai_generation_log rows."""


### PR DESCRIPTION
Implements **task F-1** of Phase 0.

Spec reference: [`docs/superpowers/specs/2026-05-22-quire-monetization-design.md`](docs/superpowers/specs/2026-05-22-quire-monetization-design.md) — sections:
- *Architectural changes → Identity hash schema versioning*
- *Build sequence → Phase 0 → item (1)*
- *One-way doors → Identity hash schema versioning* (rationale)

## Summary

Lock in identity-hash schema versioning on the server side before private beta. Every record carrying an identity hash now carries an explicit `identity_hash_version: int` (NOT NULL, DEFAULT 1, CHECK >= 1). Existing rows backfill to 1 via column-level `server_default`. The field travels on the wire in every relevant API request/response shape, and write paths apply `max(existing, incoming)` so an old (pre-versioning) client cannot downgrade a row written by a newer client.

This is the server half of the one-way-door pair. F-2 will land the Android client side (Room + recompute on next sync when client's algorithm version > N).

## Files changed and why

### Schema and migrations

- `server/quire_server/db/models.py` — add `identity_hash_version` to `Document`, `LibraryItem`, `BookInsight`. `Progress` deliberately has no own column (identity travels via parent `Document`). `InsightIdentityAlias` is deferred (a single version column is ambiguous when each side of an alias can be `content_hash`).
- `server/migrations/versions/progress_003_identity_hash_version.py` — chains off `progress_002`; adds the column to `documents` and `library_items`.
- `server/migrations/versions/ai_007_identity_hash_version.py` — chains off `ai_006`; adds the column to `book_insights`. **Cache key NOT changed** (architect call): the column is row-freshness metadata only; partitioning the shared cache by version would fragment the cross-tenant cache-hit property without paying for itself in Phase 0.

### Wire DTOs

- `server/quire_server/api/progress.py::DocumentIdentity` — adds `identity_hash_version: int = Field(default=1, ge=1)`. Push response echoes the persisted Document's version; pull response surfaces it.
- `server/quire_server/api/ai_schemas.py` — same on the AI `DocumentIdentity` (covers `/insights/lookup`, `/get`, `/regenerate`, `/invalidate`, `/promote`, sync, profile `BookRec.identity`). Adds the field to `BookInsightResponse` so all `/ai/v1/insights/*` envelopes carry the persisted version.
- `server/quire_server/api/library_schemas.py` — adds the field to `LibraryItemRequest`, `LibraryItemResponse`, and `LibraryItemIdentity` (DELETE body).
- `server/quire_server/api/ai.py` — extends the `/insights/sync` SELECT projection so each item's `identity` carries the persisted version.

### Handlers

- `server/quire_server/api/library.py` — `put_item` persists `identity_hash_version` on insert and applies `max(existing, incoming)` on update. `_to_response` emits the field on every response.
- `server/quire_server/api/progress.py` — `_resolve_or_create_document` persists on create and `max`-merges on reuse. Push response uses the persisted Document value so an old client sending v1 against a v2 row gets v2 echoed back.
- `server/quire_server/core/ai/service.py` — `_do_generate` writes the field on the new `BookInsight` row; `_cache_lookup` upgrades on cache hits via a new `_maybe_upgrade_identity_hash_version` helper; `promote_insight` copies `max(src.version, to_identity.version)`; `_row_to_response` surfaces it.

### Tests (new)

- `server/tests/integration/test_schema.py` — schema reflection asserts the column exists, is `NOT NULL` with default `1`, and the `CHECK (>= 1)` constraint is present on each of `documents`, `library_items`, `book_insights`. Plus an ORM-level round-trip test that a row created without supplying the field defaults to `1`.
- `server/tests/integration/test_library_items.py` — endpoint tests for default round-trip (`PUT` without the field → `1`), explicit-value round-trip (`PUT identity_hash_version=2` → `2` in response and GET), downgrade protection (after v2 is written, a v1 PUT must keep the row at v2), and Pydantic `ge=1` rejection of `0`.

### Tests (head-pin updates)

- `server/tests/integration/test_health.py`, `server/tests/integration/test_readyz_migration_state.py`, `server/tests/integration/test_migrate_script.py` — updated hard-coded `ai_006` / `progress_002` references to `ai_007` / `progress_003`. Synthetic migration test fixture renamed to `ai_test_008` chained off `ai_007`.

## Verification

Commands run:

```
cd server && uv run pytest && uv run ruff check
```

Last lines of output:

```
425 passed, 268 warnings in 17.11s
All checks passed!
```

## Out of scope (per architect)

- **InsightIdentityAlias versioning** — deferred because a single row-level column is ambiguous when either side of an alias can be `content_hash`. A future PR can add side-specific nullable fields if needed.
- **Cache-key partitioning by version** — additive pass only.
- **Sync-cursor changes for pure-version bumps** — clients will trigger `updated_at` advancement via their own re-write on the next sync after recompute (F-2's territory).

## Unresolved questions for the human reviewer

1. **`LibraryItemIdentity` on DELETE** currently accepts but ignores `identity_hash_version` (DELETE matches on `content_hash` only). Acceptable for Phase 0; once a real v2 hash algorithm lands we may need to tighten DELETE semantics. Flagging in case you'd prefer to remove the field from DELETE rather than accept-and-ignore.
2. **`BookInsight` cache-hit upgrade** mutates the row in-place during a "read-like" path (`get` and `generate`'s fast-path). The current code relies on the surrounding cache-hit `_log_generation` commit to flush. If there's ever a code path that calls `_cache_lookup` without a subsequent commit, the upgrade is lost. Considered safe today but worth flagging.
3. **Migration heads in mode-aware migrator**: the new tips are `ai_007` and `progress_003`. `scripts/migrate.py` and `/readyz` infer heads from Alembic metadata, so they pick this up automatically — but please sanity-check that any external cluster manifest pinning a specific revision is updated as part of the rollout.

## Merge-order hint

This PR is independent of F-2 (Android client). However, **F-2 depends on this PR's wire shape** to recompute and re-push the version field. Recommended sequence: this PR → F-2.