### PR TITLE
feat(android): identity hash version field (Phase 0, task F-2)

### DIFF
--- a/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
@@ -11,4 +11,10 @@ data class Document(
     val downloadedAt: Long,
     val seriesName: String? = null,
     val seriesIndex: Double? = null,
+    /**
+     * Schema version of the client-side hash function that produced
+     * `identity.contentHash` for this document. See
+     * [CURRENT_IDENTITY_HASH_VERSION]; today every Document is v1.
+     */
+    val identityHashVersion: Int = CURRENT_IDENTITY_HASH_VERSION,
 )

--- a/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
@@ -4,6 +4,35 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Schema version of the client-side identity-hash function. Stamped on every
+ * record that carries an identity hash (Room rows + outbound DTOs) so a future
+ * change to the hash function (edition merging, normalization fixes, etc.)
+ * doesn't break sync, caches, recs, export, or deletion across persisted data.
+ *
+ * Phase-0 task F-2 introduces this constant at value `1` — the current MD5-
+ * sampled hash in `core/identity/ContentHash.kt`. Bumping this constant later
+ * requires:
+ *   1. Updating the hash function.
+ *   2. A migration that re-computes hashes for local rows and re-uploads them.
+ *   3. Server-side acceptance of the new version (sibling task F-1 introduces
+ *      the wire field; further bumps are coordinated with the server team).
+ *
+ * The companion [isStaleHashVersion] predicate is the explicit "needs rehash"
+ * check; today it is a no-op (no rows exist at version < 1) but the mechanism
+ * is wired so a future version bump only needs to flip the constant.
+ */
+const val CURRENT_IDENTITY_HASH_VERSION: Int = 1
+
+/**
+ * True iff a record stamped with [rowVersion] was produced by an older client
+ * hash function and should be re-hashed before its next push to the server.
+ *
+ * Today this is `rowVersion < 1`, which is always false — bumping
+ * [CURRENT_IDENTITY_HASH_VERSION] activates the predicate for legacy rows.
+ */
+fun isStaleHashVersion(rowVersion: Int): Boolean = rowVersion < CURRENT_IDENTITY_HASH_VERSION
+
+/**
  * Mirrors `DocumentIdentity` in `server/quire_server/api/ai_schemas.py`.
  *
  * Canonical schemes (`metadataId`, `contentHash`) identify a downloaded EPUB
@@ -16,6 +45,13 @@ import kotlinx.serialization.Serializable
  * invariant (`contentHash` non-empty) is enforced by the call site
  * (`EpubIdentityExtractor`), not the type — pre-download paths legitimately
  * have no `contentHash`.
+ *
+ * `identityHashVersion` (Phase-0 / F-2) stamps which version of the
+ * client-side hash function produced [contentHash]. Defaults to
+ * [CURRENT_IDENTITY_HASH_VERSION] so callers building an identity from a
+ * freshly-computed hash get the right value automatically; defaults to `1`
+ * on the wire so an older server that doesn't emit the field decodes
+ * correctly (every existing hash on the network is v1).
  */
 @Serializable
 data class DocumentIdentity(
@@ -25,6 +61,7 @@ data class DocumentIdentity(
     @SerialName("opds_href") val opdsHref: String? = null,
     @SerialName("calibre_book_id") val calibreBookId: String? = null,
     val isbn: String? = null,
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 ) {
     init {
         require(

--- a/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
+++ b/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
@@ -1,9 +1,12 @@
 package io.theficos.ereader.core.model
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
 import org.junit.Test
 
 class DocumentIdentityTest {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
     @Test fun `accepts contentHash-only`() {
         val id = DocumentIdentity(metadataId = null, contentHash = "abc123")
         assertThat(id.contentHash).isEqualTo("abc123")
@@ -40,5 +43,46 @@ class DocumentIdentityTest {
     @Test fun `accepts isbn-only alias payload`() {
         val id = DocumentIdentity(isbn = "9780553293357")
         assertThat(id.isbn).isEqualTo("9780553293357")
+    }
+
+    // ---------- Phase-0 / F-2: identity hash version ----------
+
+    @Test fun `identityHashVersion defaults to current version`() {
+        val id = DocumentIdentity(contentHash = "abc")
+        assertThat(id.identityHashVersion).isEqualTo(CURRENT_IDENTITY_HASH_VERSION)
+        assertThat(CURRENT_IDENTITY_HASH_VERSION).isEqualTo(1)
+    }
+
+    @Test fun `isStaleHashVersion is no-op at current version`() {
+        assertThat(isStaleHashVersion(1)).isFalse()
+        // A future v2 row decoded by a v1 client is NOT stale (not the
+        // direction the predicate cares about).
+        assertThat(isStaleHashVersion(2)).isFalse()
+    }
+
+    @Test fun `isStaleHashVersion detects pre-current versions`() {
+        // Hypothetical bump to v2: a v1 row is now stale and needs a rehash.
+        // Asserted via the underlying inequality so the test is robust against
+        // a future constant change.
+        assertThat(0 < CURRENT_IDENTITY_HASH_VERSION).isTrue()
+        assertThat(isStaleHashVersion(0)).isTrue()
+    }
+
+    @Test fun `identity_hash_version round-trips on the wire`() {
+        val id = DocumentIdentity(contentHash = "abc", identityHashVersion = 7)
+        val encoded = json.encodeToString(DocumentIdentity.serializer(), id)
+        assertThat(encoded).contains("\"identity_hash_version\":7")
+        val decoded = json.decodeFromString(DocumentIdentity.serializer(), encoded)
+        assertThat(decoded.identityHashVersion).isEqualTo(7)
+        assertThat(decoded.contentHash).isEqualTo("abc")
+    }
+
+    @Test fun `missing identity_hash_version decodes to 1 for back-compat`() {
+        // An older server that doesn't yet emit the field (pre-F-1) must
+        // still decode cleanly. Every hash on the wire today is v1.
+        val legacyWire = """{"content_hash":"abc"}"""
+        val decoded = json.decodeFromString(DocumentIdentity.serializer(), legacyWire)
+        assertThat(decoded.identityHashVersion).isEqualTo(1)
+        assertThat(decoded.contentHash).isEqualTo("abc")
     }
 }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
@@ -301,6 +301,9 @@ class AiRepository(
             serverId = 0L,
             generatedAt = parseIsoMillis(resp.generatedAt) ?: clock(),
             syncedAt = clock(),
+            // Phase-0 / F-2: stamp the cache row with the hash version of
+            // the identity used to fetch it. See `InsightEntity.identityHashVersion`.
+            identityHashVersion = identity.identityHashVersion,
         )
         insightDao.upsert(entity)
     }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/InsightSyncRepository.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/InsightSyncRepository.kt
@@ -131,5 +131,8 @@ internal fun InsightSyncItem.toEntity(syncedAtMs: Long, json: Json): InsightEnti
         serverId = id,
         generatedAt = parseIsoMillis(generatedAt) ?: syncedAtMs,
         syncedAt = syncedAtMs,
+        // Phase-0 / F-2: cache row inherits the hash version stamped by
+        // the server on the source identity.
+        identityHashVersion = identity.identityHashVersion,
     )
 }

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
@@ -56,6 +56,10 @@ data class LibraryItemRequest(
     val language: String? = null,
     val subjects: List<String> = emptyList(),
     @SerialName("opds_href") val opdsHref: String? = null,
+    // Phase-0 / F-2: stamps which client hash-function version produced
+    // `contentHash`. Defaults to `1` for wire back-compat with an older
+    // server that doesn't yet emit the field (F-1 lands it server-side).
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
 
 /**
@@ -90,4 +94,7 @@ data class LibraryItemResponse(
     @SerialName("created_at") val createdAt: String,
     @SerialName("updated_at") val updatedAt: String,
     @SerialName("deleted_at") val deletedAt: String? = null,
+    // Phase-0 / F-2: defaults to `1` so an older server (pre-F-1) decodes
+    // safely — every hash on the wire today is v1.
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
@@ -119,6 +119,10 @@ class LibraryUploader(
             language = null,    // v2: parse from OPF
             subjects = emptyList(), // v2: parse from OPF
             opdsHref = downloadUrl,
+            // Phase-0 / F-2: forward the row's stored hash version. Today
+            // this is always 1; a future hash-function bump will set it to
+            // the version that was current when this row was hashed.
+            identityHashVersion = identityHashVersion,
         )
 
     private companion object {

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
@@ -63,4 +63,48 @@ class LibraryDtosTest {
         assertThat(parsed.totalBooks).isEqualTo(3)
         assertThat(parsed.abandonedCount).isEqualTo(0)
     }
+
+    // ---------- Phase-0 / F-2: identity_hash_version ----------
+
+    @Test
+    fun `LibraryItemRequest carries identity_hash_version on the wire`() {
+        // Round-trip with encodeDefaults=true so we can see what would
+        // travel over the wire if an AI-style client were used (the real
+        // LibraryClient uses default encodeDefaults=false, so the field
+        // is omitted on encode there — that's fine, the server applies
+        // its own DEFAULT 1).
+        val encJson = Json { encodeDefaults = true }
+        val req = LibraryItemRequest(
+            contentHash = "abc",
+            title = "T",
+            identityHashVersion = 2,
+        )
+        val encoded = encJson.encodeToString(LibraryItemRequest.serializer(), req)
+        assertThat(encoded).contains("\"identity_hash_version\":2")
+    }
+
+    @Test
+    fun `LibraryItemResponse decodes default 1 when server omits identity_hash_version`() {
+        // Older server (pre-F-1) doesn't emit the field. Every existing
+        // hash on the wire is v1, so the default `= 1` is correct.
+        val body = """
+            {
+              "content_hash":"h1","title":"T","authors":[],"created_at":"2026-01-01T00:00:00+00:00","updated_at":"2026-01-01T00:00:00+00:00"
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryItemResponse.serializer(), body)
+        assertThat(parsed.identityHashVersion).isEqualTo(1)
+    }
+
+    @Test
+    fun `LibraryItemResponse decodes non-default identity_hash_version`() {
+        val body = """
+            {
+              "content_hash":"h1","title":"T","authors":[],"identity_hash_version":3,
+              "created_at":"2026-01-01T00:00:00+00:00","updated_at":"2026-01-01T00:00:00+00:00"
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryItemResponse.serializer(), body)
+        assertThat(parsed.identityHashVersion).isEqualTo(3)
+    }
 }

--- a/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json
+++ b/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json
@@ -1,0 +1,393 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "40c4987051d2f31f8f5aeb107d62d857",
+    "entities": [
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `metadataId` TEXT, `contentHash` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `downloadUrl` TEXT NOT NULL, `localPath` TEXT NOT NULL, `coverPath` TEXT, `downloadedAt` INTEGER NOT NULL, `seriesName` TEXT, `seriesIndex` REAL, `librarySyncedAt` INTEGER, `identityHashVersion` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "librarySyncedAt",
+            "columnName": "librarySyncedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "identityHashVersion",
+            "columnName": "identityHashVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_documents_metadataId",
+            "unique": true,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_documents_contentHash",
+            "unique": true,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_documents_seriesName_seriesIndex",
+            "unique": false,
+            "columnNames": [
+              "seriesName",
+              "seriesIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_documents_seriesName_seriesIndex` ON `${TABLE_NAME}` (`seriesName`, `seriesIndex`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `documentId` INTEGER NOT NULL, `locator` TEXT NOT NULL, `percent` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `finishedAt` INTEGER, `abandonedAt` INTEGER, FOREIGN KEY(`documentId`) REFERENCES `documents`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locator",
+            "columnName": "locator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percent",
+            "columnName": "percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "abandonedAt",
+            "columnName": "abandonedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_documentId",
+            "unique": true,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_progress_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "documents",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `lastPulledAt` INTEGER NOT NULL, PRIMARY KEY(`tableName`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPulledAt",
+            "columnName": "lastPulledAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "book_insights",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identityKey` TEXT NOT NULL, `metadataId` TEXT, `contentHash` TEXT, `modelId` TEXT NOT NULL, `promptVersion` TEXT NOT NULL, `tone` TEXT NOT NULL, `language` TEXT NOT NULL, `payloadJson` TEXT NOT NULL, `sourcesJson` TEXT NOT NULL, `schemaVersion` INTEGER NOT NULL, `serverId` INTEGER NOT NULL, `generatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `identityHashVersion` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`identityKey`, `modelId`, `promptVersion`, `tone`, `language`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptVersion",
+            "columnName": "promptVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tone",
+            "columnName": "tone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedAt",
+            "columnName": "generatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHashVersion",
+            "columnName": "identityHashVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identityKey",
+            "modelId",
+            "promptVersion",
+            "tone",
+            "language"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_insights_syncedAt",
+            "unique": false,
+            "columnNames": [
+              "syncedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_syncedAt` ON `${TABLE_NAME}` (`syncedAt`)"
+          },
+          {
+            "name": "index_book_insights_metadataId",
+            "unique": false,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_book_insights_contentHash",
+            "unique": false,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_book_insights_cursor",
+            "unique": false,
+            "columnNames": [
+              "generatedAt",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_cursor` ON `${TABLE_NAME}` (`generatedAt`, `serverId`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '40c4987051d2f31f8f5aeb107d62d857')"
+    ]
+  }
+}

--- a/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local
 
+import io.theficos.ereader.core.model.CURRENT_IDENTITY_HASH_VERSION
 import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.core.model.DocumentIdentity
 import io.theficos.ereader.data.local.db.DocumentDao
@@ -80,6 +81,7 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt: Long,
         seriesName: String? = null,
         seriesIndex: Double? = null,
+        identityHashVersion: Int = CURRENT_IDENTITY_HASH_VERSION,
     ): Long = dao.insert(DocumentEntity(
         metadataId = identity.metadataId,
         contentHash = requireNotNull(identity.contentHash) {
@@ -93,11 +95,16 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt = downloadedAt,
         seriesName = seriesName?.takeIf { it.isNotBlank() },
         seriesIndex = seriesIndex,
+        identityHashVersion = identityHashVersion,
     ))
 
     private fun DocumentEntity.toDomain(): Document = Document(
         id = id,
-        identity = DocumentIdentity(metadataId = metadataId, contentHash = contentHash),
+        identity = DocumentIdentity(
+            metadataId = metadataId,
+            contentHash = contentHash,
+            identityHashVersion = identityHashVersion,
+        ),
         title = title,
         author = author,
         downloadUrl = downloadUrl,
@@ -106,6 +113,7 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt = downloadedAt,
         seriesName = seriesName,
         seriesIndex = seriesIndex,
+        identityHashVersion = identityHashVersion,
     )
 
     companion object {

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -37,4 +38,14 @@ data class DocumentEntity(
      * presence marker; we never compare it against server timestamps.
      */
     val librarySyncedAt: Long? = null,
+    /**
+     * Phase-0 / F-2: schema version of the client-side hash function that
+     * produced [contentHash]. `INTEGER NOT NULL DEFAULT 1` on disk so the
+     * 8→9 migration can backfill pre-existing rows in a single ALTER TABLE.
+     * Today every row is v1; the field exists so a future hash-function
+     * change can be detected via
+     * `io.theficos.ereader.core.model.isStaleHashVersion`.
+     */
+    @ColumnInfo(defaultValue = "1")
+    val identityHashVersion: Int = 1,
 )

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
@@ -14,7 +14,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         SyncStateEntity::class,
         InsightEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
 )
 abstract class EReaderDatabase : RoomDatabase() {
@@ -143,6 +143,33 @@ abstract class EReaderDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Phase-0 / F-2: stamps every identity-hash-carrying row with the
+         * schema version of the hash function that produced it. Backfills
+         * existing rows to `1` (the current MD5-sampled hash in
+         * `core/identity/ContentHash.kt`). Paired with
+         * `core.model.CURRENT_IDENTITY_HASH_VERSION` and
+         * `core.model.isStaleHashVersion`. Server-side change is handled by
+         * the sibling F-1 task.
+         *
+         * Two ALTER TABLEs: `documents` (the primary owner — also drives
+         * re-upload via `LibraryUploader` when stale) and `book_insights`
+         * (metadata only; this DAO cannot re-key its rows, so a future v2
+         * bump will be handled by re-syncing the cache from the server).
+         */
+        internal val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE documents ADD COLUMN identityHashVersion " +
+                        "INTEGER NOT NULL DEFAULT 1"
+                )
+                db.execSQL(
+                    "ALTER TABLE book_insights ADD COLUMN identityHashVersion " +
+                        "INTEGER NOT NULL DEFAULT 1"
+                )
+            }
+        }
+
         fun build(context: Context): EReaderDatabase =
             Room.databaseBuilder(context, EReaderDatabase::class.java, "ereader.db")
                 .addMigrations(
@@ -153,6 +180,7 @@ abstract class EReaderDatabase : RoomDatabase() {
                     MIGRATION_5_6,
                     MIGRATION_6_7,
                     MIGRATION_7_8,
+                    MIGRATION_8_9,
                 )
                 .build()
     }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/InsightEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/InsightEntity.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 
