### PR TITLE
feat(server): POST /library/v1/sync push endpoint (Phase 0, task S-2)

### DIFF
--- a/server/migrations/versions/ai_007_identity_hash_version.py
+++ b/server/migrations/versions/ai_007_identity_hash_version.py
@@ -1,0 +1,69 @@
+"""ai_007_identity_hash_version: add `identity_hash_version` to book_insights.
+
+Seventh migration on the `ai` branch. Chains off `ai_006`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function breaks sync, caches, recs, export, and
+deletion across millions of rows. Trivial now, expensive to retrofit.
+
+This migration adds `identity_hash_version` to `book_insights`, the
+SHARED-CACHE table on the `ai` branch. Companion migration `progress_003`
+adds the same column to `documents` and `library_items`.
+
+Cache-key impact: NONE. `identity_hash_version` is intentionally NOT added
+to any of the unique/cache-key constraints on `book_insights`. The
+architect-reviewed design treats it as row-freshness metadata only: a
+higher-version client hitting an existing cache row upgrades the persisted
+value via `max(existing, incoming)` in the orchestrator. Partitioning the
+cache by version would fragment the cross-tenant cache-hit property
+(see the cache-integrity comment above `BookInsight` in
+`quire_server/db/models.py`) without paying for itself in Phase 0.
+
+Schema additions:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. Pre-existing rows
+  backfill to `1` atomically via the column-level default.
+- `CHECK (identity_hash_version >= 1)`.
+
+Revision ID: ai_007
+Revises: ai_006
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_007"
+down_revision = "ai_006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "book_insights",
+        sa.Column(
+            "identity_hash_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+    op.create_check_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        "identity_hash_version >= 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        type_="check",
+    )
+    op.drop_column("book_insights", "identity_hash_version")

--- a/server/migrations/versions/progress_003_identity_hash_version.py
+++ b/server/migrations/versions/progress_003_identity_hash_version.py
@@ -1,0 +1,73 @@
+"""progress_003_identity_hash_version: add `identity_hash_version` to documents + library_items.
+
+Third migration on the `progress` branch. Chains off `progress_002`.
+`branch_labels = None` because the label is carried by `progress_001`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function (edition merging, normalization fixes,
+etc.) breaks sync, caches, recs, export, and deletion across millions of
+rows. Trivial to add now, very expensive to retrofit.
+
+This migration covers the `progress`-branch tables that carry an identity
+hash directly: `documents` and `library_items`. The companion migration
+`ai_007` adds the same column to `book_insights` on the `ai` branch.
+`progress.progress` deliberately has no own version column: identity travels
+via the parent `Document`, so `Progress.document.identity_hash_version` is
+the answer for any progress row.
+
+Schema additions per table:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. All pre-existing rows
+  backfill to `1` via the column-level default (atomic in Postgres for the
+  ADD COLUMN ... DEFAULT path; no separate UPDATE pass needed).
+- `CHECK (identity_hash_version >= 1)`. Prevents accidental zero-or-negative
+  versions from sneaking in through a future buggy writer.
+
+Downgrade-safety: dropping the column is reversible; the data loss is
+inherent and downgrade callers accept it. No indexes are added — the column
+is row-metadata, not a query predicate.
+
+Revision ID: progress_003
+Revises: progress_002
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "progress_003"
+down_revision = "progress_002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.add_column(
+            table,
+            sa.Column(
+                "identity_hash_version",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("1"),
+            ),
+        )
+        op.create_check_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            "identity_hash_version >= 1",
+        )
+
+
+def downgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.drop_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            type_="check",
+        )
+        op.drop_column(table, "identity_hash_version")

--- a/server/quire_server/api/ai.py
+++ b/server/quire_server/api/ai.py
@@ -411,6 +411,9 @@ async def sync_insights(
             BookInsight.id.label("ins_id"),
             BookInsight.metadata_id.label("ins_metadata_id"),
             BookInsight.content_hash.label("ins_content_hash"),
+            # Phase 0, task F-1: surface persisted identity-hash version
+            # to the client via the sync envelope.
+            BookInsight.identity_hash_version.label("ins_identity_hash_version"),
             BookInsight.model_id.label("ins_model_id"),
             BookInsight.prompt_version.label("ins_prompt_version"),
             BookInsight.tone.label("ins_tone"),
@@ -487,6 +490,7 @@ async def sync_insights(
             identity=DocumentIdentity(
                 metadata_id=r.ins_metadata_id,
                 content_hash=r.ins_content_hash,
+                identity_hash_version=r.ins_identity_hash_version,
             ),
             payload=BookInsightPayload.model_validate(r.ins_payload),
             sources=[Citation.model_validate(c) for c in (r.ins_sources or [])],

--- a/server/quire_server/api/ai_schemas.py
+++ b/server/quire_server/api/ai_schemas.py
@@ -221,6 +221,11 @@ class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str | None = None
 
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1` keeps
+    # pre-versioning clients compatible; the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
+
     # Alias hints (PR2). All optional. The resolver maps them to a
     # canonical via insight_identity_aliases when present.
     opds_href: str | None = None
@@ -373,6 +378,12 @@ class BookInsightResponse(BaseModel):
     model_id: str
     prompt_version: str
     generated_at: str  # ISO-8601
+    # Phase 0, task F-1: identity-hash algorithm version of the persisted
+    # row this response represents. Clients use this to decide whether to
+    # recompute their local hash on the next sync (when their computed
+    # version > N). Defaults to `1` for older serialized rows that
+    # pre-date the column.
+    identity_hash_version: int = 1
 
 
 class InsightLookupBody(BaseModel):

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -479,13 +479,17 @@ async def sync_library(
     existing_by_hash: dict[str, LibraryItem] = {}
     if hashes:
         existing_rows = (
-            await session.execute(
-                select(LibraryItem).where(
-                    LibraryItem.user_id == user_id,
-                    LibraryItem.content_hash.in_(hashes),
+            (
+                await session.execute(
+                    select(LibraryItem).where(
+                        LibraryItem.user_id == user_id,
+                        LibraryItem.content_hash.in_(hashes),
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         existing_by_hash = {r.content_hash: r for r in existing_rows}
 
     # Cross-row `metadata_id` conflict against an existing row that has a
@@ -497,13 +501,17 @@ async def sync_library(
     }
     if incoming_metadata_ids:
         conflict_rows = (
-            await session.execute(
-                select(LibraryItem).where(
-                    LibraryItem.user_id == user_id,
-                    LibraryItem.metadata_id.in_(incoming_metadata_ids.keys()),
+            (
+                await session.execute(
+                    select(LibraryItem).where(
+                        LibraryItem.user_id == user_id,
+                        LibraryItem.metadata_id.in_(incoming_metadata_ids.keys()),
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for conflict in conflict_rows:
             expected_hash = incoming_metadata_ids.get(conflict.metadata_id or "")
             if expected_hash is not None and conflict.content_hash != expected_hash:

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -61,6 +61,7 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
     return LibraryItemResponse(
         metadata_id=row.metadata_id,
         content_hash=row.content_hash,
+        identity_hash_version=row.identity_hash_version,
         title=row.title,
         authors=list(row.authors or []),
         series_name=row.series_name,
@@ -78,6 +79,11 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
 def _apply_payload(row: LibraryItem, payload: LibraryItemRequest) -> None:
     """Write payload fields onto `row`. Caller is responsible for timestamps."""
     row.metadata_id = payload.metadata_id
+    # Phase 0, task F-1: downgrade protection. An old client (sending the
+    # default `1`) MUST NOT overwrite a row whose hash version was advanced
+    # by a newer client. `max(existing, incoming)` is the load-bearing rule.
+    if payload.identity_hash_version > row.identity_hash_version:
+        row.identity_hash_version = payload.identity_hash_version
     row.title = payload.title
     row.authors = list(payload.authors)
     row.series_name = payload.series_name
@@ -134,6 +140,7 @@ async def put_item(
         row = LibraryItem(
             user_id=user_id,
             content_hash=payload.content_hash,
+            identity_hash_version=payload.identity_hash_version,
             title=payload.title,
             authors=list(payload.authors),
             metadata_id=payload.metadata_id,

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -26,6 +26,8 @@ does not cover this table.
 
 from __future__ import annotations
 
+import logging
+import time
 from datetime import UTC, datetime
 from typing import Annotated
 
@@ -41,9 +43,14 @@ from quire_server.api.library_schemas import (
     LibraryItemRequest,
     LibraryItemResponse,
     LibraryStatsResponse,
+    LibrarySyncEntry,
+    LibrarySyncRequest,
+    LibrarySyncStatus,
+    LibrarySyncSummary,
     TopAuthor,
     TopTheme,
 )
+from quire_server.config import Settings, get_settings
 from quire_server.core.auth import current_user_id
 from quire_server.db.models import (
     BookInsight,
@@ -53,6 +60,8 @@ from quire_server.db.models import (
     Progress,
 )
 from quire_server.db.session import get_session
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["library"])
 
@@ -238,6 +247,381 @@ async def delete_item(
         await session.refresh(row)
 
     return _to_response(row)
+
+
+# ---------------------------------------------------------------------------
+# POST /sync — Phase 0, task S-2: push-model bulk library mirror.
+# ---------------------------------------------------------------------------
+# The client is authoritative about its library and pushes a bag of
+# `{present, deleted}` entries here; the server upserts and never reaches
+# outward. Per spec section "Architectural changes → Push-model API" in
+# `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`, the
+# existing single-item PUT/GET/DELETE endpoints stay reachable unchanged
+# (deprecation window comes in a sibling task S-4, not here).
+#
+# Design contract:
+# - All-or-nothing per request. Validation conflicts (`422`) and existing-row
+#   metadata_id conflicts (`409`) abort the whole batch with no partial
+#   commit. Per-entry partial success would require savepoints around every
+#   row and a far more complex client contract; v1 keeps it simple.
+# - Idempotent on replay. A `present` entry whose persisted row already
+#   matches every field is skipped, NOT rewritten — bumping `updated_at`
+#   on every replay would flood `GET /library/v1/items?since=` with the
+#   entire library on every sync cycle.
+# - `last_seen_at` is wire-only in v1: validated tz-aware, never stored
+#   (no column exists). The architect-flagged footgun was using a client
+#   clock as a server cursor; the server's own `updated_at` is the only
+#   trustworthy delta source.
+# - Missing entries are NEVER auto-deleted. Tombstones travel via an
+#   explicit `status=deleted` command. A tombstone command for an unknown
+#   `content_hash` is counted as `missing_deleted` and otherwise ignored.
+# ---------------------------------------------------------------------------
+
+
+# Fields whose values participate in the "row already matches" diff for a
+# `present` entry. Order doesn't matter for set membership but does matter
+# for list-valued comparisons (authors order is meaningful — `[Smith, Doe]`
+# is a different shelf face than `[Doe, Smith]`).
+_DIFF_FIELDS: tuple[str, ...] = (
+    "metadata_id",
+    "title",
+    "authors",
+    "series_name",
+    "series_index",
+    "isbn",
+    "language",
+    "subjects",
+    "opds_href",
+)
+
+
+def _entry_to_payload(entry: LibrarySyncEntry) -> dict[str, object]:
+    """Materialize a `present` sync entry into the field dict used for diff/apply.
+
+    Centralises the "missing optional field → empty default" rule. Sync is
+    full-replace semantics: an entry that omits `authors` is asserting "no
+    authors", same as the existing PUT endpoint. Bulk sync MUST NOT
+    diverge from per-item PUT on this rule.
+    """
+    return {
+        "metadata_id": entry.metadata_id,
+        "title": entry.title or "",
+        "authors": list(entry.authors),
+        "series_name": entry.series_name,
+        "series_index": entry.series_index,
+        "isbn": entry.isbn,
+        "language": entry.language,
+        "subjects": list(entry.subjects),
+        "opds_href": entry.opds_href,
+    }
+
+
+def _row_matches_payload(row: LibraryItem, payload: dict[str, object]) -> bool:
+    """True if every diff field on `row` already equals `payload`.
+
+    The `identity_hash_version` is deliberately NOT compared here — it has
+    its own `max(existing, incoming)` rule applied separately, and a
+    client sending the same value as the existing row is the common case
+    we want to skip.
+    """
+    for f in _DIFF_FIELDS:
+        existing = getattr(row, f)
+        incoming = payload[f]
+        # JSONB fields (authors/subjects) come back from SQLAlchemy as
+        # plain Python lists; the in-memory comparison is reliable.
+        # Numeric (series_index) is tricky: a Decimal('1.0') and
+        # Decimal('1.00') are equal under `==` (Decimal compares by
+        # value, not representation), but Decimal('1') != int(1) under
+        # `is`; the broad `!=` here covers both with Decimal semantics.
+        if existing != incoming:
+            return False
+    return True
+
+
+def _apply_sync_payload(
+    row: LibraryItem, entry: LibrarySyncEntry, payload: dict[str, object]
+) -> None:
+    """Write a `present` sync entry's fields onto an existing row.
+
+    Mirrors `_apply_payload` (the PUT path) but takes the pre-built
+    payload dict to avoid re-materializing. Downgrade-protection on
+    `identity_hash_version` is identical to the PUT path — the load-
+    bearing `max(existing, incoming)` rule from F-1 stays intact.
+    """
+    if entry.identity_hash_version > row.identity_hash_version:
+        row.identity_hash_version = entry.identity_hash_version
+    row.metadata_id = payload["metadata_id"]  # type: ignore[assignment]
+    row.title = payload["title"]  # type: ignore[assignment]
+    row.authors = payload["authors"]  # type: ignore[assignment]
+    row.series_name = payload["series_name"]  # type: ignore[assignment]
+    row.series_index = payload["series_index"]  # type: ignore[assignment]
+    row.isbn = payload["isbn"]  # type: ignore[assignment]
+    row.language = payload["language"]  # type: ignore[assignment]
+    row.subjects = payload["subjects"]  # type: ignore[assignment]
+    row.opds_href = payload["opds_href"]  # type: ignore[assignment]
+
+
+def _dedupe_entries(entries: list[LibrarySyncEntry]) -> list[LibrarySyncEntry]:
+    """Collapse intra-payload duplicates by `content_hash`.
+
+    Architect-flagged footgun: Postgres `ON CONFLICT DO UPDATE` blows up
+    when one INSERT batch touches the same key twice. We don't use raw
+    UPSERT — we do select+merge in the ORM — but the same logical
+    problem applies: a row updated twice in one transaction gets the
+    last writer's payload non-deterministically.
+
+    Rules:
+    - If all fields match exactly (post `identity_hash_version` maxing),
+      collapse silently. This is the "the client emitted the same entry
+      twice in one sync" benign case.
+    - Otherwise, raise — duplicate `content_hash` with conflicting
+      `status` or different metadata is a client bug and the safest
+      response is rejection rather than picking a winner.
+    """
+    by_hash: dict[str, LibrarySyncEntry] = {}
+    for e in entries:
+        prev = by_hash.get(e.content_hash)
+        if prev is None:
+            by_hash[e.content_hash] = e
+            continue
+        if prev.status != e.status:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={
+                    "error": "duplicate_content_hash_conflict",
+                    "content_hash": e.content_hash,
+                    "reason": "conflicting status values",
+                },
+            )
+        # Compare all wire fields except `identity_hash_version` (max-merge)
+        # and `last_seen_at` (wire-only, never durable). Anything else
+        # diverging means the client emitted two conflicting truths.
+        prev_payload = _entry_to_payload(prev) if prev.status is LibrarySyncStatus.PRESENT else {}
+        curr_payload = _entry_to_payload(e) if e.status is LibrarySyncStatus.PRESENT else {}
+        if prev_payload != curr_payload:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={
+                    "error": "duplicate_content_hash_conflict",
+                    "content_hash": e.content_hash,
+                    "reason": "conflicting metadata across duplicate entries",
+                },
+            )
+        # Identical entries (modulo hash version): keep the max version.
+        if e.identity_hash_version > prev.identity_hash_version:
+            by_hash[e.content_hash] = e
+    return list(by_hash.values())
+
+
+def _check_intra_payload_metadata_collisions(entries: list[LibrarySyncEntry]) -> None:
+    """Reject payloads that internally claim one `metadata_id` for two books.
+
+    Maps `metadata_id -> first content_hash that claimed it`. A second
+    entry with the same `metadata_id` and a DIFFERENT `content_hash`
+    means the client is internally inconsistent: per the existing PUT
+    semantics (and the partial unique index
+    `uq_library_items_user_metadata`), one `metadata_id` belongs to one
+    book per user. PR2 will introduce identity-aliases to reconcile
+    these; until then, surface as `422` rather than letting one of the
+    INSERTs blow up with a Postgres unique-violation midway through the
+    batch.
+    """
+    claimants: dict[str, str] = {}
+    for e in entries:
+        if e.status is LibrarySyncStatus.DELETED:
+            continue  # tombstones don't carry a binding metadata_id
+        if e.metadata_id is None:
+            continue
+        prior = claimants.get(e.metadata_id)
+        if prior is not None and prior != e.content_hash:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={
+                    "error": "metadata_id_collision_in_payload",
+                    "metadata_id": e.metadata_id,
+                    "content_hashes": sorted({prior, e.content_hash}),
+                },
+            )
+        claimants[e.metadata_id] = e.content_hash
+
+
+@router.post("/sync", response_model=LibrarySyncSummary)
+async def sync_library(
+    body: LibrarySyncRequest,
+    user_id: Annotated[str, Depends(current_user_id)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> LibrarySyncSummary:
+    received = len(body.items)
+    t0 = time.monotonic()
+    now = datetime.now(UTC)
+
+    # Bounded payload. The RequestSizeMiddleware already enforces a byte
+    # ceiling (`max_request_bytes`); this guards the parsed-entry count
+    # so a tightly-packed but valid body can't blow past Postgres bind-
+    # parameter ceilings or balloon one transaction.
+    if received > settings.library_sync_max_items:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "too_many_items",
+                "limit": settings.library_sync_max_items,
+                "received": received,
+            },
+        )
+
+    # ---- Preflight (all checks abort the batch before any DB writes) ----
+    entries = _dedupe_entries(list(body.items))
+    _check_intra_payload_metadata_collisions(entries)
+
+    # Bulk-fetch all rows this batch touches in a single SELECT.
+    hashes = [e.content_hash for e in entries]
+    existing_by_hash: dict[str, LibraryItem] = {}
+    if hashes:
+        existing_rows = (
+            await session.execute(
+                select(LibraryItem).where(
+                    LibraryItem.user_id == user_id,
+                    LibraryItem.content_hash.in_(hashes),
+                )
+            )
+        ).scalars().all()
+        existing_by_hash = {r.content_hash: r for r in existing_rows}
+
+    # Cross-row `metadata_id` conflict against an existing row that has a
+    # DIFFERENT `content_hash`. Mirror the per-item PUT's 409 contract.
+    incoming_metadata_ids = {
+        e.metadata_id: e.content_hash
+        for e in entries
+        if e.status is LibrarySyncStatus.PRESENT and e.metadata_id is not None
+    }
+    if incoming_metadata_ids:
+        conflict_rows = (
+            await session.execute(
+                select(LibraryItem).where(
+                    LibraryItem.user_id == user_id,
+                    LibraryItem.metadata_id.in_(incoming_metadata_ids.keys()),
+                )
+            )
+        ).scalars().all()
+        for conflict in conflict_rows:
+            expected_hash = incoming_metadata_ids.get(conflict.metadata_id or "")
+            if expected_hash is not None and conflict.content_hash != expected_hash:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "error": "metadata_id_conflict",
+                        "metadata_id": conflict.metadata_id,
+                        "existing_content_hash": conflict.content_hash,
+                        "incoming_content_hash": expected_hash,
+                    },
+                )
+
+    # ---- Apply ----
+    created = updated = reactivated = deleted = skipped = missing_deleted = 0
+
+    for entry in entries:
+        existing = existing_by_hash.get(entry.content_hash)
+
+        if entry.status is LibrarySyncStatus.DELETED:
+            if existing is None:
+                # Architect rule: don't materialize tombstones for rows the
+                # server has never seen. Count and move on.
+                missing_deleted += 1
+                continue
+            if existing.deleted_at is not None:
+                # Already tombstoned. Preserve timestamps to avoid the
+                # `?since=` re-delivery bug documented on `delete_item`.
+                skipped += 1
+                continue
+            existing.deleted_at = now
+            existing.updated_at = now
+            # Downgrade-protected version bump still applies on delete:
+            # a newer client noticing a deletion shouldn't downgrade the
+            # row's version metadata.
+            if entry.identity_hash_version > existing.identity_hash_version:
+                existing.identity_hash_version = entry.identity_hash_version
+            deleted += 1
+            continue
+
+        # status == PRESENT
+        payload = _entry_to_payload(entry)
+        if existing is None:
+            row = LibraryItem(
+                user_id=user_id,
+                content_hash=entry.content_hash,
+                identity_hash_version=entry.identity_hash_version,
+                metadata_id=payload["metadata_id"],
+                title=payload["title"],
+                authors=payload["authors"],
+                series_name=payload["series_name"],
+                series_index=payload["series_index"],
+                isbn=payload["isbn"],
+                language=payload["language"],
+                subjects=payload["subjects"],
+                opds_href=payload["opds_href"],
+                created_at=now,
+                updated_at=now,
+                deleted_at=None,
+            )
+            session.add(row)
+            created += 1
+            continue
+
+        if existing.deleted_at is not None:
+            # Tombstoned → reactivate. Always counts as a write (timestamps
+            # change); diff-skip doesn't apply because the deleted_at
+            # transition is itself state-changing.
+            _apply_sync_payload(existing, entry, payload)
+            existing.deleted_at = None
+            existing.updated_at = now
+            reactivated += 1
+            continue
+
+        # Existing alive row. Diff-skip if and only if nothing meaningful
+        # changes — including the hash version (clients sending the same
+        # value as persisted shouldn't move `updated_at`).
+        version_would_change = entry.identity_hash_version > existing.identity_hash_version
+        if not version_would_change and _row_matches_payload(existing, payload):
+            skipped += 1
+            continue
+
+        _apply_sync_payload(existing, entry, payload)
+        existing.updated_at = now
+        updated += 1
+
+    await session.commit()
+
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    # One aggregate log line per request — per-entry logging at this scale
+    # is noise. `extra` fields land in structured-log adapters when
+    # configured; the f-string keeps human-readable plain-text logs sane.
+    logger.info(
+        "library_sync user_id=%s received=%d processed=%d created=%d updated=%d "
+        "reactivated=%d deleted=%d skipped=%d missing_deleted=%d duration_ms=%d",
+        user_id,
+        received,
+        len(entries),
+        created,
+        updated,
+        reactivated,
+        deleted,
+        skipped,
+        missing_deleted,
+        duration_ms,
+    )
+
+    return LibrarySyncSummary(
+        received=received,
+        processed=len(entries),
+        created=created,
+        updated=updated,
+        reactivated=reactivated,
+        deleted=deleted,
+        skipped=skipped,
+        missing_deleted=missing_deleted,
+        server_time=now,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/server/quire_server/api/library_schemas.py
+++ b/server/quire_server/api/library_schemas.py
@@ -26,6 +26,11 @@ class LibraryItemRequest(BaseModel):
 
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1`
+    # accepts pre-versioning clients; the server's PUT path applies
+    # `max(existing, incoming)` so an old client cannot downgrade a row
+    # written by a newer client.
+    identity_hash_version: int = Field(default=1, ge=1)
     title: str
     authors: list[str] = Field(default_factory=list)
     series_name: str | None = None
@@ -47,6 +52,12 @@ class LibraryItemIdentity(BaseModel):
     """The identity sub-object inside a DELETE body."""
 
     content_hash: str
+    # Phase 0, task F-1: optional on DELETE. The current matcher keys
+    # exclusively on `content_hash` so the field is accepted but not used
+    # for row selection — clients can already locate a row by hash alone.
+    # Once a real hash-version migration happens this field becomes the
+    # tiebreaker for delete semantics.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class LibraryItemDeleteBody(BaseModel):
@@ -58,6 +69,10 @@ class LibraryItemResponse(BaseModel):
 
     metadata_id: str | None
     content_hash: str
+    # Phase 0, task F-1: always emitted from server, so clients can detect
+    # the row's persisted hash-algorithm version and trigger recompute on
+    # next sync when their computed-version > N.
+    identity_hash_version: int
     title: str
     authors: list[str]
     series_name: str | None

--- a/server/quire_server/api/library_schemas.py
+++ b/server/quire_server/api/library_schemas.py
@@ -1,4 +1,4 @@
-"""Pydantic schemas for `/library/v1/items`.
+"""Pydantic schemas for `/library/v1/items` and `/library/v1/sync`.
 
 Identity travels in the JSON body, never the path (URL-encoded sha256s are a
 footgun). Wrapping each request under `{"item": {...}}` keeps the door open
@@ -7,18 +7,23 @@ for a future bulk endpoint shaped `{"items": [...]}` without breaking clients.
 Request and response shapes are intentionally distinct so they can evolve
 independently:
 
-- `LibraryItemRequest` is what the client sends. Server timestamps are
-  forbidden here.
+- `LibraryItemRequest` is what the client sends to PUT. Server timestamps
+  are forbidden here.
 - `LibraryItemResponse` is what the server returns. Always includes
   `created_at`, `updated_at`, and (possibly null) `deleted_at`.
+- `LibrarySyncRequest`/`LibrarySyncEntry` model the bulk push surface
+  introduced by Phase 0 task S-2. Each entry is one of two shapes
+  discriminated by `status`: a `present` entry carries metadata, a
+  `deleted` entry carries identity only.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 from decimal import Decimal
+from enum import StrEnum
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
 
 class LibraryItemRequest(BaseModel):
@@ -165,3 +170,167 @@ class LibraryStatsResponse(BaseModel):
     top_authors: list[TopAuthor]
     top_themes: list[TopTheme]
     themes_caveat: str
+
+
+# ---------------------------------------------------------------------------
+# Phase 0, task S-2 — `POST /library/v1/sync` bulk push.
+# ---------------------------------------------------------------------------
+# The push-model API per the monetization design spec
+# (`docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+# "Architectural changes → Push-model API"). The client is authoritative
+# about its library and pushes a bag of {present, deleted} entries here;
+# the server upserts and never reaches outward.
+#
+# Two intentional asymmetries vs `/library/v1/items` (PUT):
+#   1. NO `item` wrapper — bulk responses lead with `items:` already, and a
+#      `{"items": [...]}` body is idiomatic. This is the same shape the
+#      original PUT module-docstring anticipated.
+#   2. Two-shape discriminated entry: `status="present"` carries metadata
+#      and behaves like the existing PUT upsert; `status="deleted"`
+#      carries identity only and tombstones an existing row (idempotent).
+#
+# Absent entries are NEVER auto-deleted in v1 — the spec's "Entries not
+# present in this push are NOT auto-deleted" rule. Clients send an explicit
+# tombstone command to delete.
+
+
+class LibrarySyncStatus(StrEnum):
+    """Lifecycle status carried on each sync entry.
+
+    Deliberately narrow — `present` and `deleted` are the only states this
+    table durably represents. Reading lifecycle (in-progress, finished,
+    abandoned) lives in the `progress` table and reaches the server via
+    `/sync/v1/progress`, not here.
+    """
+
+    PRESENT = "present"
+    DELETED = "deleted"
+
+
+class LibrarySyncEntry(BaseModel):
+    """One book in a `POST /library/v1/sync` request.
+
+    Validation is status-aware (see `_check_present_requires_title`). For
+    `status=deleted`, only `content_hash` (plus the optional
+    `identity_hash_version` / `last_seen_at`) is meaningful; metadata fields
+    are accepted but ignored. For `status=present`, `title` is required
+    (matches the `LibraryItem.title` NOT-NULL column).
+    """
+
+    # Identity (the only required field across both statuses).
+    content_hash: str = Field(min_length=1)
+
+    # Phase 0, task F-1: identity-hash algorithm version. Defaults to 1 so
+    # pre-versioning clients round-trip. The sync handler applies
+    # `max(existing, incoming)` on upsert — an old client can never
+    # downgrade a row written by a newer client.
+    identity_hash_version: int = Field(default=1, ge=1)
+
+    # Lifecycle status — defaults to `present` so a minimal payload
+    # `{"content_hash": "..."}` is interpreted as "this book exists,
+    # treat metadata as unset/empty".
+    status: LibrarySyncStatus = LibrarySyncStatus.PRESENT
+
+    # Client-supplied freshness signal. The spec calls this out on the
+    # wire. THIS IS NOT WRITTEN TO THE DATABASE in this PR (no column
+    # exists; adding one is a deliberately separate change). The handler
+    # validates it (tz-aware ISO-8601) and ignores it. The field is
+    # surfaced so future server features (per-book TTL, stale-detection)
+    # can adopt it without a wire-protocol change.
+    last_seen_at: datetime | None = None
+
+    # Metadata block — optional on the wire but `title` becomes required
+    # for `present` entries via the model validator below.
+    metadata_id: str | None = None
+    title: str | None = None
+    authors: list[str] = Field(default_factory=list)
+    series_name: str | None = None
+    series_index: Decimal | None = None
+    isbn: str | None = None
+    language: str | None = None
+    subjects: list[str] = Field(default_factory=list)
+    opds_href: str | None = None
+
+    @field_validator("last_seen_at")
+    @classmethod
+    def _last_seen_at_must_be_aware(cls, v: datetime | None) -> datetime | None:
+        """Reject naive datetimes.
+
+        Server-side timestamp arithmetic assumes UTC. Accepting a naive
+        timestamp here would let a misconfigured client poison future
+        comparisons silently. Pydantic v2's default ISO-8601 parser keeps
+        the original tzinfo, so we can detect naive values explicitly.
+        """
+        if v is not None and v.tzinfo is None:
+            raise ValueError(
+                "last_seen_at must be timezone-aware (e.g. ISO-8601 with 'Z' or +HH:MM)"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _check_present_requires_title(self) -> LibrarySyncEntry:
+        """`present` entries need a title; `deleted` entries do not.
+
+        The underlying `library_items.title` column is NOT NULL. The PUT
+        endpoint enforces this implicitly via Pydantic — `title: str`.
+        Sync makes it optional at the field level so deletions don't need
+        bogus metadata, then re-asserts the constraint here for `present`.
+        """
+        if self.status is LibrarySyncStatus.PRESENT and not (self.title and self.title.strip()):
+            raise ValueError("title is required when status='present'")
+        return self
+
+
+class LibrarySyncRequest(BaseModel):
+    """Body of `POST /library/v1/sync`.
+
+    Empty `items` is valid (the client telling the server "I've seen
+    nothing new this cycle" is a legitimate no-op heartbeat).
+    """
+
+    items: list[LibrarySyncEntry] = Field(default_factory=list)
+
+
+class LibrarySyncSummary(BaseModel):
+    """Response body of `POST /library/v1/sync` — counts plus server time.
+
+    The handler returns counts, not per-row diffs. For 500 entries a
+    per-row response is wasted bytes (the client trusts the counts; if it
+    wants per-row state it calls `GET /library/v1/items?since=`).
+    """
+
+    # Raw count of entries in the request body, pre-dedup. Useful to
+    # confirm the client and server agree on what was sent.
+    received: int
+    # Entries the server actually inspected, post intra-payload dedupe
+    # (`processed <= received`).
+    processed: int
+    # New rows inserted.
+    created: int
+    # Existing alive rows whose persisted fields changed.
+    updated: int
+    # Existing tombstoned rows that were brought back to life via a
+    # `present` entry — a write-amplification metric that helps the
+    # client understand churn.
+    reactivated: int
+    # Existing alive rows transitioned to tombstone via `status=deleted`.
+    deleted: int
+    # Entries that produced no DB change. Either:
+    #   - `present` for a row whose persisted fields already match
+    #     (no-op replay), or
+    #   - `deleted` for an already-tombstoned row (preserves timestamps so
+    #     `?since=` doesn't re-deliver the same tombstone forever).
+    skipped: int
+    # `deleted` entries that referenced a `content_hash` the server has
+    # never seen for this user. Counted, not failed — the server is not
+    # the source of truth for what the client believes it deleted, and a
+    # stale tombstone command is harmless.
+    missing_deleted: int
+    # Wall-clock from BEFORE the writes. Same cursor shape as the
+    # existing `GET ?since=` endpoint — clients use this as the next
+    # delta-fetch cursor.
+    server_time: datetime
+
+    @field_serializer("server_time")
+    def _serialize_server_time(self, v: datetime) -> str:
+        return _iso(v)

--- a/server/quire_server/api/progress.py
+++ b/server/quire_server/api/progress.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, Field, field_serializer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,11 @@ router = APIRouter(tags=["progress"])
 class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version travelling on the
+    # wire. Default `1` keeps old clients (pre-versioning) round-trippable;
+    # new clients send their own value and the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class ProgressItem(BaseModel):
@@ -102,6 +107,10 @@ async def _resolve_or_create_document(
             )
         ).scalar_one_or_none()
         if existing:
+            # Phase 0, task F-1: downgrade protection. An old client (sending
+            # `1`) MUST NOT overwrite a row written by a newer client.
+            if ident.identity_hash_version > existing.identity_hash_version:
+                existing.identity_hash_version = ident.identity_hash_version
             return existing
     existing = (
         await session.execute(
@@ -114,8 +123,16 @@ async def _resolve_or_create_document(
         # Backfill metadata_id if we just learned it
         if ident.metadata_id and existing.metadata_id is None:
             existing.metadata_id = ident.metadata_id
+        # Phase 0, task F-1: downgrade protection (see above).
+        if ident.identity_hash_version > existing.identity_hash_version:
+            existing.identity_hash_version = ident.identity_hash_version
         return existing
-    doc = Document(user_id=user_id, metadata_id=ident.metadata_id, content_hash=ident.content_hash)
+    doc = Document(
+        user_id=user_id,
+        metadata_id=ident.metadata_id,
+        content_hash=ident.content_hash,
+        identity_hash_version=ident.identity_hash_version,
+    )
     session.add(doc)
     await session.flush()  # populate doc.pk
     return doc
@@ -130,6 +147,14 @@ async def push_progress(
     results: list[ProgressPushResult] = []
     for item in body.items:
         doc = await _resolve_or_create_document(session, user_id, item.document)
+        # Phase 0, task F-1: the result echoes the persisted Document's
+        # identity_hash_version (which may be >= the incoming one after the
+        # downgrade-protection logic in _resolve_or_create_document).
+        persisted_identity = DocumentIdentity(
+            metadata_id=doc.metadata_id,
+            content_hash=doc.content_hash,
+            identity_hash_version=doc.identity_hash_version,
+        )
         existing = (
             await session.execute(select(Progress).where(Progress.document_pk == doc.pk))
         ).scalar_one_or_none()
@@ -158,7 +183,7 @@ async def push_progress(
             )
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -172,7 +197,7 @@ async def push_progress(
             existing.abandoned_at = abandoned_at
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -180,7 +205,7 @@ async def push_progress(
         else:
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="stale",
                     server_client_updated_at=existing.client_updated_at,
                 )
@@ -223,7 +248,11 @@ async def pull_progress(
             effective_abandoned_at = None
         items.append(
             ProgressPullItem(
-                document=DocumentIdentity(metadata_id=d.metadata_id, content_hash=d.content_hash),
+                document=DocumentIdentity(
+                    metadata_id=d.metadata_id,
+                    content_hash=d.content_hash,
+                    identity_hash_version=d.identity_hash_version,
+                ),
                 locator=p.locator,
                 percent=p.percent,
                 client_updated_at=p.client_updated_at,

--- a/server/quire_server/config.py
+++ b/server/quire_server/config.py
@@ -29,6 +29,15 @@ class Settings(BaseSettings):
     # Enforced by RequestSizeMiddleware; oversized requests get 413.
     max_request_bytes: int = 1_048_576
 
+    # Phase 0, task S-2: hard cap on the number of entries `POST
+    # /library/v1/sync` will accept in a single request. Middleware
+    # already enforces a byte ceiling (max_request_bytes); this guards the
+    # parsed-entry count so a tightly-packed but valid payload can't blow
+    # past Postgres bind-parameter ceilings or balloon a single transaction.
+    # Conservative default; raise once we have data on real Android-side
+    # library sizes.
+    library_sync_max_items: int = 500
+
     # AI substrate (Phase 1). Default flipped from False → True in PR-A so the
     # full-stack mode is the documented default. Existing prod deployments
     # already set QUIRE_SERVER_AI_ENABLED=true explicitly, so this flip is

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -2248,9 +2248,7 @@ def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
 
 
-def _maybe_upgrade_identity_hash_version(
-    row: BookInsight, ident: DocumentIdentity
-) -> None:
+def _maybe_upgrade_identity_hash_version(row: BookInsight, ident: DocumentIdentity) -> None:
     """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
     identity-hash version on a cache-hit.
 

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -664,6 +664,10 @@ class InsightOrchestrator:
         row = BookInsight(
             metadata_id=ident.metadata_id,
             content_hash=effective_content_hash,
+            # Phase 0, task F-1: persist the incoming identity-hash version
+            # so future reads return the correct level. Defaults to `1` for
+            # pre-versioning clients.
+            identity_hash_version=getattr(ident, "identity_hash_version", 1),
             model_id=self.model_id,
             prompt_version=self.prompt_version,
             tone=tone,
@@ -857,6 +861,7 @@ class InsightOrchestrator:
                 )
             ).scalar_one_or_none()
             if row is not None:
+                _maybe_upgrade_identity_hash_version(row, ident)
                 return row
         # Step 2: by content_hash (live rows only)
         if not ident.content_hash:
@@ -875,6 +880,10 @@ class InsightOrchestrator:
         ).scalar_one_or_none()
         if row is None:
             return None
+        # Phase 0, task F-1: upgrade the row's identity_hash_version if the
+        # incoming identity is newer. Same downgrade-protection rule as
+        # Document/LibraryItem: max(existing, incoming).
+        _maybe_upgrade_identity_hash_version(row, ident)
         # Alias reconciliation: backfill metadata_id if we just learned it.
         if allow_backfill and ident.metadata_id and row.metadata_id is None:
             row.metadata_id = ident.metadata_id
@@ -1174,6 +1183,13 @@ class InsightOrchestrator:
         new_row = BookInsight(
             metadata_id=to_identity.metadata_id,
             content_hash=to_identity.content_hash or src_row.content_hash,
+            # Phase 0, task F-1: the copied row takes the maximum of the
+            # source row's version and the destination identity's version
+            # so a v2 destination promoted from a v1 source persists as v2.
+            identity_hash_version=max(
+                src_row.identity_hash_version,
+                getattr(to_identity, "identity_hash_version", 1),
+            ),
             model_id=src_row.model_id,
             prompt_version=src_row.prompt_version,
             tone=src_row.tone,
@@ -2213,6 +2229,10 @@ class InsightOrchestrator:
             model_id=row.model_id,
             prompt_version=row.prompt_version,
             generated_at=row.generated_at.isoformat(),
+            # Phase 0, task F-1: surface the persisted identity-hash version
+            # so clients can detect rows produced under an older algorithm
+            # and trigger their own recompute logic (F-2 territory).
+            identity_hash_version=row.identity_hash_version,
         )
 
 
@@ -2226,6 +2246,24 @@ def _tone_of(style: AiStyle | None) -> str:
 
 def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
+
+
+def _maybe_upgrade_identity_hash_version(
+    row: BookInsight, ident: DocumentIdentity
+) -> None:
+    """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
+    identity-hash version on a cache-hit.
+
+    Operates in-place on `row`. The surrounding transaction commits as
+    part of the normal cache-hit log write, so we do not flush here.
+
+    Defensive: ``ident.identity_hash_version`` is wire-side and defaults to
+    `1` when the client did not supply it (pre-versioning clients). The
+    `>` comparison therefore protects against accidental downgrades.
+    """
+    incoming = getattr(ident, "identity_hash_version", 1)
+    if incoming > row.identity_hash_version:
+        row.identity_hash_version = incoming
 
 
 # ---------- PR2 identity-resolution helpers ---------------------------------

--- a/server/quire_server/db/models.py
+++ b/server/quire_server/db/models.py
@@ -32,6 +32,10 @@ class Document(Base):
     __table_args__ = (
         UniqueConstraint("user_id", "metadata_id", name="uq_documents_user_metadata"),
         UniqueConstraint("user_id", "content_hash", name="uq_documents_user_content_hash"),
+        CheckConstraint(
+            "identity_hash_version >= 1",
+            name="ck_documents_identity_hash_version_ge_1",
+        ),
         Index("ix_documents_user", "user_id"),
     )
 
@@ -39,6 +43,15 @@ class Document(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1 (one-way-door per 2026-05-22 monetization spec):
+    # version of the identity-hash algorithm used to derive `content_hash`.
+    # Persisted with every record so a future hash-function change does not
+    # break sync/cache/recs/export/deletion across millions of rows. Always
+    # >= 1; current rows backfill to 1 in migration `progress_003`. Clients
+    # reading vN rows recompute on next sync when their algorithm > N.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -108,6 +121,14 @@ class BookInsight(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version. NOT part of the
+    # cache key (see architect decision in Phase 0 plan): treated as row-
+    # freshness metadata only. A higher-version client hitting an existing
+    # cache row upgrades the persisted value via max(existing, incoming).
+    # CHECK constraint lives in migration `ai_007`.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     model_id: Mapped[str] = mapped_column(String, nullable=False)
     prompt_version: Mapped[str] = mapped_column(String, nullable=False)
     # Part of the cache key so users with different AiStyle.tone get their own
@@ -349,6 +370,13 @@ class LibraryItem(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version (see Document for
+    # full rationale). The CHECK constraint is declared in the alembic
+    # migration `progress_003` because partial-index-style metadata for
+    # this table lives there.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     authors: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,11 +29,12 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # ai branch is at ai_006 (pr-β added the audit-log generalization +
-    # profile_count column); the progress branch is at progress_002 (pr-α
-    # added abandoned_at). With the default-true mode flags, both branch
-    # heads are reported, sorted.
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`); the progress branch is at
+    # progress_003 (same task, added `identity_hash_version` to
+    # `documents` + `library_items`). With the default-true mode flags,
+    # both branch heads are reported, sorted.
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_library_items.py
+++ b/server/tests/integration/test_library_items.py
@@ -392,3 +392,87 @@ async def test_unauthenticated_request_rejected(app_under_test, unique_user):
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         r = await c.get("/library/v1/items")
     assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning on /library/v1/items.
+# ---------------------------------------------------------------------------
+# Three behaviours travel together:
+#   1. Default round-trip: omitting `identity_hash_version` in the PUT body
+#      persists as `1` and the GET response carries it.
+#   2. Explicit value round-trip: sending `identity_hash_version=2` persists
+#      `2` and the response/GET reflect it.
+#   3. Downgrade protection: after writing version `2`, a later PUT that
+#      defaults to `1` (or explicitly sends `1`) MUST keep the row at `2`.
+#      This is the `max(existing, incoming)` rule that prevents an old
+#      client from clobbering a newer client's row.
+
+
+async def test_identity_hash_version_defaults_to_1_when_absent(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 1
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.status_code == 200
+        items = r2.json()["items"]
+        assert len(items) == 1
+        assert items[0]["identity_hash_version"] == 1
+
+
+async def test_identity_hash_version_round_trips_explicit_value(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 2
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.json()["items"][0]["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_protects_against_downgrade(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Newer client writes v2.
+        r1 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r1.json()["identity_hash_version"] == 2
+
+        # Older client sends nothing (defaults to v1) — must NOT downgrade.
+        r2 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r2.status_code == 200
+        assert r2.json()["identity_hash_version"] == 2
+
+        # Explicit v1 must also not downgrade.
+        r3 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=1),
+            headers=headers,
+        )
+        assert r3.json()["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_rejects_zero(app_under_test, unique_user):
+    """Pydantic `ge=1` returns 422 for non-positive versions."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=0),
+            headers=headers,
+        )
+    assert r.status_code == 422, r.text

--- a/server/tests/integration/test_library_sync.py
+++ b/server/tests/integration/test_library_sync.py
@@ -1,0 +1,660 @@
+"""Integration tests for `POST /library/v1/sync` (Phase 0, task S-2).
+
+The bulk-push endpoint coexists with the existing per-item PUT/GET/DELETE.
+Tests here mirror the structure of `test_library_items.py` (same fixtures,
+same Basic-auth setup, same `unique_user` isolation strategy) so the two
+test files read together as one cohesive suite for `/library/v1/*`.
+
+Spec reference:
+`docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Push-model API" and "Build sequence
+→ Phase 0 item (2)".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.requires_progress
+
+
+def _basic(user: str, pw: str) -> dict[str, str]:
+    token = base64.b64encode(f"{user}:{pw}".encode()).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+@pytest.fixture
+def unique_user(cwa_users) -> tuple[str, str]:
+    user = f"user-{uuid.uuid4().hex[:8]}"
+    pw = "pw"
+    cwa_users[user] = pw
+    return user, pw
+
+
+def _entry(**overrides) -> dict:
+    """Build a `present` sync entry. Required-ish defaults match the PUT path."""
+    base = {
+        "content_hash": "ch-1",
+        "status": "present",
+        "metadata_id": "md-1",
+        "title": "Foundation",
+        "authors": ["Isaac Asimov"],
+        "series_name": "Foundation",
+        "series_index": 1,
+        "isbn": "9780553293357",
+        "language": "en",
+        "subjects": ["Science Fiction"],
+        "opds_href": "https://example/foundation.epub",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_happy_path_creates_multiple_books(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    payload = {
+        "items": [
+            _entry(content_hash=f"ch-{i}", metadata_id=f"md-{i}", title=f"Book {i}")
+            for i in range(3)
+        ]
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/library/v1/sync", json=payload, headers=headers)
+        assert r.status_code == 200, r.text
+        summary = r.json()
+        assert summary["received"] == 3
+        assert summary["processed"] == 3
+        assert summary["created"] == 3
+        assert summary["updated"] == 0
+        assert summary["reactivated"] == 0
+        assert summary["deleted"] == 0
+        assert summary["skipped"] == 0
+        assert summary["missing_deleted"] == 0
+        assert summary["server_time"]
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        items = r2.json()["items"]
+        assert len(items) == 3
+        assert {it["content_hash"] for it in items} == {"ch-0", "ch-1", "ch-2"}
+
+
+async def test_sync_idempotent_does_not_bump_updated_at(app_under_test, unique_user):
+    """Replay of an identical payload must not flood `?since=`.
+
+    The architect-flagged no-op-replay footgun: bumping `updated_at` on
+    every replay would deliver the whole library on the next delta sync
+    even when nothing changed.
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    payload = {"items": [_entry()]}
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r1 = await c.post("/library/v1/sync", json=payload, headers=headers)
+        assert r1.json()["created"] == 1
+
+        first_get = (await c.get("/library/v1/items", headers=headers)).json()
+        first_updated_at = first_get["items"][0]["updated_at"]
+
+        await asyncio.sleep(0.02)
+        r2 = await c.post("/library/v1/sync", json=payload, headers=headers)
+        assert r2.status_code == 200
+        summary = r2.json()
+        assert summary["created"] == 0
+        assert summary["updated"] == 0
+        assert summary["skipped"] == 1
+
+        second_get = (await c.get("/library/v1/items", headers=headers)).json()
+        assert second_get["items"][0]["updated_at"] == first_updated_at
+
+
+async def test_sync_partial_update_changes_one_field_bumps_updated(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post("/library/v1/sync", json={"items": [_entry()]}, headers=headers)
+        first = (await c.get("/library/v1/items", headers=headers)).json()["items"][0]
+
+        await asyncio.sleep(0.02)
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(title="Foundation (Revised)")]},
+            headers=headers,
+        )
+        assert r.json()["updated"] == 1
+        second = (await c.get("/library/v1/items", headers=headers)).json()["items"][0]
+        assert second["title"] == "Foundation (Revised)"
+        assert second["updated_at"] > first["updated_at"]
+
+
+async def test_sync_empty_items_is_noop(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/library/v1/sync", json={"items": []}, headers=headers)
+    assert r.status_code == 200
+    summary = r.json()
+    assert summary["received"] == 0
+    assert summary["processed"] == 0
+    assert summary["created"] == summary["updated"] == summary["deleted"] == 0
+
+
+# ---------------------------------------------------------------------------
+# identity_hash_version
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_identity_hash_version_round_trips(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(identity_hash_version=2)]},
+            headers=headers,
+        )
+        items = (await c.get("/library/v1/items", headers=headers)).json()["items"]
+    assert items[0]["identity_hash_version"] == 2
+
+
+async def test_sync_identity_hash_version_downgrade_protection(app_under_test, unique_user):
+    """v1 push after v2 must NOT downgrade — `max(existing, incoming)` rule."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Write v2.
+        await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(identity_hash_version=2)]},
+            headers=headers,
+        )
+        # Replay default (v1) — same payload otherwise. Must skip (no
+        # downgrade, no content change).
+        r = await c.post("/library/v1/sync", json={"items": [_entry()]}, headers=headers)
+        assert r.json()["skipped"] == 1
+        items = (await c.get("/library/v1/items", headers=headers)).json()["items"]
+    assert items[0]["identity_hash_version"] == 2
+
+
+async def test_sync_rejects_zero_identity_hash_version(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(identity_hash_version=0)]},
+            headers=headers,
+        )
+    assert r.status_code == 422, r.text
+
+
+# ---------------------------------------------------------------------------
+# Bounded payload
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_rejects_over_max_items(app_under_test, unique_user, monkeypatch):
+    """Lower the cap for the test to keep the payload small."""
+    from quire_server.api import library as library_mod
+
+    # Replace the dependency cleanly with a tiny limit. The dependency-
+    # override path on the app is simpler than reaching into Settings.
+    from quire_server.config import Settings, get_settings
+
+    def small_settings() -> Settings:
+        s = get_settings().model_copy()
+        s.library_sync_max_items = 2
+        return s
+
+    app_under_test.dependency_overrides[get_settings] = small_settings
+    try:
+        transport = ASGITransport(app=app_under_test)
+        headers = _basic(*unique_user)
+        payload = {
+            "items": [
+                _entry(content_hash=f"ch-{i}", metadata_id=f"md-{i}", title=f"Book {i}")
+                for i in range(3)  # 3 > limit=2
+            ]
+        }
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            r = await c.post("/library/v1/sync", json=payload, headers=headers)
+        assert r.status_code == 422
+        detail = r.json()["detail"]
+        assert detail["error"] == "too_many_items"
+        assert detail["limit"] == 2
+        assert detail["received"] == 3
+    finally:
+        app_under_test.dependency_overrides.pop(get_settings, None)
+        # Touching the unused alias keeps the linter from pruning the import
+        # if test layout changes later.
+        _ = library_mod  # noqa: F841
+
+
+# ---------------------------------------------------------------------------
+# Auth + isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_requires_auth(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/library/v1/sync", json={"items": [_entry()]})
+    assert r.status_code == 401
+
+
+async def test_sync_user_isolation(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry()]},
+            headers=_basic("alice", "alicepass"),
+        )
+        r = await c.get("/library/v1/items", headers=_basic("bob", "bobpass"))
+    assert r.status_code == 200
+    assert r.json()["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tombstone semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_status_deleted_tombstones_existing_row(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post("/library/v1/sync", json={"items": [_entry()]}, headers=headers)
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [{"content_hash": "ch-1", "status": "deleted"}]},
+            headers=headers,
+        )
+        assert r.status_code == 200
+        assert r.json()["deleted"] == 1
+
+        # No `since` → tombstones omitted, alive set is empty.
+        alive = (await c.get("/library/v1/items", headers=headers)).json()
+        assert alive["items"] == []
+
+        # `since=epoch` → tombstone delivered.
+        with_tombs = await c.get(
+            "/library/v1/items?since=1970-01-01T00%3A00%3A00%2B00%3A00",
+            headers=headers,
+        )
+        items = with_tombs.json()["items"]
+        assert len(items) == 1
+        assert items[0]["deleted_at"] is not None
+
+
+async def test_sync_status_deleted_for_unknown_is_skipped(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [{"content_hash": "never-seen", "status": "deleted"}]},
+            headers=headers,
+        )
+        assert r.status_code == 200
+        summary = r.json()
+        assert summary["missing_deleted"] == 1
+        assert summary["deleted"] == 0
+
+        # No phantom row was created.
+        with_tombs = await c.get(
+            "/library/v1/items?since=1970-01-01T00%3A00%3A00%2B00%3A00",
+            headers=headers,
+        )
+        assert with_tombs.json()["items"] == []
+
+
+async def test_sync_repeat_delete_is_idempotent_and_preserves_timestamps(
+    app_under_test, unique_user
+):
+    """A second `status=deleted` for an already-tombstoned row must NOT
+    bump `updated_at` (would re-deliver the tombstone forever on
+    `?since=`)."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post("/library/v1/sync", json={"items": [_entry()]}, headers=headers)
+        await c.post(
+            "/library/v1/sync",
+            json={"items": [{"content_hash": "ch-1", "status": "deleted"}]},
+            headers=headers,
+        )
+        snap = await c.get(
+            "/library/v1/items?since=1970-01-01T00%3A00%3A00%2B00%3A00",
+            headers=headers,
+        )
+        first_updated = snap.json()["items"][0]["updated_at"]
+
+        await asyncio.sleep(0.02)
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [{"content_hash": "ch-1", "status": "deleted"}]},
+            headers=headers,
+        )
+        assert r.json()["skipped"] == 1
+        assert r.json()["deleted"] == 0
+
+        snap2 = await c.get(
+            "/library/v1/items?since=1970-01-01T00%3A00%3A00%2B00%3A00",
+            headers=headers,
+        )
+    assert snap2.json()["items"][0]["updated_at"] == first_updated
+
+
+async def test_sync_deleted_then_present_reactivates(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post("/library/v1/sync", json={"items": [_entry()]}, headers=headers)
+        await c.post(
+            "/library/v1/sync",
+            json={"items": [{"content_hash": "ch-1", "status": "deleted"}]},
+            headers=headers,
+        )
+        r = await c.post("/library/v1/sync", json={"items": [_entry()]}, headers=headers)
+        assert r.status_code == 200
+        assert r.json()["reactivated"] == 1
+
+        alive = (await c.get("/library/v1/items", headers=headers)).json()["items"]
+    assert len(alive) == 1
+    assert alive[0]["deleted_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Intra-payload dedup & conflict detection
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_dedup_collapses_identical_duplicates(app_under_test, unique_user):
+    """Same content_hash listed twice, identical → treated as one entry."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(), _entry()]},
+            headers=headers,
+        )
+        assert r.status_code == 200
+        summary = r.json()
+        assert summary["received"] == 2
+        assert summary["processed"] == 1
+        assert summary["created"] == 1
+
+
+async def test_sync_dedup_rejects_conflicting_status_duplicates(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={
+                "items": [
+                    _entry(),
+                    {"content_hash": "ch-1", "status": "deleted"},
+                ]
+            },
+            headers=headers,
+        )
+    assert r.status_code == 422
+    assert r.json()["detail"]["error"] == "duplicate_content_hash_conflict"
+
+
+async def test_sync_dedup_rejects_conflicting_metadata_duplicates(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={
+                "items": [
+                    _entry(title="Title A"),
+                    _entry(title="Title B"),
+                ]
+            },
+            headers=headers,
+        )
+    assert r.status_code == 422
+    assert r.json()["detail"]["error"] == "duplicate_content_hash_conflict"
+
+
+async def test_sync_intra_payload_metadata_id_collision_rejected(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={
+                "items": [
+                    _entry(content_hash="ch-A", metadata_id="MD-X"),
+                    _entry(content_hash="ch-B", metadata_id="MD-X"),
+                ]
+            },
+            headers=headers,
+        )
+    assert r.status_code == 422
+    assert r.json()["detail"]["error"] == "metadata_id_collision_in_payload"
+
+
+# ---------------------------------------------------------------------------
+# Cross-row conflicts and atomicity
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_metadata_id_conflict_against_existing_row(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Seed row A with metadata_id=MD-X.
+        await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(content_hash="ch-A", metadata_id="MD-X")]},
+            headers=headers,
+        )
+        # Push a different content_hash claiming MD-X → 409.
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(content_hash="ch-B", metadata_id="MD-X")]},
+            headers=headers,
+        )
+    assert r.status_code == 409
+    detail = r.json()["detail"]
+    assert detail["error"] == "metadata_id_conflict"
+    assert detail["existing_content_hash"] == "ch-A"
+    assert detail["incoming_content_hash"] == "ch-B"
+
+
+async def test_sync_metadata_conflict_aborts_whole_batch_atomically(app_under_test, unique_user):
+    """A valid entry sharing a batch with a 409-triggering entry must NOT
+    commit. All-or-nothing per request."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Seed: ch-A holds MD-X.
+        await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(content_hash="ch-A", metadata_id="MD-X")]},
+            headers=headers,
+        )
+        # Batch: a fresh ch-C entry (would otherwise be created) + a
+        # conflict-triggering ch-B claiming MD-X.
+        r = await c.post(
+            "/library/v1/sync",
+            json={
+                "items": [
+                    _entry(content_hash="ch-C", metadata_id="MD-Y", title="Fresh"),
+                    _entry(content_hash="ch-B", metadata_id="MD-X", title="Conflict"),
+                ]
+            },
+            headers=headers,
+        )
+        assert r.status_code == 409
+        # Atomicity: ch-C must not have been committed.
+        items = (await c.get("/library/v1/items", headers=headers)).json()["items"]
+        hashes = {it["content_hash"] for it in items}
+        assert hashes == {"ch-A"}
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_present_without_title_rejected(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [{"content_hash": "ch-X", "status": "present"}]},
+            headers=headers,
+        )
+    assert r.status_code == 422
+
+
+async def test_sync_deleted_entry_without_title_accepted(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Seed first so the delete has something to act on.
+        await c.post("/library/v1/sync", json={"items": [_entry()]}, headers=headers)
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [{"content_hash": "ch-1", "status": "deleted"}]},
+            headers=headers,
+        )
+    assert r.status_code == 200
+    assert r.json()["deleted"] == 1
+
+
+async def test_sync_last_seen_at_naive_rejected(app_under_test, unique_user):
+    """A naive datetime would silently poison future comparisons — reject."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(last_seen_at="2026-05-22T10:00:00")]},  # no tz
+            headers=headers,
+        )
+    assert r.status_code == 422
+
+
+async def test_sync_last_seen_at_aware_accepted_but_not_durable(app_under_test, unique_user):
+    """An aware `last_seen_at` is accepted, validated, and dropped on the
+    server side (no column to persist into in v1)."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/library/v1/sync",
+            json={"items": [_entry(last_seen_at="2026-05-22T10:00:00+00:00")]},
+            headers=headers,
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["created"] == 1
+
+
+async def test_sync_missing_content_hash_rejected(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    payload = {"items": [_entry()]}
+    payload["items"][0].pop("content_hash")
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/library/v1/sync", json=payload, headers=headers)
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Coexistence with existing PUT/GET/DELETE
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_coexists_with_per_item_put(app_under_test, unique_user):
+    """A row created via PUT can be updated via sync, and vice versa.
+
+    The two endpoints share the same uniqueness contract on
+    `(user_id, content_hash)`; this test guards against drift between
+    them (e.g. a future change that gives sync its own table or its own
+    upsert semantics).
+    """
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # PUT-create.
+        r1 = await c.put(
+            "/library/v1/items",
+            json={"item": {
+                "content_hash": "ch-shared",
+                "metadata_id": "md-shared",
+                "title": "Via PUT",
+                "authors": ["Author"],
+            }},
+            headers=headers,
+        )
+        assert r1.status_code == 200
+
+        # Sync-update.
+        r2 = await c.post(
+            "/library/v1/sync",
+            json={
+                "items": [
+                    _entry(
+                        content_hash="ch-shared",
+                        metadata_id="md-shared",
+                        title="Via Sync",
+                    )
+                ]
+            },
+            headers=headers,
+        )
+        assert r2.status_code == 200
+        assert r2.json()["updated"] == 1
+
+        items = (await c.get("/library/v1/items", headers=headers)).json()["items"]
+        assert len(items) == 1
+        assert items[0]["title"] == "Via Sync"
+
+
+async def test_existing_per_item_endpoints_still_work(app_under_test, unique_user):
+    """Regression guard — the new endpoint must not have broken the
+    existing per-item flow."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json={"item": {
+                "content_hash": "ch-put",
+                "metadata_id": "md-put",
+                "title": "Put",
+                "authors": [],
+            }},
+            headers=headers,
+        )
+        assert r.status_code == 200
+        items = (await c.get("/library/v1/items", headers=headers)).json()["items"]
+        assert len(items) == 1
+        r2 = await c.request(
+            "DELETE",
+            "/library/v1/items",
+            json={"item": {"content_hash": "ch-put"}},
+            headers=headers,
+        )
+    assert r2.status_code == 200
+    assert r2.json()["deleted_at"] is not None

--- a/server/tests/integration/test_library_sync.py
+++ b/server/tests/integration/test_library_sync.py
@@ -599,12 +599,14 @@ async def test_sync_coexists_with_per_item_put(app_under_test, unique_user):
         # PUT-create.
         r1 = await c.put(
             "/library/v1/items",
-            json={"item": {
-                "content_hash": "ch-shared",
-                "metadata_id": "md-shared",
-                "title": "Via PUT",
-                "authors": ["Author"],
-            }},
+            json={
+                "item": {
+                    "content_hash": "ch-shared",
+                    "metadata_id": "md-shared",
+                    "title": "Via PUT",
+                    "authors": ["Author"],
+                }
+            },
             headers=headers,
         )
         assert r1.status_code == 200
@@ -639,12 +641,14 @@ async def test_existing_per_item_endpoints_still_work(app_under_test, unique_use
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         r = await c.put(
             "/library/v1/items",
-            json={"item": {
-                "content_hash": "ch-put",
-                "metadata_id": "md-put",
-                "title": "Put",
-                "authors": [],
-            }},
+            json={
+                "item": {
+                    "content_hash": "ch-put",
+                    "metadata_id": "md-put",
+                    "title": "Put",
+                    "authors": [],
+                }
+            },
             headers=headers,
         )
         assert r.status_code == 200

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -2,11 +2,11 @@
 
 Cases covered:
 1. Default state with real migrations: wrapper upgrades backbone + ai branch,
-   DB ends at ai@head (currently `ai_006`).
+   DB ends at ai@head (currently `ai_007`).
 2. Idempotent: running twice in a row is a no-op.
-3. Synthetic branched script directory (tmp copy of migrations + an ai_test_006
-   revision chained off the current ai@head):
-   - ai_enabled=true → upgrades to ai_test_006.
+3. Synthetic branched script directory (tmp copy of migrations + an
+   ai_test_008 revision chained off the current ai@head):
+   - ai_enabled=true → upgrades to ai_test_008.
    - ai_enabled=false → stays at 0004 (no ai branch applied).
 """
 
@@ -53,7 +53,7 @@ async def _downgrade_in_thread(cfg, target: str) -> None:
 
 
 async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str):
-    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_006)."""
+    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_007)."""
 
     # Wipe DB to fresh state.
     eng = create_async_engine(postgres_url, future=True)