@@ -41,4 +42,17 @@ data class InsightEntity(
     val generatedAt: Long,
     /** When this row was upserted locally; wall clock millis. */
     val syncedAt: Long,
+    /**
+     * Phase-0 / F-2: schema version of the client-side hash function that
+     * produced the [contentHash] / [identityKey] this row is filed under.
+     * `INTEGER NOT NULL DEFAULT 1` on disk.
+     *
+     * Stored as metadata only — this DAO cannot re-key existing rows when
+     * the hash function bumps because the `identityKey` is part of the
+     * primary key and the source EPUB is not addressable from here. A
+     * future hash-function change will be handled by re-syncing the cache
+     * (server-driven) rather than by mutating this column in place.
+     */
+    @ColumnInfo(defaultValue = "1")
+    val identityHashVersion: Int = 1,
 )

--- a/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
@@ -258,5 +258,116 @@ class MigrationTest {
         }
     }
 
+    @Test fun `migrate 8 to 9 stamps identityHashVersion=1 on documents and book_insights`() {
+        // v8 fixture: seed one row in `documents` and one in `book_insights`
+        // (both tables exist at v8). identityHashVersion does NOT exist yet.
+        helper.createDatabase(DB, 8).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (41, 'm41', 'h41', 'Pre-F2 title', NULL, 'u', 'p', NULL, 51, NULL, NULL, NULL)"
+            )
+            db.execSQL(
+                "INSERT INTO book_insights (identityKey, metadataId, contentHash, modelId, " +
+                    "promptVersion, tone, language, payloadJson, sourcesJson, schemaVersion, " +
+                    "serverId, generatedAt, syncedAt) VALUES " +
+                    "('m41', 'm41', 'h41', 'llama3.1', '4', 'neutral', 'auto', '{}', '[]', 4, " +
+                    "100, 1000, 1100)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(DB, 9, true, EReaderDatabase.MIGRATION_8_9).use { db ->
+            // Both tables gained the column.
+            for (table in listOf("documents", "book_insights")) {
+                db.query("PRAGMA table_info('$table')").use { c ->
+                    val cols = mutableSetOf<String>()
+                    while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                    assertThat(cols).contains("identityHashVersion")
+                }
+            }
+            // Existing rows backfill to 1 via the DEFAULT clause.
+            db.query("SELECT identityHashVersion FROM documents WHERE id=41").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            db.query(
+                "SELECT identityHashVersion FROM book_insights " +
+                    "WHERE identityKey='m41' AND modelId='llama3.1' AND promptVersion='4'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            // New rows round-trip a non-default value.
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt, " +
+                    "identityHashVersion) " +
+                    "VALUES (42, 'm42', 'h42', 'Post-F2 title', NULL, 'u', 'p', NULL, 52, NULL, " +
+                    "NULL, NULL, 2)"
+            )
+            db.query("SELECT identityHashVersion FROM documents WHERE id=42").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(2)
+            }
+            db.execSQL(
+                "INSERT INTO book_insights (identityKey, metadataId, contentHash, modelId, " +
+                    "promptVersion, tone, language, payloadJson, sourcesJson, schemaVersion, " +
+                    "serverId, generatedAt, syncedAt, identityHashVersion) VALUES " +
+                    "('m42', 'm42', 'h42', 'llama3.1', '4', 'neutral', 'auto', '{}', '[]', 4, " +
+                    "200, 2000, 2100, 3)"
+            )
+            db.query(
+                "SELECT identityHashVersion FROM book_insights " +
+                    "WHERE identityKey='m42' AND modelId='llama3.1' AND promptVersion='4'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(3)
+            }
+        }
+    }
+
+    @Test fun `migrate 6 to 9 chains all additive migrations`() {
+        // Long-tail upgrade path: a v6 install (pre-PR-η) jumps straight to
+        // v9 (post-F-2). Every additive migration in between must survive.
+        helper.createDatabase(DB, 6).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (51, 'm51', 'h51', 'Pre-F2 chain title', NULL, 'u', 'p', NULL, 61, NULL, NULL, NULL)"
+            )
+            db.execSQL(
+                "INSERT INTO progress (id, documentId, locator, percent, updatedAt, " +
+                    "localUpdatedAt, syncedAt, finishedAt) " +
+                    "VALUES (51, 51, 'loc', 0.8, 100, 100, 0, NULL)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(
+            DB,
+            9,
+            true,
+            EReaderDatabase.MIGRATION_6_7,
+            EReaderDatabase.MIGRATION_7_8,
+            EReaderDatabase.MIGRATION_8_9,
+        ).use { db ->
+            // F-2 column landed on both tables.
+            db.query("SELECT identityHashVersion FROM documents WHERE id=51").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            db.query("PRAGMA table_info('book_insights')").use { c ->
+                val cols = mutableSetOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("identityHashVersion")
+            }
+            // Earlier additive migrations still present.
+            db.query("PRAGMA table_info('progress')").use { c ->
+                val cols = mutableSetOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("abandonedAt")
+            }
+        }
+    }
+
     private companion object { const val DB = "migration-test.db" }
 }

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
@@ -7,6 +7,11 @@ import kotlinx.serialization.Serializable
 data class DocumentIdDto(
     @SerialName("metadata_id") val metadataId: String? = null,
     @SerialName("content_hash") val contentHash: String,
+    // Phase-0 / F-2: schema version of the client-side hash function that
+    // produced `contentHash`. Defaults to `1` so an older server that does
+    // not yet emit the field (pre-F-1) decodes safely — every existing
+    // hash on the wire is v1.
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
 
 @Serializable

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
@@ -31,6 +31,9 @@ class SyncOrchestrator(
                         contentHash = requireNotNull(doc.identity.contentHash) {
                             "downloaded document must have a contentHash"
                         },
+                        // Phase-0 / F-2: stamp every outbound progress push
+                        // with the hash version of the row it references.
+                        identityHashVersion = doc.identityHashVersion,
                     ),
                     locator = progress.locator,
                     percent = progress.percent,
@@ -65,7 +68,15 @@ class SyncOrchestrator(
     }
 
     private suspend fun applyPulled(item: ProgressItemDto) {
-        val identity = DocumentIdentity(metadataId = item.document.metadataId, contentHash = item.document.contentHash)
+        // Phase-0 / F-2: forward the server-reported identity_hash_version
+        // into the DocumentIdentity used for local lookup. We don't act on
+        // it here (progress doesn't carry a hash on disk; doc rows are
+        // looked up by metadataId/contentHash) — but the field travels.
+        val identity = DocumentIdentity(
+            metadataId = item.document.metadataId,
+            contentHash = item.document.contentHash,
+            identityHashVersion = item.document.identityHashVersion,
+        )
         val doc = documentRepo.findByIdentity(identity) ?: return
         val incomingUpdatedAt = Instant.parse(item.clientUpdatedAt).toEpochMilli()
         val incomingFinishedAt = item.finishedAt?.let { Instant.parse(it).toEpochMilli() }

--- a/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
+++ b/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
@@ -113,4 +113,23 @@ class ProgressDtosTest {
         assertThat(r.items.first().abandonedAt).isEqualTo("2026-05-20T12:00:00+00:00")
         assertThat(r.items.first().finishedAt).isNull()
     }
+
+    // ---------- Phase-0 / F-2: identity_hash_version ----------
+
+    @Test fun `DocumentIdDto carries identity_hash_version on the wire`() {
+        val encJson = Json { encodeDefaults = true }
+        val dto = DocumentIdDto(metadataId = "m1", contentHash = "h1", identityHashVersion = 2)
+        val encoded = encJson.encodeToString(DocumentIdDto.serializer(), dto)
+        assertThat(encoded).contains("\"identity_hash_version\":2")
+        val decoded = encJson.decodeFromString(DocumentIdDto.serializer(), encoded)
+        assertThat(decoded.identityHashVersion).isEqualTo(2)
+    }
+
+    @Test fun `DocumentIdDto missing identity_hash_version defaults to 1`() {
+        // Pre-F-1 server payload — the field hasn't landed server-side yet
+        // (or the deploy lags). Every hash on the wire today is v1.
+        val raw = """{"metadata_id":"m1","content_hash":"h1"}"""
+        val decoded = json.decodeFromString(DocumentIdDto.serializer(), raw)
+        assertThat(decoded.identityHashVersion).isEqualTo(1)
+    }
 }


### PR DESCRIPTION
Implements task **F-2** of Phase 0 of the Quire monetization plan: every record carrying the client-side identity hash now travels with an explicit schema-version stamp, so a future change to the hash function (edition merging, normalization fixes, etc.) does not silently break sync, caches, recs, export, or deletion across persisted data.

Spec references:
- `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`
  - **Architectural changes -> "Identity hash schema versioning"**
  - **Build sequence -> Phase 0 item (1)**
  - **One-way doors -> "Identity hash schema versioning"**

## What lands

**Single source of truth + mechanism**
- `core.model.CURRENT_IDENTITY_HASH_VERSION = 1` + `isStaleHashVersion(rowVersion)` predicate. Today the predicate is a no-op (no row has version < 1); the wiring is in place so a future hash bump only needs to flip the constant and add the re-hash pipeline.

**Wire DTOs (defaulted `Int = 1`, so an older server pre-F-1 decodes cleanly)**
- `core/model/.../DocumentIdentity.kt` — `@SerialName("identity_hash_version")`.
- `data/library/.../LibraryDtos.kt` — `LibraryItemRequest`, `LibraryItemResponse`.
- `data/sync/.../ProgressDtos.kt` — `DocumentIdDto`.

**Room entities (Int column, `NOT NULL DEFAULT 1`)**
- `DocumentEntity` — primary owner.
- `InsightEntity` — metadata only (DAO cannot re-key by `identityKey` PK; a future v2 will re-sync the cache rather than mutate in place).
- `ProgressEntity` intentionally unchanged — it is keyed by `documentId` and carries no hash on disk.

**Room migration 8 -> 9**
- Two additive `ALTER TABLE ... ADD COLUMN identityHashVersion INTEGER NOT NULL DEFAULT 1` statements, schema export regenerated (`data/local/schemas/.../9.json`).

**Propagation**
- `DocumentRepository.insert(...)` accepts `identityHashVersion` (default `CURRENT_IDENTITY_HASH_VERSION`); `toDomain()` propagates it into the `Document` + nested `DocumentIdentity`.
- `LibraryUploader` stamps outbound `LibraryItemRequest` with the row's `identityHashVersion`.
- `SyncOrchestrator` forwards the version both ways (push + pull) inside `DocumentIdDto`.
- `AiRepository.writeLocalFromResponse` and `InsightSyncRepository.toEntity` stamp the cache row with the inbound identity's version.

## Files changed

- `core/model/.../Document.kt`
- `core/model/.../DocumentIdentity.kt` (+ matching test)
- `data/local/.../db/DocumentEntity.kt`
- `data/local/.../db/InsightEntity.kt`
- `data/local/.../db/EReaderDatabase.kt` (DB version bump 8 -> 9, MIGRATION_8_9)
- `data/local/.../DocumentRepository.kt`
- `data/local/.../db/MigrationTest.kt` (single + chained migration test)
- `data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json` (new, KSP-generated)
- `data/library/.../LibraryDtos.kt` (+ matching test)
- `data/library/.../LibraryUploader.kt`
- `data/sync/.../ProgressDtos.kt` (+ matching test)
- `data/sync/.../SyncOrchestrator.kt`
- `data/ai/.../AiRepository.kt`
- `data/ai/.../InsightSyncRepository.kt`

## Verification

```
scripts/dgradle :core:model:test :core:identity:test \\
                :data:local:testDebugUnitTest \\
                :data:library:testDebugUnitTest \\
                :data:sync:testDebugUnitTest \\
                :data:ai:testDebugUnitTest \\
                :app:testDebugUnitTest
```

All targeted module test suites pass, including:
- `MigrationTest.migrate 8 to 9 stamps identityHashVersion=1 on documents and book_insights`
- `MigrationTest.migrate 6 to 9 chains all additive migrations`
- `DocumentIdentityTest.identity_hash_version round-trips on the wire`
- `DocumentIdentityTest.missing identity_hash_version decodes to 1 for back-compat`
- `LibraryDtosTest.LibraryItemRequest carries identity_hash_version on the wire`
- `LibraryDtosTest.LibraryItemResponse decodes default 1 when server omits identity_hash_version`
- `ProgressDtosTest.DocumentIdDto carries identity_hash_version on the wire`
- `ProgressDtosTest.DocumentIdDto missing identity_hash_version defaults to 1`

## Test plan

- [ ] CI runs the full module-unit-test matrix on the PR.
- [ ] Smoke-test app start on a v8 install fixture to confirm the 8 -> 9 ALTER lands without data loss.
- [ ] Coordinate with the sibling F-1 PR before either is taken out of draft — confirm the server tolerates an `identity_hash_version` key on inbound `LibraryItemRequest`/`DocumentIdDto`/`DocumentIdentity` payloads (Pydantic default `extra="ignore"` is sufficient).

## Out of scope / deferred

- Hash function v2 itself — `ContentHash.kt` is unchanged; bumping `CURRENT_IDENTITY_HASH_VERSION` activates the predicate but the recompute-and-re-upload pipeline is a follow-up task.
- Mutating `book_insights.identityKey` when the hash function changes — that will be handled by re-syncing the cache from the server, not by an in-place column migration.
- Server-side changes (`server/`) — handled by the sibling **F-1** task.

## Unresolved questions

- Final wire-name agreement with F-1 is **`identity_hash_version`** as written in the spec. If F-1 uses a different camelCase/snake_case convention, this PR needs the `@SerialName` updated to match. Not blocking the diff but blocking integration.

## Merge-order hints

- This PR is safe to merge **before, after, or independently of F-1**. The DTOs default to `1` on both encode (omitted via no `encodeDefaults`) and decode (defaulted), so the client works with any combination of "F-2 landed / F-2 not landed" on the server side.