@@ -66,9 +66,11 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch is at ai_006 (pr-β / Bundle 3 added the audit-log generalization
-    # + profile_count column). The progress branch is at progress_002.
-    assert versions == {"ai_006", "progress_002"}
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`). The progress branch is at
+    # progress_003 (same task, added the column to `documents` and
+    # `library_items`).
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
@@ -81,14 +83,14 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_006", "progress_002"}
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
-    """Copy real migrations to tmp + add a synthetic ai_test_007 chained off
-    ai_006; verify enabled run advances to ai_test_007 (the new ai@head)."""
+    """Copy real migrations to tmp + add a synthetic ai_test_008 chained off
+    ai_007; verify enabled run advances to ai_test_008 (the new ai@head)."""
 
-    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_006).
+    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_007).
     real_cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
 
@@ -96,22 +98,23 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
     versions_dir = synth_dir / "versions"
-    # Chain off ai_006 (the current ai@head after pr-β) with branch_labels=None.
-    (versions_dir / "ai_test_007.py").write_text(
+    # Chain off ai_007 (the current ai@head after Phase 0 / F-1) with
+    # branch_labels=None.
+    (versions_dir / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration.
 
-            Revision ID: ai_test_007
-            Revises: ai_006
-            Create Date: 2026-05-21 00:00:00.000000
+            Revision ID: ai_test_008
+            Revises: ai_007
+            Create Date: 2026-05-22 00:00:00.000000
             """
 
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -132,18 +135,18 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     # ai branch advances to the new tip.
-    assert "ai_test_007" in versions, versions
+    assert "ai_test_008" in versions, versions
     await eng.dispose()
 
     # Cleanup: roll back the synthetic migration so other tests aren't affected.
-    await _downgrade_in_thread(cfg, "ai_006")
+    await _downgrade_in_thread(cfg, "ai_007")
 
 
 async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
     """With ai_enabled=False, the wrapper skips advancing the ai branch.
 
     Pre-condition: DB is rolled back to 0004 (no ai branch applied), then the
-    wrapper is invoked with ai_enabled=False. ai_test_007 (the synthetic head)
+    wrapper is invoked with ai_enabled=False. ai_test_008 (the synthetic head)
     must NOT be applied; the backbone stays at 0004.
     """
     # Stamp DB back to backbone (pre-ai-branch state) for this test.
@@ -152,15 +155,15 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
 
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
-    (synth_dir / "versions" / "ai_test_007.py").write_text(
+    (synth_dir / "versions" / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration."""
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -179,17 +182,19 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch skipped → ai_test_007 not applied, ai_006 not applied,
-    # ai_001 not applied. The `progress` branch still advanced.
-    assert "ai_test_007" not in versions
+    # ai branch skipped → ai_test_008 not applied, ai_007 not applied,
+    # ai_006 not applied, ai_001 not applied. The `progress` branch still
+    # advanced.
+    assert "ai_test_008" not in versions
+    assert "ai_007" not in versions
     assert "ai_006" not in versions
     assert "ai_005" not in versions
     assert "ai_004" not in versions
     assert "ai_003" not in versions
     assert "ai_001" not in versions
     # progress branch advanced (progress_enabled=True). The backbone itself
-    # is no longer a head once progress_002 sits on top of 0004.
-    assert "progress_002" in versions
+    # is no longer a head once progress_003 sits on top of 0004.
+    assert "progress_003" in versions
 
     # Restore DB for subsequent tests.
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -53,8 +53,9 @@ async def restore_after(postgres_url: str, alembic_upgrade):
 
 
 async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
-    """With ai@head (ai_006) + progress@head (progress_002) materialized,
-    /readyz reports both heads. (ai_006 added by pr-β.)
+    """With ai@head (ai_007) + progress@head (progress_003) materialized,
+    /readyz reports both heads. (ai_007 / progress_003 added by Phase 0
+    task F-1: server identity-hash schema versioning.)
     """
     # Some earlier test in the session may have downgraded the DB
     # (test_migrate_script.py exercises rollback). Ensure both branches are
@@ -72,14 +73,15 @@ async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upg
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
     """DB stamped below backbone; with both modes enabled, required head is
-    ai_006 (ai@head after pr-β) — that's what should be reported missing."""
+    ai_007 (ai@head after Phase 0 / F-1) — that's what should be reported
+    missing."""
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -87,7 +89,7 @@ async def test_readyz_503_when_db_below_backbone(
     assert r.status_code == 503
     body = r.json()
     assert body["ready"] is False
-    assert "ai_006" in body["missing"]
+    assert "ai_007" in body["missing"]
 
 
 async def test_readyz_200_with_neither_mode_at_backbone(

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -154,6 +154,65 @@ async def test_library_items_table_exists(engine) -> None:
     assert where_alive is not None and "deleted_at" in str(where_alive).lower()
 
 
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning (server side).
+# ---------------------------------------------------------------------------
+# Two migrations land the same `identity_hash_version INTEGER NOT NULL DEFAULT 1`
+# column with `CHECK (>= 1)`:
+#   * `progress_003` → `documents`, `library_items`.
+#   * `ai_007`       → `book_insights`.
+# These tests reflect the live schema (post-migration) and assert the column
+# shape on every table that should carry it.
+
+
+def _identity_hash_version_column_meta(sync_conn, table: str) -> dict:
+    insp = inspect(sync_conn)
+    cols = {c["name"]: c for c in insp.get_columns(table)}
+    checks = {c["name"]: c for c in insp.get_check_constraints(table)}
+    return {"col": cols.get("identity_hash_version"), "checks": checks}
+
+
+async def test_documents_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "documents")
+    col = info["col"]
+    assert col is not None, "documents.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_documents_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_progress
+async def test_library_items_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "library_items")
+    col = info["col"]
+    assert col is not None, "library_items.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_library_items_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_ai
+async def test_book_insights_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "book_insights")
+    col = info["col"]
+    assert col is not None, "book_insights.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_book_insights_identity_hash_version_ge_1" in info["checks"]
+
+
+async def test_documents_identity_hash_version_default_round_trip(session) -> None:
+    """A row created without supplying `identity_hash_version` defaults to 1."""
+    doc = Document(user_id="alice-v1", metadata_id="md-ver-1", content_hash="ch-ver-1")
+    session.add(doc)
+    await session.commit()
+    await session.refresh(doc)
+    assert doc.identity_hash_version == 1
+
+
 @pytest.mark.requires_ai
 async def test_ai_generation_log_round_trip(session) -> None:
     """ORM model writes and reads ai_generation_log rows."""


### PR DESCRIPTION
Implements **Phase 0, task S-2** of the Quire monetization design (`docs/superpowers/specs/2026-05-22-quire-monetization-design.md`, sections "Architectural changes -> Push-model API" and "Build sequence -> Phase 0 item (2)").

**Stacked on top of PR #47 (F-1).** Builds on `identity_hash_version` and reuses the load-bearing `max(existing, incoming)` downgrade-protection rule from F-1.

## What this PR adds

- New endpoint `POST /library/v1/sync` accepting `{items: [{content_hash, identity_hash_version, status, last_seen_at?, metadata...}]}`. Returns a counts-only summary `{received, processed, created, updated, reactivated, deleted, skipped, missing_deleted, server_time}`.
- Two-shape entry discriminated by `status`:
  - `present` requires `title`; performs upsert with diff-skip on no-op replay.
  - `deleted` requires `content_hash` only; idempotent tombstone.
- New config knob `QUIRE_SERVER_LIBRARY_SYNC_MAX_ITEMS` (default 500) guards parsed entry count on top of the existing byte-size middleware (`max_request_bytes`, default 1 MiB).
- Coexists with existing `PUT /library/v1/items` / `GET` / `DELETE` -- spec-mandated; deprecation of any pull paths is a sibling task (S-4), not this PR.

## Architectural choices (architect + plan-reviewer consult)

- **All-or-nothing per request.** Conflict (`409 metadata_id_conflict`) or validation (`422`) aborts the whole batch -- no partial commit. Atomicity is enforced by a single `await session.commit()` at the end.
- **Idempotent on replay.** A `present` entry whose persisted row already matches every field is `skipped`, NOT rewritten. Bumping `updated_at` on every replay would flood `GET /library/v1/items?since=` with the entire library each cycle.
- **`last_seen_at` is wire-only in v1.** Validated tz-aware (naive rejected), never stored. The architect-flagged footgun was using a client clock as a server cursor; we don't.
- **Missing entries are NEVER auto-deleted.** Tombstones travel via an explicit `status=deleted` command. A tombstone for an unknown `content_hash` is counted as `missing_deleted` and ignored -- no phantom rows materialized (the `library_items.title` column is NOT NULL).
- **Already-tombstoned `status=deleted` preserves timestamps** so `?since=` doesn't re-deliver the same tombstone forever.
- **Intra-payload duplicate `content_hash`** collapses if identical, otherwise `422 duplicate_content_hash_conflict`.
- **Intra-payload `metadata_id`** claimed by two different `content_hash` values -> `422 metadata_id_collision_in_payload` (preempts the mid-batch unique-index race).
- Single bulk-fetch SELECT + ORM merge inside one transaction.

## Files changed

- `server/quire_server/api/library_schemas.py` -- `LibrarySyncStatus`, `LibrarySyncEntry`, `LibrarySyncRequest`, `LibrarySyncSummary`.
- `server/quire_server/api/library.py` -- `POST /sync` handler plus `_dedupe_entries`, `_check_intra_payload_metadata_collisions`, `_entry_to_payload`, `_row_matches_payload`, `_apply_sync_payload`.
- `server/quire_server/config.py` -- `library_sync_max_items` setting.
- `server/tests/integration/test_library_sync.py` -- 27 new integration tests.

## Verification

```
$ cd server && uv run ruff check
All checks passed!

$ cd server && uv run pytest
====================== 452 passed, 326 warnings in 19.65s ======================
```

Test coverage:
- happy path multi-book create
- idempotent replay does NOT bump `updated_at` (key cursor-pollution test)
- partial update bumps `updated_at`
- empty `items` no-op
- `identity_hash_version` round-trip + downgrade protection
- zero/missing `identity_hash_version` rejected
- bounded payload (`too_many_items` 422)
- auth required (401), user isolation
- `status=deleted` tombstones existing row; tombstone for unknown is skipped
- repeated delete preserves timestamps (idempotent)
- deleted-then-present reactivates
- intra-payload dedup collapses identical, rejects conflicting status/metadata duplicates
- intra-payload `metadata_id` collision -> 422
- cross-row `metadata_id` conflict -> 409
- **atomicity**: 409 in batch leaves DB unchanged (no partial commit)
- `present` without title rejected; `deleted` without title accepted
- `last_seen_at`: naive rejected, aware accepted (validated but not persisted)
- missing `content_hash` rejected
- coexistence with existing per-item PUT/DELETE

## Out of scope (deliberately)

- Persisting `last_seen_at` to a column (no migration in this PR; deferred until there's a server-side feature that needs durable client freshness).
- Deprecating pull paths (sibling task S-4 marks the calibre-web pull flag deprecated). Note: in the current codebase the only outbound call is the calibre-web Basic-auth probe -- no library-pull endpoint exists today, so there is nothing to remove here either way.
- Auth-backend refactor (sibling task S-1). This PR uses the existing `current_user_id` dependency unchanged; once S-1 lands the new `AuthBackend` interface works transparently.
- Identity-hash logic (F-1 already shipped it).
- Android client changes.

## Unresolved questions

- The spec wire shape uses `identity_hash` while the existing server schema uses `content_hash`. I kept `content_hash` for wire-protocol consistency with the existing `/library/v1/items` endpoints. If the Android client ends up sending `identity_hash`, a Pydantic alias is a one-line addition.
- `last_seen_at` is accepted but not stored. A future PR can add a column without changing the wire protocol.