### PR TITLE
feat(server): pluggable AuthBackend + minimum NativeAuth (Phase 0, task S-1)

### DIFF
--- a/server/migrations/versions/ai_007_identity_hash_version.py
+++ b/server/migrations/versions/ai_007_identity_hash_version.py
@@ -1,0 +1,69 @@
+"""ai_007_identity_hash_version: add `identity_hash_version` to book_insights.
+
+Seventh migration on the `ai` branch. Chains off `ai_006`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function breaks sync, caches, recs, export, and
+deletion across millions of rows. Trivial now, expensive to retrofit.
+
+This migration adds `identity_hash_version` to `book_insights`, the
+SHARED-CACHE table on the `ai` branch. Companion migration `progress_003`
+adds the same column to `documents` and `library_items`.
+
+Cache-key impact: NONE. `identity_hash_version` is intentionally NOT added
+to any of the unique/cache-key constraints on `book_insights`. The
+architect-reviewed design treats it as row-freshness metadata only: a
+higher-version client hitting an existing cache row upgrades the persisted
+value via `max(existing, incoming)` in the orchestrator. Partitioning the
+cache by version would fragment the cross-tenant cache-hit property
+(see the cache-integrity comment above `BookInsight` in
+`quire_server/db/models.py`) without paying for itself in Phase 0.
+
+Schema additions:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. Pre-existing rows
+  backfill to `1` atomically via the column-level default.
+- `CHECK (identity_hash_version >= 1)`.
+
+Revision ID: ai_007
+Revises: ai_006
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_007"
+down_revision = "ai_006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "book_insights",
+        sa.Column(
+            "identity_hash_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+    op.create_check_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        "identity_hash_version >= 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        type_="check",
+    )
+    op.drop_column("book_insights", "identity_hash_version")

--- a/server/migrations/versions/auth_001_native_users_and_sessions.py
+++ b/server/migrations/versions/auth_001_native_users_and_sessions.py
@@ -1,0 +1,98 @@
+"""auth_001_native_users_and_sessions: create native_users + native_sessions.
+
+First migration on the new ``auth`` branch. Chains off the backbone tip
+``0004`` so it sits alongside the existing ``progress`` and ``ai`` branches.
+
+Phase 0, task S-1 (per
+``docs/superpowers/specs/2026-05-22-quire-monetization-design.md``,
+section "Architectural changes → Thin auth abstraction in ``quire_server``"
+and "Build sequence → Phase 0" item 3):
+
+The OSS server defaults to CalibreWeb Basic auth. The Cloud product needs
+its own identity layer (email/password + magic-link). This migration adds
+the two tables NativeAuth needs:
+
+* ``native_users``  — email (canonical lowercase, UNIQUE), argon2id PHC hash.
+* ``native_sessions`` — opaque session token store. Primary key is
+  ``sha256(token_plain)`` hex; the raw token never reaches the DB.
+
+Both tables are ALWAYS materialized (the ``auth`` branch is unconditionally
+upgraded by ``scripts/migrate.py``) so that switching between backends is a
+config-only flip, not a schema migration.
+
+Scope discipline: this migration ships only what minimum-viable NativeAuth
+needs for Cloud. Password-reset tokens, magic-link tokens, refresh tokens,
+audit-log tables, rate-limit ledger, lockout state, MFA factors, and account
+recovery state are all DEFERRED per spec.
+
+Revision ID: auth_001
+Revises: 0004
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "auth_001"
+down_revision = "0004"
+# Claim the ``auth`` branch label here. Subsequent ``auth_NNN`` revisions
+# leave this None (label is propagated forward by Alembic), matching the
+# convention used by ``ai_001`` / ``progress_001``.
+branch_labels = ("auth",)
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "native_users",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("password_hash", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("email", name="uq_native_users_email"),
+        sa.CheckConstraint("email = lower(email)", name="ck_native_users_email_lower"),
+    )
+
+    op.create_table(
+        "native_sessions",
+        # Primary key is the sha256(token) hex digest. The raw token lives
+        # only in the client. Compromise of the DB does not leak active
+        # session secrets.
+        sa.Column("token_hash", sa.String(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.BigInteger(),
+            sa.ForeignKey("native_users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_native_sessions_user",
+        "native_sessions",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_native_sessions_expires",
+        "native_sessions",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_native_sessions_expires", table_name="native_sessions")
+    op.drop_index("ix_native_sessions_user", table_name="native_sessions")
+    op.drop_table("native_sessions")
+    op.drop_table("native_users")

--- a/server/migrations/versions/progress_003_identity_hash_version.py
+++ b/server/migrations/versions/progress_003_identity_hash_version.py
@@ -1,0 +1,73 @@
+"""progress_003_identity_hash_version: add `identity_hash_version` to documents + library_items.
+
+Third migration on the `progress` branch. Chains off `progress_002`.
+`branch_labels = None` because the label is carried by `progress_001`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function (edition merging, normalization fixes,
+etc.) breaks sync, caches, recs, export, and deletion across millions of
+rows. Trivial to add now, very expensive to retrofit.
+
+This migration covers the `progress`-branch tables that carry an identity
+hash directly: `documents` and `library_items`. The companion migration
+`ai_007` adds the same column to `book_insights` on the `ai` branch.
+`progress.progress` deliberately has no own version column: identity travels
+via the parent `Document`, so `Progress.document.identity_hash_version` is
+the answer for any progress row.
+
+Schema additions per table:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. All pre-existing rows
+  backfill to `1` via the column-level default (atomic in Postgres for the
+  ADD COLUMN ... DEFAULT path; no separate UPDATE pass needed).
+- `CHECK (identity_hash_version >= 1)`. Prevents accidental zero-or-negative
+  versions from sneaking in through a future buggy writer.
+
+Downgrade-safety: dropping the column is reversible; the data loss is
+inherent and downgrade callers accept it. No indexes are added — the column
+is row-metadata, not a query predicate.
+
+Revision ID: progress_003
+Revises: progress_002
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "progress_003"
+down_revision = "progress_002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.add_column(
+            table,
+            sa.Column(
+                "identity_hash_version",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("1"),
+            ),
+        )
+        op.create_check_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            "identity_hash_version >= 1",
+        )
+
+
+def downgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.drop_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            type_="check",
+        )
+        op.drop_column(table, "identity_hash_version")

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
     "pydantic-settings>=2.4",
     "httpx>=0.27",
     "python-json-logger>=2.0",
+    # Phase 0, task S-1: argon2id password hashing for NativeAuth. The CFFI
+    # binding is the canonical Python implementation; no alternative is
+    # acceptable for password-hash storage.
+    "argon2-cffi>=23.1",
 ]
 
 [project.optional-dependencies]

--- a/server/quire_server/api/ai.py
+++ b/server/quire_server/api/ai.py
@@ -411,6 +411,9 @@ async def sync_insights(
             BookInsight.id.label("ins_id"),
             BookInsight.metadata_id.label("ins_metadata_id"),
             BookInsight.content_hash.label("ins_content_hash"),
+            # Phase 0, task F-1: surface persisted identity-hash version
+            # to the client via the sync envelope.
+            BookInsight.identity_hash_version.label("ins_identity_hash_version"),
             BookInsight.model_id.label("ins_model_id"),
             BookInsight.prompt_version.label("ins_prompt_version"),
             BookInsight.tone.label("ins_tone"),
@@ -487,6 +490,7 @@ async def sync_insights(
             identity=DocumentIdentity(
                 metadata_id=r.ins_metadata_id,
                 content_hash=r.ins_content_hash,
+                identity_hash_version=r.ins_identity_hash_version,
             ),
             payload=BookInsightPayload.model_validate(r.ins_payload),
             sources=[Citation.model_validate(c) for c in (r.ins_sources or [])],

--- a/server/quire_server/api/ai_schemas.py
+++ b/server/quire_server/api/ai_schemas.py
@@ -221,6 +221,11 @@ class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str | None = None
 
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1` keeps
+    # pre-versioning clients compatible; the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
+
     # Alias hints (PR2). All optional. The resolver maps them to a
     # canonical via insight_identity_aliases when present.
     opds_href: str | None = None
@@ -373,6 +378,12 @@ class BookInsightResponse(BaseModel):
     model_id: str
     prompt_version: str
     generated_at: str  # ISO-8601
+    # Phase 0, task F-1: identity-hash algorithm version of the persisted
+    # row this response represents. Clients use this to decide whether to
+    # recompute their local hash on the next sync (when their computed
+    # version > N). Defaults to `1` for older serialized rows that
+    # pre-date the column.
+    identity_hash_version: int = 1
 
 
 class InsightLookupBody(BaseModel):

--- a/server/quire_server/api/auth.py
+++ b/server/quire_server/api/auth.py
@@ -1,4 +1,4 @@
-""" ``/auth/v1/*`` router for NativeAuth.
+"""``/auth/v1/*`` router for NativeAuth.
 
 Phase 0, task S-1 (per
 ``docs/superpowers/specs/2026-05-22-quire-monetization-design.md``,

--- a/server/quire_server/api/auth.py
+++ b/server/quire_server/api/auth.py
@@ -1,0 +1,180 @@
+""" ``/auth/v1/*`` router for NativeAuth.
+
+Phase 0, task S-1 (per
+``docs/superpowers/specs/2026-05-22-quire-monetization-design.md``,
+"Architectural changes → Thin auth abstraction in ``quire_server``").
+
+This router is mounted ONLY when ``QUIRE_SERVER_AUTH_BACKEND=native``. OSS
+deployments running CalibreWeb Basic never see these endpoints — a stray
+``POST /auth/v1/login`` against an OSS server returns the FastAPI default
+404, which is exactly the right shape: the endpoints do not exist there.
+
+Endpoint set (the MINIMUM Cloud needs):
+
+  * ``POST /auth/v1/login`` — email/password → opaque bearer session token.
+  * ``POST /auth/v1/logout`` — revoke the bearer used to authenticate the
+    request. Idempotent (a repeat call is silent, not 404).
+  * ``POST /auth/v1/magic-link/request`` — STUB. Always 202. Sends nothing.
+    Future Cloud-side delivery will replace the body, NOT the URL.
+  * ``GET  /auth/v1/magic-link/consume`` — STUB. Always 501.
+
+EXPLICITLY DEFERRED per spec ("self-host UX polish for Native auth is
+deferred"): signup, password reset, email change, OAuth, refresh tokens,
+rate limiting, lockout, CAPTCHA, MFA, audit trail surfacing, account
+deletion. Cloud's control plane will handle signup/password-management
+flows; the OSS server has no UX to support them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel, Field
+
+from quire_server.core.auth import current_auth_user
+from quire_server.core.auth_backend import AuthUser, NativeAuth
+
+router = APIRouter(tags=["auth"])
+
+
+# ----------------------------------------------------------------------------
+# Schemas
+# ----------------------------------------------------------------------------
+
+
+class LoginRequest(BaseModel):
+    # We accept ``str`` rather than :class:`EmailStr` so the response shape
+    # for an obviously malformed email matches the unknown-email path
+    # (single 401). Cloud's control plane can validate strictly at signup
+    # time; the OSS login path treats all failures the same.
+    email: str = Field(..., min_length=1, max_length=320)
+    password: str = Field(..., min_length=1, max_length=1024)
+
+
+class LoginResponse(BaseModel):
+    token: str
+    # Expiry as ISO-8601. Clients should refresh BEFORE this fires; the
+    # server does not currently support refresh-without-relogin (deferred).
+    expires_at: datetime
+
+
+class MagicLinkRequest(BaseModel):
+    # `EmailStr` requires the optional `email-validator` package which we
+    # do not depend on. Accept raw str; the stub does no work anyway.
+    email: str = Field(..., min_length=1, max_length=320)
+
+
+class MagicLinkStubResponse(BaseModel):
+    status: str = Field(default="accepted")
+    # Hard-coded explanation so the response shape signals "this is a stub"
+    # to any client probing it from outside Cloud. Cloud's real
+    # implementation will keep ``status`` but drop or reshape ``detail``.
+    detail: str = Field(
+        default=(
+            "magic-link delivery is not implemented in the OSS server; "
+            "Quire Cloud sends magic links from a separate control plane"
+        )
+    )
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+async def _require_native_backend(request: Request) -> NativeAuth:
+    """Return the configured backend, asserting it is :class:`NativeAuth`.
+
+    The router is mounted only under Native mode, but a misconfigured
+    deployment could in principle swap backends at runtime via app.state
+    mutation. Failing fast with a 500 surfaces that instead of returning
+    a confusing 401.
+    """
+    backend = getattr(request.app.state, "auth_backend", None)
+    if not isinstance(backend, NativeAuth):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="auth_backend_not_native",
+        )
+    return backend
+
+
+# ----------------------------------------------------------------------------
+# Endpoints
+# ----------------------------------------------------------------------------
+
+
+@router.post("/login", response_model=LoginResponse)
+async def login(
+    body: LoginRequest,
+    backend: Annotated[NativeAuth, Depends(_require_native_backend)],
+) -> LoginResponse:
+    """Verify creds, issue a session token.
+
+    Failure modes (unknown email, wrong password, malformed input) all
+    collapse to ``401 {"detail": "invalid credentials"}``. The dummy-hash
+    trick in :class:`NativeAuth.login` keeps the verify cost roughly
+    constant across paths.
+    """
+    token, expires_at = await backend.login(email=body.email, password=body.password)
+    return LoginResponse(token=token, expires_at=expires_at)
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(
+    user: Annotated[AuthUser, Depends(current_auth_user)],
+    backend: Annotated[NativeAuth, Depends(_require_native_backend)],
+) -> Response:
+    """Revoke the session backing the current bearer token.
+
+    Idempotent. A repeat call against an already-revoked token (or a token
+    that was never valid) still returns 204; the ``current_auth_user``
+    dependency above is what rejects unknown tokens at the boundary.
+    """
+    if user.session_token_hash is None:
+        # Should be impossible under NativeAuth (current_user always sets
+        # the hash); defensive 500 catches a future regression.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="no_session_token",
+        )
+    await backend.revoke(user.session_token_hash)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/magic-link/request",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=MagicLinkStubResponse,
+)
+async def magic_link_request(_: MagicLinkRequest) -> MagicLinkStubResponse:
+    """STUB: accept the request shape, do nothing.
+
+    Always returns 202 regardless of whether the email exists — leaks
+    nothing about user existence. Cloud's control plane handles real
+    delivery in Phase 1; the OSS server keeps the URL reserved.
+    """
+    return MagicLinkStubResponse(status="accepted")
+
+
+@router.get(
+    "/magic-link/consume",
+    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+)
+async def magic_link_consume(token: str = "") -> Response:
+    """STUB: deliberately unimplemented in the OSS server.
+
+    Cloud will implement consumption in its closed control plane; until
+    then this endpoint reserves the URL and signals 501 so a client
+    probing it gets a clear "not here yet" rather than a 404 that would
+    suggest the URL might exist on a different mount.
+    """
+    # Use ``EmailStr``-style hint var to satisfy linters that flag unused
+    # query params; the param exists for future-shape parity only.
+    _ = token
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="not implemented",
+    )

--- a/server/quire_server/api/health.py
+++ b/server/quire_server/api/health.py
@@ -90,7 +90,16 @@ def _required_heads(script, progress_enabled: bool, ai_enabled: bool) -> set[str
     labels = _existing_branch_labels(script)
     required: set[str] = set()
 
-    candidates = [(True, "core"), (progress_enabled, "progress"), (ai_enabled, "ai")]
+    # Phase 0, task S-1: ``auth`` is foundational (NativeAuth tables exist
+    # regardless of the configured backend) so it is required whenever the
+    # label is present, on a par with ``core``. The actual selection of a
+    # backend is a config-only flip — schema must be there either way.
+    candidates = [
+        (True, "core"),
+        (True, "auth"),
+        (progress_enabled, "progress"),
+        (ai_enabled, "ai"),
+    ]
     for enabled, label in candidates:
         if enabled and label in labels:
             rev = script.get_revision(f"{label}@head")

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -61,6 +61,7 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
     return LibraryItemResponse(
         metadata_id=row.metadata_id,
         content_hash=row.content_hash,
+        identity_hash_version=row.identity_hash_version,
         title=row.title,
         authors=list(row.authors or []),
         series_name=row.series_name,
@@ -78,6 +79,11 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
 def _apply_payload(row: LibraryItem, payload: LibraryItemRequest) -> None:
     """Write payload fields onto `row`. Caller is responsible for timestamps."""
     row.metadata_id = payload.metadata_id
+    # Phase 0, task F-1: downgrade protection. An old client (sending the
+    # default `1`) MUST NOT overwrite a row whose hash version was advanced
+    # by a newer client. `max(existing, incoming)` is the load-bearing rule.
+    if payload.identity_hash_version > row.identity_hash_version:
+        row.identity_hash_version = payload.identity_hash_version
     row.title = payload.title
     row.authors = list(payload.authors)
     row.series_name = payload.series_name
@@ -134,6 +140,7 @@ async def put_item(
         row = LibraryItem(
             user_id=user_id,
             content_hash=payload.content_hash,
+            identity_hash_version=payload.identity_hash_version,
             title=payload.title,
             authors=list(payload.authors),
             metadata_id=payload.metadata_id,

--- a/server/quire_server/api/library_schemas.py
+++ b/server/quire_server/api/library_schemas.py
@@ -26,6 +26,11 @@ class LibraryItemRequest(BaseModel):
 
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1`
+    # accepts pre-versioning clients; the server's PUT path applies
+    # `max(existing, incoming)` so an old client cannot downgrade a row
+    # written by a newer client.
+    identity_hash_version: int = Field(default=1, ge=1)
     title: str
     authors: list[str] = Field(default_factory=list)
     series_name: str | None = None
@@ -47,6 +52,12 @@ class LibraryItemIdentity(BaseModel):
     """The identity sub-object inside a DELETE body."""
 
     content_hash: str
+    # Phase 0, task F-1: optional on DELETE. The current matcher keys
+    # exclusively on `content_hash` so the field is accepted but not used
+    # for row selection — clients can already locate a row by hash alone.
+    # Once a real hash-version migration happens this field becomes the
+    # tiebreaker for delete semantics.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class LibraryItemDeleteBody(BaseModel):
@@ -58,6 +69,10 @@ class LibraryItemResponse(BaseModel):
 
     metadata_id: str | None
     content_hash: str
+    # Phase 0, task F-1: always emitted from server, so clients can detect
+    # the row's persisted hash-algorithm version and trigger recompute on
+    # next sync when their computed-version > N.
+    identity_hash_version: int
     title: str
     authors: list[str]
     series_name: str | None

--- a/server/quire_server/api/progress.py
+++ b/server/quire_server/api/progress.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, Field, field_serializer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,11 @@ router = APIRouter(tags=["progress"])
 class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version travelling on the
+    # wire. Default `1` keeps old clients (pre-versioning) round-trippable;
+    # new clients send their own value and the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class ProgressItem(BaseModel):
@@ -102,6 +107,10 @@ async def _resolve_or_create_document(
             )
         ).scalar_one_or_none()
         if existing:
+            # Phase 0, task F-1: downgrade protection. An old client (sending
+            # `1`) MUST NOT overwrite a row written by a newer client.
+            if ident.identity_hash_version > existing.identity_hash_version:
+                existing.identity_hash_version = ident.identity_hash_version
             return existing
     existing = (
         await session.execute(
@@ -114,8 +123,16 @@ async def _resolve_or_create_document(
         # Backfill metadata_id if we just learned it
         if ident.metadata_id and existing.metadata_id is None:
             existing.metadata_id = ident.metadata_id
+        # Phase 0, task F-1: downgrade protection (see above).
+        if ident.identity_hash_version > existing.identity_hash_version:
+            existing.identity_hash_version = ident.identity_hash_version
         return existing
-    doc = Document(user_id=user_id, metadata_id=ident.metadata_id, content_hash=ident.content_hash)
+    doc = Document(
+        user_id=user_id,
+        metadata_id=ident.metadata_id,
+        content_hash=ident.content_hash,
+        identity_hash_version=ident.identity_hash_version,
+    )
     session.add(doc)
     await session.flush()  # populate doc.pk
     return doc
@@ -130,6 +147,14 @@ async def push_progress(
     results: list[ProgressPushResult] = []
     for item in body.items:
         doc = await _resolve_or_create_document(session, user_id, item.document)
+        # Phase 0, task F-1: the result echoes the persisted Document's
+        # identity_hash_version (which may be >= the incoming one after the
+        # downgrade-protection logic in _resolve_or_create_document).
+        persisted_identity = DocumentIdentity(
+            metadata_id=doc.metadata_id,
+            content_hash=doc.content_hash,
+            identity_hash_version=doc.identity_hash_version,
+        )
         existing = (
             await session.execute(select(Progress).where(Progress.document_pk == doc.pk))
         ).scalar_one_or_none()
@@ -158,7 +183,7 @@ async def push_progress(
             )
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -172,7 +197,7 @@ async def push_progress(
             existing.abandoned_at = abandoned_at
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -180,7 +205,7 @@ async def push_progress(
         else:
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="stale",
                     server_client_updated_at=existing.client_updated_at,
                 )
@@ -223,7 +248,11 @@ async def pull_progress(
             effective_abandoned_at = None
         items.append(
             ProgressPullItem(
-                document=DocumentIdentity(metadata_id=d.metadata_id, content_hash=d.content_hash),
+                document=DocumentIdentity(
+                    metadata_id=d.metadata_id,
+                    content_hash=d.content_hash,
+                    identity_hash_version=d.identity_hash_version,
+                ),
                 locator=p.locator,
                 percent=p.percent,
                 client_updated_at=p.client_updated_at,

--- a/server/quire_server/config.py
+++ b/server/quire_server/config.py
@@ -89,6 +89,23 @@ class Settings(BaseSettings):
     # Required when ai_auth_mode == "token". Validated against token `aud`.
     ai_token_audience: str | None = None
 
+    # ---------------------------------------------------------------------
+    # Phase 0, task S-1: primary AuthBackend selector.
+    # ---------------------------------------------------------------------
+    # Which AuthBackend resolves ``Depends(current_user_id)``:
+    #   * ``"calibreweb"`` (default, OSS) – wraps the existing
+    #     :class:`CalibreAuthValidator`. ``Authorization: Basic ...``.
+    #     ``user_id`` is the lowercase CWA username.
+    #   * ``"native"`` – Quire Cloud. Email/password + opaque bearer
+    #     session tokens. ``user_id`` is ``"native:<NativeUser.id>"``.
+    #     Mounts the ``/auth/v1/*`` router; CalibreWeb mode does not.
+    auth_backend: Literal["calibreweb", "native"] = "calibreweb"
+
+    # NativeAuth session lifetime. Default 30 days; clients should refresh
+    # by logging in again before expiry. No refresh-token mechanism exists
+    # at this stage (deferred per spec).
+    native_session_ttl_s: int = 30 * 24 * 3600
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -2248,9 +2248,7 @@ def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
 
 
-def _maybe_upgrade_identity_hash_version(
-    row: BookInsight, ident: DocumentIdentity
-) -> None:
+def _maybe_upgrade_identity_hash_version(row: BookInsight, ident: DocumentIdentity) -> None:
     """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
     identity-hash version on a cache-hit.
 

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -664,6 +664,10 @@ class InsightOrchestrator:
         row = BookInsight(
             metadata_id=ident.metadata_id,
             content_hash=effective_content_hash,
+            # Phase 0, task F-1: persist the incoming identity-hash version
+            # so future reads return the correct level. Defaults to `1` for
+            # pre-versioning clients.
+            identity_hash_version=getattr(ident, "identity_hash_version", 1),
             model_id=self.model_id,
             prompt_version=self.prompt_version,
             tone=tone,
@@ -857,6 +861,7 @@ class InsightOrchestrator:
                 )
             ).scalar_one_or_none()
             if row is not None:
+                _maybe_upgrade_identity_hash_version(row, ident)
                 return row
         # Step 2: by content_hash (live rows only)
         if not ident.content_hash:
@@ -875,6 +880,10 @@ class InsightOrchestrator:
         ).scalar_one_or_none()
         if row is None:
             return None
+        # Phase 0, task F-1: upgrade the row's identity_hash_version if the
+        # incoming identity is newer. Same downgrade-protection rule as
+        # Document/LibraryItem: max(existing, incoming).
+        _maybe_upgrade_identity_hash_version(row, ident)
         # Alias reconciliation: backfill metadata_id if we just learned it.
         if allow_backfill and ident.metadata_id and row.metadata_id is None:
             row.metadata_id = ident.metadata_id
@@ -1174,6 +1183,13 @@ class InsightOrchestrator:
         new_row = BookInsight(
             metadata_id=to_identity.metadata_id,
             content_hash=to_identity.content_hash or src_row.content_hash,
+            # Phase 0, task F-1: the copied row takes the maximum of the
+            # source row's version and the destination identity's version
+            # so a v2 destination promoted from a v1 source persists as v2.
+            identity_hash_version=max(
+                src_row.identity_hash_version,
+                getattr(to_identity, "identity_hash_version", 1),
+            ),
             model_id=src_row.model_id,
             prompt_version=src_row.prompt_version,
             tone=src_row.tone,
@@ -2213,6 +2229,10 @@ class InsightOrchestrator:
             model_id=row.model_id,
             prompt_version=row.prompt_version,
             generated_at=row.generated_at.isoformat(),
+            # Phase 0, task F-1: surface the persisted identity-hash version
+            # so clients can detect rows produced under an older algorithm
+            # and trigger their own recompute logic (F-2 territory).
+            identity_hash_version=row.identity_hash_version,
         )
 
 
@@ -2226,6 +2246,24 @@ def _tone_of(style: AiStyle | None) -> str:
 
 def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
+
+
+def _maybe_upgrade_identity_hash_version(
+    row: BookInsight, ident: DocumentIdentity
+) -> None:
+    """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
+    identity-hash version on a cache-hit.
+
+    Operates in-place on `row`. The surrounding transaction commits as
+    part of the normal cache-hit log write, so we do not flush here.
+
+    Defensive: ``ident.identity_hash_version`` is wire-side and defaults to
+    `1` when the client did not supply it (pre-versioning clients). The
+    `>` comparison therefore protects against accidental downgrades.
+    """
+    incoming = getattr(ident, "identity_hash_version", 1)
+    if incoming > row.identity_hash_version:
+        row.identity_hash_version = incoming
 
 
 # ---------- PR2 identity-resolution helpers ---------------------------------

--- a/server/quire_server/core/auth.py
+++ b/server/quire_server/core/auth.py
@@ -114,11 +114,51 @@ async def get_validator(request: Request) -> CalibreAuthValidator:
     return request.app.state.auth_validator
 
 
+# Phase 0, task S-1: primary-auth dependency now resolves through the
+# configured :class:`AuthBackend` instead of going straight to the CalibreWeb
+# validator. The public signature stays ``-> str`` so every existing route
+# and every test that overrides ``current_user_id`` via
+# ``app.dependency_overrides`` keeps working unchanged.
+#
+# Routes that need the full :class:`AuthUser` (notably ``/auth/v1/logout``,
+# which needs the session token hash) use :func:`current_auth_user` instead.
+#
+# Implementation note: importing :class:`AuthBackend` at module level would
+# create a circular import (auth_backend imports from this module). The
+# dependency loads it lazily.
+
+
+async def get_auth_backend(request: Request):
+    """FastAPI dependency: pull the configured backend off ``app.state``."""
+    backend = getattr(request.app.state, "auth_backend", None)
+    if backend is None:
+        # main.py always wires this. A 500 surfaces the misconfiguration
+        # rather than silently 401-ing every request.
+        logger.error("auth_backend missing from app.state")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="auth_backend_not_configured",
+        )
+    return backend
+
+
 async def current_user_id(
     request: Request,
-    validator: Annotated[CalibreAuthValidator, Depends(get_validator)],
+    backend: Annotated[object, Depends(get_auth_backend)],
 ) -> str:
-    auth = request.headers.get("authorization")
-    if not auth:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing credentials")
-    return await validator.validate(auth)
+    """Return the storage-scope user id for the authenticated request.
+
+    Format depends on the configured backend: CalibreWeb yields a lowercase
+    CWA username; NativeAuth yields ``"native:<id>"``. Existing user-scoped
+    tables persist this string verbatim.
+    """
+    user = await backend.current_user(request)  # type: ignore[attr-defined]
+    return user.user_id
+
+
+async def current_auth_user(
+    request: Request,
+    backend: Annotated[object, Depends(get_auth_backend)],
+):
+    """Return the full :class:`AuthUser`. Used by ``/auth/v1/logout``."""
+    return await backend.current_user(request)  # type: ignore[attr-defined]

--- a/server/quire_server/core/auth_backend.py
+++ b/server/quire_server/core/auth_backend.py
@@ -1,0 +1,375 @@
+"""AuthBackend protocol + ``CalibreWebBasicAuth`` and ``NativeAuth``.
+
+Phase 0, task S-1 (per
+``docs/superpowers/specs/2026-05-22-quire-monetization-design.md``,
+"Architectural changes → Thin auth abstraction in ``quire_server``" and
+"Build sequence → Phase 0" item 3).
+
+The OSS server historically coupled primary auth to CalibreWeb Basic. This
+module introduces a thin protocol the rest of the server depends on, plus
+two implementations:
+
+* ``CalibreWebBasicAuth`` — wraps the existing :class:`CalibreAuthValidator`.
+  Default in OSS. Emits ``user_id`` as the lowercase CWA username (preserved
+  byte-for-byte from the pre-refactor behavior).
+* ``NativeAuth`` — email/password + opaque session tokens. Used by Quire
+  Cloud. Emits ``user_id`` as ``"native:<users.id>"`` so user-scoped storage
+  rows do not collide with the CalibreWeb namespace.
+
+Scope discipline: ``NativeAuth`` ships the minimum Cloud needs (login,
+logout, session-validation, magic-link STUBS). Password reset, recovery,
+abuse handling, rate-limiting, and refresh tokens are deferred per spec.
+
+FastAPI wiring (see :mod:`quire_server.core.auth`):
+the public dependency is still ``current_user_id``, returning ``str``. Tests
+that override that dependency continue to work unchanged. Endpoints needing
+the full :class:`AuthUser` (notably ``/auth/v1/logout``, which needs the
+session token to revoke) use ``current_auth_user``.
+
+AI-routes seam (``quire_server.api.ai_auth.AiAuthenticator``) remains
+independent: AI keeps its own auth mechanism so token-mode multi-tenant
+deployments are not entangled with primary-auth selection. The app factory
+guards against the misconfiguration ``auth_backend=native`` +
+``ai_enabled=true`` + ``ai_auth_mode=basic`` (which would silently leave
+AI on CalibreWeb Basic).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Literal, Protocol
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from quire_server.core.auth import CalibreAuthValidator
+from quire_server.core.native_auth import (
+    canonical_email,
+    generate_session_token,
+    get_dummy_hash,
+    hash_password,
+    hash_session_token,
+    verify_password,
+)
+from quire_server.db.models import NativeSession, NativeUser
+
+logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------------------
+# Public types
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AuthUser:
+    """A request's authenticated identity, as seen by primary-auth callers.
+
+    ``user_id`` is the storage-scope identifier persisted into existing
+    user-scoped tables (``documents.user_id``, ``library_items.user_id``,
+    etc.). The format is backend-dependent:
+
+      * CalibreWeb: lowercase CWA username (e.g. ``"alice"``).
+      * Native: ``"native:<NativeUser.id>"`` (e.g. ``"native:42"``).
+
+    ``backend`` is the configured backend that authenticated this request.
+    ``session_token_hash`` is set only under Native auth (it is the hash
+    used as the ``native_sessions`` primary key); ``logout`` needs it to
+    target the right session row. CalibreWeb has no equivalent state.
+    """
+
+    user_id: str
+    backend: Literal["calibreweb", "native"]
+    session_token_hash: str | None = None
+
+
+class AuthBackend(Protocol):
+    """The primary-auth seam.
+
+    A backend MUST resolve any valid request to an :class:`AuthUser` or
+    raise :class:`fastapi.HTTPException(401)` on failure. The dependency
+    layer above translates the result into the legacy ``user_id`` str
+    expected by every existing route.
+    """
+
+    async def current_user(self, request: Request) -> AuthUser: ...
+
+
+# ----------------------------------------------------------------------------
+# CalibreWeb Basic auth
+# ----------------------------------------------------------------------------
+
+
+class CalibreWebBasicAuth:
+    """Default OSS backend.
+
+    Wraps the existing :class:`CalibreAuthValidator` so the byte-exact
+    behavior of pre-S-1 deployments (Basic header, lowercase username as
+    ``user_id``, CWA probe + TTL cache) is preserved verbatim.
+    """
+
+    def __init__(self, validator: CalibreAuthValidator) -> None:
+        self._validator = validator
+
+    async def current_user(self, request: Request) -> AuthUser:
+        auth = request.headers.get("authorization")
+        if not auth:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="missing credentials",
+            )
+        # CalibreAuthValidator raises HTTPException(401/503) on failure;
+        # let those propagate verbatim so the wire shape matches the
+        # pre-refactor server.
+        user_id = await self._validator.validate(auth)
+        return AuthUser(
+            user_id=user_id,
+            backend="calibreweb",
+            session_token_hash=None,
+        )
+
+
+# ----------------------------------------------------------------------------
+# Native auth
+# ----------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+# Sentinel returned by ``revoke`` to indicate idempotent no-op. Tests use it
+# to assert the second logout of the same token is silent rather than 404.
+REVOKE_NOOP = "noop"
+REVOKE_OK = "ok"
+
+
+class NativeAuth:
+    """Email/password + opaque session tokens backend.
+
+    Operations:
+
+      * :meth:`register` — create a NativeUser with an argon2id hash. Used
+        by tests and (in Phase 1) by Cloud's signup flow. Returns the new
+        user id.
+      * :meth:`login` — verify email+password, mint a session token, return
+        ``(token_plain, expires_at)``. Constant-time against unknown email
+        via the dummy-hash trick.
+      * :meth:`revoke` — set ``revoked_at`` on the session matching the
+        given token hash. Idempotent: revoking an already-revoked or
+        unknown token returns silently.
+      * :meth:`current_user` — validate the Bearer token on an inbound
+        request, return the :class:`AuthUser`.
+
+    The class never touches FastAPI globals; it is constructed with an
+    async sessionmaker so unit tests can wire a clean engine without
+    spinning up an app.
+
+    All login/lookup paths fail with a single ``401 invalid credentials``
+    response body — the same shape used by :class:`CalibreAuthValidator`.
+    The reason for failure goes to the structured log only.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_factory: async_sessionmaker,
+        session_ttl_s: int,
+        clock: callable = _now_utc,  # type: ignore[valid-type]
+    ) -> None:
+        self._sf = session_factory
+        self._ttl_s = session_ttl_s
+        self._clock = clock
+
+    # ------------------------------------------------------------------ #
+    # Public API (called by the /auth/v1/* router and by tests)          #
+    # ------------------------------------------------------------------ #
+
+    async def register(self, *, email: str, password: str) -> int:
+        """Create a new NativeUser. Returns the new user's id.
+
+        The router exposes signup as a Cloud-controlled flow (Phase 1), so
+        the OSS server itself does NOT mount a signup endpoint. This method
+        is the building block used by tests and by the future control plane.
+
+        Raises ``ValueError`` on duplicate email; the router translates to
+        409 / 422 as appropriate.
+        """
+        canon = canonical_email(email)
+        if not canon:
+            raise ValueError("empty email")
+        if not password:
+            raise ValueError("empty password")
+        pw_hash = await hash_password(password)
+        async with self._sf() as s:
+            row = NativeUser(email=canon, password_hash=pw_hash)
+            s.add(row)
+            try:
+                await s.flush()
+                user_id = row.id
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+        return user_id
+
+    async def login(self, *, email: str, password: str) -> tuple[str, datetime]:
+        """Verify creds and issue a session.
+
+        Returns ``(token_plain, expires_at)`` on success. Raises
+        ``HTTPException(401, detail='invalid credentials')`` on any failure
+        (unknown email OR wrong password) AFTER running argon2-verify
+        against either the real hash or a precomputed dummy. The verify
+        cost dominates the DB hit/miss timing, so unknown-email and
+        wrong-password responses are not trivially distinguishable.
+        """
+        canon = canonical_email(email)
+        async with self._sf() as s:
+            user_row = None
+            if canon:
+                user_row = (
+                    await s.execute(
+                        select(NativeUser).where(NativeUser.email == canon)
+                    )
+                ).scalar_one_or_none()
+
+            if user_row is None:
+                # Run a verify against the dummy hash anyway so the failure
+                # path takes the same wall-clock cost as a real wrong-
+                # password. The result is discarded.
+                await verify_password(get_dummy_hash(), password or "")
+                logger.info("event=auth.login_failed reason=unknown_email")
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="invalid credentials",
+                )
+
+            ok = await verify_password(user_row.password_hash, password or "")
+            if not ok:
+                logger.info(
+                    "event=auth.login_failed reason=wrong_password user_id=%s",
+                    user_row.id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="invalid credentials",
+                )
+
+            token_plain, token_hash = generate_session_token()
+            now = self._clock()
+            expires_at = now + timedelta(seconds=self._ttl_s)
+            s.add(
+                NativeSession(
+                    token_hash=token_hash,
+                    user_id=user_row.id,
+                    expires_at=expires_at,
+                )
+            )
+            await s.commit()
+            logger.info(
+                "event=auth.login_ok user_id=%s expires_at=%s",
+                user_row.id,
+                expires_at.isoformat(),
+            )
+            return token_plain, expires_at
+
+    async def revoke(self, token_hash: str) -> str:
+        """Set ``revoked_at`` on the session matching ``token_hash``.
+
+        Idempotent: returns :data:`REVOKE_NOOP` if no live session matched
+        (either unknown hash or already-revoked), :data:`REVOKE_OK` on a
+        first-time revoke. The router treats both as 204.
+        """
+        now = self._clock()
+        async with self._sf() as s:
+            row = (
+                await s.execute(
+                    select(NativeSession).where(NativeSession.token_hash == token_hash)
+                )
+            ).scalar_one_or_none()
+            if row is None or row.revoked_at is not None:
+                return REVOKE_NOOP
+            row.revoked_at = now
+            await s.commit()
+            return REVOKE_OK
+
+    # ------------------------------------------------------------------ #
+    # AuthBackend protocol implementation                                #
+    # ------------------------------------------------------------------ #
+
+    async def current_user(self, request: Request) -> AuthUser:
+        token = _extract_bearer_token(request)
+        token_hash = hash_session_token(token)
+        now = self._clock()
+
+        async with self._sf() as s:
+            row = (
+                await s.execute(
+                    select(NativeSession).where(NativeSession.token_hash == token_hash)
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                logger.info("event=auth.session_invalid reason=unknown_token")
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="invalid credentials",
+                )
+            if row.revoked_at is not None:
+                logger.info(
+                    "event=auth.session_invalid reason=revoked user_id=%s",
+                    row.user_id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="invalid credentials",
+                )
+            if row.expires_at <= now:
+                logger.info(
+                    "event=auth.session_invalid reason=expired user_id=%s",
+                    row.user_id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="invalid credentials",
+                )
+            return AuthUser(
+                user_id=f"native:{row.user_id}",
+                backend="native",
+                session_token_hash=token_hash,
+            )
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _extract_bearer_token(request: Request) -> str:
+    """Pull the opaque token out of an ``Authorization: Bearer ...`` header.
+
+    Strict format: exactly ``"Bearer "`` followed by the token; no leading
+    whitespace, no trailing tokens, no tabs. All failure modes collapse to
+    a single 401 so the response shape mirrors the AI-routes token
+    authenticator.
+    """
+    header = request.headers.get("authorization", "")
+    if not header:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing credentials",
+        )
+    if not header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+        )
+    token = header[len("Bearer ") :]
+    if not token or " " in token or "\t" in token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+        )
+    return token

--- a/server/quire_server/core/auth_backend.py
+++ b/server/quire_server/core/auth_backend.py
@@ -231,9 +231,7 @@ class NativeAuth:
             user_row = None
             if canon:
                 user_row = (
-                    await s.execute(
-                        select(NativeUser).where(NativeUser.email == canon)
-                    )
+                    await s.execute(select(NativeUser).where(NativeUser.email == canon))
                 ).scalar_one_or_none()
 
             if user_row is None:
@@ -286,9 +284,7 @@ class NativeAuth:
         now = self._clock()
         async with self._sf() as s:
             row = (
-                await s.execute(
-                    select(NativeSession).where(NativeSession.token_hash == token_hash)
-                )
+                await s.execute(select(NativeSession).where(NativeSession.token_hash == token_hash))
             ).scalar_one_or_none()
             if row is None or row.revoked_at is not None:
                 return REVOKE_NOOP
@@ -307,9 +303,7 @@ class NativeAuth:
 
         async with self._sf() as s:
             row = (
-                await s.execute(
-                    select(NativeSession).where(NativeSession.token_hash == token_hash)
-                )
+                await s.execute(select(NativeSession).where(NativeSession.token_hash == token_hash))
             ).scalar_one_or_none()
             if row is None:
                 logger.info("event=auth.session_invalid reason=unknown_token")

--- a/server/quire_server/core/native_auth.py
+++ b/server/quire_server/core/native_auth.py
@@ -1,0 +1,190 @@
+"""NativeAuth primitives: password hashing, email canonicalization, tokens.
+
+Phase 0, task S-1 (per
+``docs/superpowers/specs/2026-05-22-quire-monetization-design.md``,
+"Architectural changes → Thin auth abstraction in ``quire_server``").
+
+This module holds the side-effect-free primitives used by the NativeAuth
+backend. The backend class itself lives in ``quire_server.core.auth_backend``.
+Splitting the two keeps the cryptographic surface trivially auditable.
+
+Scope discipline: this is the MINIMUM Cloud needs. No password reset, no
+magic-link delivery, no refresh tokens, no lockout. Those are deferred per
+spec.
+
+Argon2 parameters (m=64 MiB, t=3, p=4) sit above OWASP's current Argon2id
+minimum (m=19 MiB, t=2, p=1) and inside RFC 9106's recommended low-memory
+profile. The cost is calibrated so a single ``verify`` takes well under a
+second on the target Hetzner CX-class hardware; if capacity hurts later,
+reduce ``parallelism`` before reducing memory.
+
+Async story: argon2-cffi's ``hash`` / ``verify`` are synchronous and CPU-
+bound for tens of milliseconds. Running them on the asyncio event loop
+would stall every other request for the duration. All callers therefore
+go through ``anyio.to_thread.run_sync``.
+
+References:
+* `OWASP Password Storage Cheat Sheet
+  <https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html>`_
+* `RFC 9106 <https://www.rfc-editor.org/rfc/rfc9106.html>`_
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import unicodedata
+
+import anyio
+from argon2 import PasswordHasher
+from argon2.exceptions import (
+    InvalidHashError,
+    VerificationError,
+    VerifyMismatchError,
+)
+
+# ----------------------------------------------------------------------------
+# Argon2 configuration
+# ----------------------------------------------------------------------------
+# These constants are the single source of truth; the PasswordHasher singleton
+# is built from them. Tests import them directly to assert the deployed values.
+
+ARGON2_TIME_COST = 3
+ARGON2_MEMORY_COST_KIB = 64 * 1024  # 64 MiB
+ARGON2_PARALLELISM = 4
+ARGON2_HASH_LEN = 32
+ARGON2_SALT_LEN = 16
+
+# Hard cap on raw password byte length, applied BEFORE argon2 sees the input.
+# argon2-cffi happily accepts arbitrarily large inputs but a 1 MiB password
+# is purely a denial-of-service vector. The cap is generous (any human
+# password fits) and intentionally NOT exposed as config.
+MAX_PASSWORD_BYTES = 1024
+
+
+def _build_hasher() -> PasswordHasher:
+    return PasswordHasher(
+        time_cost=ARGON2_TIME_COST,
+        memory_cost=ARGON2_MEMORY_COST_KIB,
+        parallelism=ARGON2_PARALLELISM,
+        hash_len=ARGON2_HASH_LEN,
+        salt_len=ARGON2_SALT_LEN,
+    )
+
+
+# Module-level singleton. Building a PasswordHasher is cheap, but constructing
+# one per request would obscure the "all hashes use the same parameters"
+# invariant that ``check_needs_rehash`` callers depend on. Tests that need to
+# vary parameters build their own.
+_HASHER: PasswordHasher = _build_hasher()
+
+
+# Constant-time dummy hash: precomputed once at import time so the
+# unknown-email login path can ``verify`` against a real-shaped argon2 PHC
+# string. The plaintext is itself random so a clever attacker cannot guess
+# it offline and time the comparison. The value of the dummy doesn't matter
+# beyond "it's never going to match a real password".
+_DUMMY_HASH: str = _HASHER.hash(secrets.token_urlsafe(32))
+
+
+def get_password_hasher() -> PasswordHasher:
+    """Return the module-level PasswordHasher singleton."""
+    return _HASHER
+
+
+def get_dummy_hash() -> str:
+    """Return the precomputed dummy hash used for unknown-email login paths."""
+    return _DUMMY_HASH
+
+
+# ----------------------------------------------------------------------------
+# Async wrappers
+# ----------------------------------------------------------------------------
+
+
+async def hash_password(plain: str) -> str:
+    """Argon2id hash a password off the event loop.
+
+    Raises ``ValueError`` if the password exceeds ``MAX_PASSWORD_BYTES`` after
+    UTF-8 encoding. Empty passwords are accepted at this layer; the router
+    is responsible for rejecting them via pydantic ``min_length=1``.
+    """
+    if len(plain.encode("utf-8")) > MAX_PASSWORD_BYTES:
+        raise ValueError("password too long")
+    return await anyio.to_thread.run_sync(_HASHER.hash, plain)
+
+
+async def verify_password(stored_hash: str, plain: str) -> bool:
+    """Argon2 verify off the event loop.
+
+    Returns ``True`` on match, ``False`` on mismatch / malformed hash. Never
+    raises. Callers MUST run this exactly once per login attempt regardless
+    of whether the user exists — see the dummy-hash trick above.
+
+    Oversize passwords return ``False`` rather than raising so the unknown-
+    user code path (which receives the user-supplied plaintext blindly)
+    cannot be probed via a different error shape.
+    """
+    if len(plain.encode("utf-8")) > MAX_PASSWORD_BYTES:
+        return False
+    try:
+        return await anyio.to_thread.run_sync(_HASHER.verify, stored_hash, plain)
+    except VerifyMismatchError:
+        return False
+    except (VerificationError, InvalidHashError):
+        # A malformed stored hash should not crash login; treat as miss. The
+        # operator's monitoring picks up such rows separately.
+        return False
+
+
+# ----------------------------------------------------------------------------
+# Email canonicalization
+# ----------------------------------------------------------------------------
+
+
+def canonical_email(raw: str) -> str:
+    """Return the canonical storage form of an email address.
+
+    Rules (intentionally minimal):
+      * strip leading/trailing whitespace
+      * NFKC normalize the Unicode form
+      * casefold (which subsumes ``lower()`` for ASCII)
+
+    NOT IMPLEMENTED ON PURPOSE: gmail-style ``+tag`` stripping, domain
+    aliasing (``googlemail.com`` ↔ ``gmail.com``), IDN punycoding. Those
+    are policy decisions the OSS server should not make; Cloud's signup
+    flow can normalize further before calling ``register``.
+    """
+    return unicodedata.normalize("NFKC", raw.strip()).casefold()
+
+
+# ----------------------------------------------------------------------------
+# Session tokens
+# ----------------------------------------------------------------------------
+
+# 32 bytes of CSPRNG entropy → 43-char urlsafe-base64 string. Plenty of
+# entropy (256 bits) for an opaque bearer token. We keep ``token_urlsafe`` so
+# the token survives unencoded transport through ``Authorization: Bearer``.
+SESSION_TOKEN_ENTROPY_BYTES = 32
+
+
+def generate_session_token() -> tuple[str, str]:
+    """Mint a fresh opaque session token.
+
+    Returns ``(token_plain, token_hash_hex)``. The plaintext is what the
+    client sees once (in the login response) and sends back in subsequent
+    ``Authorization: Bearer`` headers. The hash is what the DB stores.
+
+    Hash function: SHA-256 hex digest. We are NOT using HMAC because there
+    is no server-side secret here: the hash exists only to prevent leak-by-
+    DB-read, not to authenticate the token. Token entropy alone (256 bits)
+    is sufficient against guessing.
+    """
+    token_plain = secrets.token_urlsafe(SESSION_TOKEN_ENTROPY_BYTES)
+    token_hash_hex = hashlib.sha256(token_plain.encode("ascii")).hexdigest()
+    return token_plain, token_hash_hex
+
+
+def hash_session_token(token_plain: str) -> str:
+    """Return the storage form for an incoming bearer token."""
+    return hashlib.sha256(token_plain.encode("ascii")).hexdigest()

--- a/server/quire_server/db/models.py
+++ b/server/quire_server/db/models.py
@@ -470,3 +470,70 @@ class ReaderProfile(Base):
     generated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+
+
+# ============================================================================
+# Native auth (Phase 0, task S-1) — `auth` branch.
+# ----------------------------------------------------------------------------
+# Email/password + opaque session token storage for the Cloud product. The
+# OSS server keeps CalibreWeb Basic auth as default; these tables only get
+# populated when `QUIRE_SERVER_AUTH_BACKEND=native`. They are always
+# materialized regardless of mode (the `auth` Alembic branch is unconditional)
+# so the schema is stable across deployments.
+#
+# Scope discipline (per 2026-05-22-quire-monetization-design.md
+# "Architectural changes → Thin auth abstraction in `quire_server`"):
+# self-host UX polish (password reset, recovery flows, abuse handling) is
+# explicitly deferred. These tables ship only the minimum Cloud needs.
+#
+# user_id namespace: a NativeUser surfaces in existing user-scoped tables
+# (Document.user_id, LibraryItem.user_id, user_ai_preferences.user_id,
+# ai_usage_daily.user_id) as the string `"native:<id>"`. Calibre users keep
+# their lowercase CWA username. Email is the login identity, NOT the storage
+# identity, so renaming an email never rewrites user-scoped rows.
+# ============================================================================
+class NativeUser(Base):
+    __tablename__ = "native_users"
+    __table_args__ = (
+        # The application always lowercases+casefolds before INSERT; the
+        # CHECK guarantees the stored value is canonical at the DB layer,
+        # so a buggy writer can't sneak an inconsistent casing past the
+        # unique index. `casefold()` is not exposed in Postgres, so we
+        # use the closest available rule (`lower()`) at the DB level. The
+        # app-side canonicalization is stricter (NFKC + casefold) — the
+        # DB check is the floor, not the ceiling.
+        CheckConstraint("email = lower(email)", name="ck_native_users_email_lower"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    email: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    # Argon2id PHC string. Stored verbatim; never compared to anything other
+    # than the configured PasswordHasher.
+    password_hash: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class NativeSession(Base):
+    __tablename__ = "native_sessions"
+    __table_args__ = (
+        Index("ix_native_sessions_user", "user_id"),
+        # Sweepers (future) will scan expired rows; index keeps that cheap.
+        Index("ix_native_sessions_expires", "expires_at"),
+    )
+
+    # PRIMARY KEY is the sha256(token) hex digest. The raw token never lives
+    # in the DB, only in the client's Bearer header. Compromise of the DB
+    # therefore does not yield active session secrets.
+    token_hash: Mapped[str] = mapped_column(String, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("native_users.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # NULL while the session is live; set to revocation time by `logout`.
+    # A revoked session is rejected even before its expires_at fires.
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/server/quire_server/db/models.py
+++ b/server/quire_server/db/models.py
@@ -32,6 +32,10 @@ class Document(Base):
     __table_args__ = (
         UniqueConstraint("user_id", "metadata_id", name="uq_documents_user_metadata"),
         UniqueConstraint("user_id", "content_hash", name="uq_documents_user_content_hash"),
+        CheckConstraint(
+            "identity_hash_version >= 1",
+            name="ck_documents_identity_hash_version_ge_1",
+        ),
         Index("ix_documents_user", "user_id"),
     )
 
@@ -39,6 +43,15 @@ class Document(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1 (one-way-door per 2026-05-22 monetization spec):
+    # version of the identity-hash algorithm used to derive `content_hash`.
+    # Persisted with every record so a future hash-function change does not
+    # break sync/cache/recs/export/deletion across millions of rows. Always
+    # >= 1; current rows backfill to 1 in migration `progress_003`. Clients
+    # reading vN rows recompute on next sync when their algorithm > N.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -108,6 +121,14 @@ class BookInsight(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version. NOT part of the
+    # cache key (see architect decision in Phase 0 plan): treated as row-
+    # freshness metadata only. A higher-version client hitting an existing
+    # cache row upgrades the persisted value via max(existing, incoming).
+    # CHECK constraint lives in migration `ai_007`.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     model_id: Mapped[str] = mapped_column(String, nullable=False)
     prompt_version: Mapped[str] = mapped_column(String, nullable=False)
     # Part of the cache key so users with different AiStyle.tone get their own
@@ -349,6 +370,13 @@ class LibraryItem(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version (see Document for
+    # full rationale). The CHECK constraint is declared in the alembic
+    # migration `progress_003` because partial-index-style metadata for
+    # this table lives there.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     authors: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list

--- a/server/quire_server/main.py
+++ b/server/quire_server/main.py
@@ -23,8 +23,38 @@ from quire_server.api import health
 from quire_server.api.middleware import RequestIDMiddleware, RequestSizeMiddleware
 from quire_server.config import Settings, get_settings
 from quire_server.core.auth import CalibreAuthValidator
+from quire_server.core.auth_backend import CalibreWebBasicAuth, NativeAuth
 from quire_server.core.logging_ctx import RequestIdLogFilter
 from quire_server.db.session import configure, make_engine, make_session_factory
+
+
+def _validate_auth_backend_settings(settings: Settings) -> None:
+    """Phase 0, task S-1: cross-config guard for the primary AuthBackend.
+
+    The independent AI auth seam (``ai_auth_mode``) means a Cloud-style
+    deployment that flips ``auth_backend`` to ``native`` could
+    accidentally leave ``ai_auth_mode=basic``, which would route AI
+    requests through CalibreWeb Basic — a backend that doesn't exist in
+    a Cloud deployment. Fail loudly at startup.
+
+    Valid combinations:
+      * ``auth_backend=calibreweb`` + any ``ai_auth_mode`` (today's OSS).
+      * ``auth_backend=native``    + ``ai_enabled=false`` OR
+                                     ``ai_auth_mode=token``.
+    """
+    if settings.auth_backend != "native":
+        return
+    if not settings.ai_enabled:
+        return
+    if settings.ai_auth_mode != "basic":
+        return
+    raise RuntimeError(
+        "QUIRE_SERVER_AUTH_BACKEND=native is incompatible with "
+        "QUIRE_SERVER_AI_AUTH_MODE=basic when AI is enabled: AI requests "
+        "would silently route through the CalibreWeb verifier. Either "
+        "disable AI (QUIRE_SERVER_AI_ENABLED=false) or switch AI auth to "
+        "token mode (QUIRE_SERVER_AI_AUTH_MODE=token)."
+    )
 
 
 def _validate_ai_auth_settings(settings: Settings) -> None:
@@ -111,6 +141,11 @@ def create_app() -> FastAPI:
 
     httpx_client = httpx.AsyncClient(timeout=settings.cwa_probe_timeout_s)
     app.state.httpx_client = httpx_client
+    # The CalibreWeb validator is kept constructed unconditionally so that
+    # tests overriding ``app.state.auth_validator`` (the pre-S-1 pattern)
+    # still work even in NativeAuth deployments. The AI-routes Basic
+    # authenticator also relies on its existence. In NativeAuth mode the
+    # primary-auth path simply doesn't dispatch through it.
     app.state.auth_validator = CalibreAuthValidator(
         client=httpx_client,
         cwa_base_url=settings.cwa_base_url,
@@ -120,6 +155,19 @@ def create_app() -> FastAPI:
         max_entries=settings.auth_cache_max_entries,
     )
 
+    # Phase 0, task S-1: pick the primary AuthBackend before any router
+    # mounts so /readyz and the AI-auth wiring below see a consistent
+    # picture. The cross-config guard runs first; misconfigurations
+    # crashloop here instead of silently 401-ing users.
+    _validate_auth_backend_settings(settings)
+    if settings.auth_backend == "native":
+        app.state.auth_backend = NativeAuth(
+            session_factory=session_factory,
+            session_ttl_s=settings.native_session_ttl_s,
+        )
+    else:
+        app.state.auth_backend = CalibreWebBasicAuth(app.state.auth_validator)
+
     @app.on_event("shutdown")
     async def _close() -> None:
         await httpx_client.aclose()
@@ -127,6 +175,14 @@ def create_app() -> FastAPI:
     # Always-on root endpoints (no prefix). Mounted before mode gates so they
     # remain available even when both flags are false.
     app.include_router(health.router)
+
+    # Phase 0, task S-1: ``/auth/v1/*`` exists only when NativeAuth is the
+    # primary backend. A CalibreWeb deployment treats those URLs as 404 —
+    # which is the correct shape for "this server doesn't speak that".
+    if settings.auth_backend == "native":
+        from quire_server.api.auth import router as auth_router
+
+        app.include_router(auth_router, prefix="/auth/v1")
 
     if settings.progress_enabled:
         # Lazy import: only pull progress + library routers when progress mode

--- a/server/scripts/migrate.py
+++ b/server/scripts/migrate.py
@@ -95,6 +95,14 @@ def run_migrations(cfg: Config, *, progress_enabled: bool, ai_enabled: bool) -> 
     if "core" in labels:
         _upgrade_branch(cfg, "core")
 
+    # Phase 0, task S-1: ``auth`` is foundational, not a feature. It carries
+    # NativeAuth tables that must exist whether or not the deployment has
+    # ``QUIRE_SERVER_AUTH_BACKEND=native`` set, so a flip between backends
+    # is config-only (no schema migration). Always upgrade when the label
+    # exists.
+    if "auth" in labels:
+        _upgrade_branch(cfg, "auth")
+
     if progress_enabled and "progress" in labels:
         _upgrade_branch(cfg, "progress")
     elif progress_enabled:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -137,6 +137,7 @@ def app_under_test(postgres_url, alembic_upgrade, monkeypatch, cwa_transport):
     get_settings.cache_clear()
 
     from quire_server.core.auth import CalibreAuthValidator
+    from quire_server.core.auth_backend import CalibreWebBasicAuth
     from quire_server.main import create_app
 
     app = create_app()
@@ -148,4 +149,9 @@ def app_under_test(postgres_url, alembic_upgrade, monkeypatch, cwa_transport):
         client=test_client,
         cwa_base_url="http://test-cwa",
     )
+    # Phase 0, task S-1: the primary auth dependency now resolves through
+    # ``app.state.auth_backend``, which captured a reference to the
+    # ORIGINAL validator at create_app() time. Rebuild the backend so it
+    # wraps the test's CWA-mock validator instead.
+    app.state.auth_backend = CalibreWebBasicAuth(app.state.auth_validator)
     return app

--- a/server/tests/integration/conftest.py
+++ b/server/tests/integration/conftest.py
@@ -43,7 +43,11 @@ async def _truncate_ai_tables_between_tests(request, engine: AsyncEngine):
                 "TRUNCATE TABLE book_insights, user_ai_preferences, "
                 "external_source_cache, ai_usage_daily, "
                 "insight_identity_aliases, library_items, "
-                "reader_profiles, progress, documents "
+                "reader_profiles, progress, documents, "
+                # Phase 0, task S-1: NativeAuth tables. Listed even when the
+                # test fixture defaults to CalibreWeb backend so opt-in
+                # NativeAuth tests start from a clean slate.
+                "native_sessions, native_users "
                 "RESTART IDENTITY CASCADE"
             )
         )

--- a/server/tests/integration/test_auth_backend.py
+++ b/server/tests/integration/test_auth_backend.py
@@ -1,0 +1,342 @@
+"""Integration tests for the AuthBackend seam (Phase 0, task S-1).
+
+Coverage:
+
+* NativeAuth login success returns a token + ISO expiry; the token round-
+  trips against a protected sync route (``GET /library/v1/items``).
+* Wrong password and unknown email return the SAME 401 body.
+* Logout revokes the session; the same token then fails.
+* Logout is idempotent at the token layer (second call → 401 from dep, OK).
+* Expired sessions are rejected.
+* Magic-link request returns 202; consume returns 501.
+* The ``/auth/v1/*`` router is NOT mounted under CalibreWeb mode.
+* Schema sanity: ``native_users`` + ``native_sessions`` exist.
+
+Tests opt out of ``client_factory``'s ``dependency_overrides`` plumbing
+via ``skip_auth_overrides=True`` so the REAL backend resolves requests.
+
+The ``app`` fixture is the shared ``_AppProxy`` from integration/conftest.py;
+it forwards attribute access to the most-recently created app, so reading
+``app.state.auth_backend`` after the factory returns yields the backend the
+test wants to exercise.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from quire_server.core.auth_backend import NativeAuth
+from quire_server.core.native_auth import get_dummy_hash, hash_session_token
+from quire_server.db.models import NativeSession, NativeUser
+
+# Common factory kwargs for every Native test. The `_isolate` mark is
+# attached at the test-function level so a slip into the default CalibreWeb
+# fixture path is impossible.
+_NATIVE_KW = {
+    "auth_backend": "native",
+    "ai_enabled": "false",
+    "skip_auth_overrides": True,
+}
+
+
+async def _register(app, *, email: str, password: str) -> int:
+    """Create a NativeUser via the backend's register() helper.
+
+    Bypasses HTTP because the OSS server intentionally does not mount a
+    signup endpoint (Cloud's control plane owns signup).
+    """
+    backend = app.state.auth_backend
+    assert isinstance(backend, NativeAuth)
+    return await backend.register(email=email, password=password)
+
+
+# ----------------------------------------------------------------------------
+# Default-mode (CalibreWeb) guarantees
+# ----------------------------------------------------------------------------
+
+
+async def test_calibreweb_mode_does_not_mount_auth_router(client_factory):
+    """In OSS / default mode the auth router is invisible."""
+    async with client_factory() as client:
+        r = await client.post(
+            "/auth/v1/login", json={"email": "x@y.z", "password": "p"}
+        )
+    assert r.status_code == 404
+
+
+# ----------------------------------------------------------------------------
+# NativeAuth happy path
+# ----------------------------------------------------------------------------
+
+
+async def test_native_login_success_returns_token_and_expiry(client_factory, app):
+    async with client_factory(**_NATIVE_KW) as client:
+        await _register(app, email="alice@example.com", password="hunter2-strong-pw")
+        r = await client.post(
+            "/auth/v1/login",
+            json={"email": "alice@example.com", "password": "hunter2-strong-pw"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert isinstance(body["token"], str) and len(body["token"]) >= 40
+    expires = datetime.fromisoformat(body["expires_at"])
+    assert expires > datetime.now(UTC)
+
+
+async def test_native_login_token_round_trips_protected_endpoint(client_factory, app):
+    """A login-issued token authenticates a real protected route."""
+    async with client_factory(**_NATIVE_KW) as client:
+        await _register(app, email="bob@example.com", password="bobs-strong-pw")
+        r = await client.post(
+            "/auth/v1/login",
+            json={"email": "bob@example.com", "password": "bobs-strong-pw"},
+        )
+        token = r.json()["token"]
+
+        # /library/v1/items is a sync route protected by current_user_id.
+        # With a Bearer token resolved through NativeAuth, the request must
+        # authenticate and return 200 (empty list for a fresh user).
+        r2 = await client.get(
+            "/library/v1/items",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r2.status_code == 200, r2.text
+
+
+# ----------------------------------------------------------------------------
+# Failure modes — unknown email vs wrong password are indistinguishable
+# ----------------------------------------------------------------------------
+
+
+async def test_unknown_email_and_wrong_password_return_identical_401(
+    client_factory, app
+):
+    """The response body shape must be byte-identical for both failures."""
+    async with client_factory(**_NATIVE_KW) as client:
+        await _register(app, email="carol@example.com", password="carols-strong-pw")
+        r_unknown = await client.post(
+            "/auth/v1/login",
+            json={"email": "nobody@example.com", "password": "anything"},
+        )
+        r_wrong = await client.post(
+            "/auth/v1/login",
+            json={"email": "carol@example.com", "password": "WRONG"},
+        )
+    assert r_unknown.status_code == 401
+    assert r_wrong.status_code == 401
+    assert r_unknown.json() == r_wrong.json() == {"detail": "invalid credentials"}
+
+
+async def test_unknown_email_triggers_dummy_hash_verify(monkeypatch, client_factory):
+    """Deterministic guarantee that the unknown-email path runs a real
+    verify against the dummy hash. Replaces a timing-based test which would
+    be flaky in CI.
+    """
+    calls: list[str] = []
+
+    async def _spy_verify(stored_hash: str, plain: str) -> bool:
+        calls.append(stored_hash)
+        return False
+
+    monkeypatch.setattr(
+        "quire_server.core.auth_backend.verify_password", _spy_verify
+    )
+
+    async with client_factory(**_NATIVE_KW) as client:
+        r = await client.post(
+            "/auth/v1/login",
+            json={"email": "ghost@example.com", "password": "anything"},
+        )
+    assert r.status_code == 401
+    # Exactly one verify call, against the precomputed dummy hash.
+    assert calls == [get_dummy_hash()]
+
+
+# ----------------------------------------------------------------------------
+# Logout / session lifecycle
+# ----------------------------------------------------------------------------
+
+
+async def test_logout_revokes_session(client_factory, app):
+    async with client_factory(**_NATIVE_KW) as client:
+        await _register(app, email="dave@example.com", password="daves-strong-pw")
+        login = await client.post(
+            "/auth/v1/login",
+            json={"email": "dave@example.com", "password": "daves-strong-pw"},
+        )
+        token = login.json()["token"]
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Pre-logout: token works.
+        r_before = await client.get("/library/v1/items", headers=headers)
+        assert r_before.status_code == 200
+
+        # Logout returns 204.
+        r_logout = await client.post("/auth/v1/logout", headers=headers)
+        assert r_logout.status_code == 204
+
+        # Post-logout: same token is now rejected.
+        r_after = await client.get("/library/v1/items", headers=headers)
+    assert r_after.status_code == 401
+    assert r_after.json() == {"detail": "invalid credentials"}
+
+
+async def test_logout_idempotent_at_token_layer(client_factory, app):
+    """A second logout with the same token gets 401 from current_auth_user
+    (the dep rejects revoked sessions before the route runs). That's the
+    contract: revoke-before-validate would let attackers iterate revocations.
+    """
+    async with client_factory(**_NATIVE_KW) as client:
+        await _register(app, email="erin@example.com", password="erins-strong-pw")
+        login = await client.post(
+            "/auth/v1/login",
+            json={"email": "erin@example.com", "password": "erins-strong-pw"},
+        )
+        token = login.json()["token"]
+        headers = {"Authorization": f"Bearer {token}"}
+
+        await client.post("/auth/v1/logout", headers=headers)
+        r2 = await client.post("/auth/v1/logout", headers=headers)
+    assert r2.status_code == 401
+
+
+async def test_expired_session_is_rejected(client_factory, app, engine):
+    """Backdating ``expires_at`` simulates an aged-out session."""
+    async with client_factory(**_NATIVE_KW) as client:
+        await _register(app, email="frank@example.com", password="franks-strong-pw")
+        login = await client.post(
+            "/auth/v1/login",
+            json={"email": "frank@example.com", "password": "franks-strong-pw"},
+        )
+        token = login.json()["token"]
+        token_hash = hash_session_token(token)
+
+        sf = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+        async with sf() as s:
+            row = (
+                await s.execute(
+                    select(NativeSession).where(
+                        NativeSession.token_hash == token_hash
+                    )
+                )
+            ).scalar_one()
+            row.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await s.commit()
+
+        r = await client.get(
+            "/library/v1/items",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 401
+
+
+# ----------------------------------------------------------------------------
+# Magic-link stubs
+# ----------------------------------------------------------------------------
+
+
+async def test_magic_link_request_returns_202_stub(client_factory):
+    async with client_factory(**_NATIVE_KW) as client:
+        r = await client.post(
+            "/auth/v1/magic-link/request", json={"email": "x@y.z"}
+        )
+    assert r.status_code == 202
+    body = r.json()
+    assert body["status"] == "accepted"
+    # Body documents itself as a stub.
+    detail = body["detail"].lower()
+    assert "magic-link" in detail or "not implemented" in detail or "stub" in detail
+
+
+async def test_magic_link_consume_returns_501(client_factory):
+    async with client_factory(**_NATIVE_KW) as client:
+        r = await client.get("/auth/v1/magic-link/consume?token=abc")
+    assert r.status_code == 501
+    assert r.json() == {"detail": "not implemented"}
+
+
+# ----------------------------------------------------------------------------
+# Email canonicalization at the storage layer
+# ----------------------------------------------------------------------------
+
+
+async def test_login_accepts_canonicalized_email(client_factory, app):
+    """Mixed-case + whitespace email at login matches the canonical row."""
+    async with client_factory(**_NATIVE_KW) as client:
+        await _register(app, email="grace@example.com", password="graces-strong-pw")
+        r = await client.post(
+            "/auth/v1/login",
+            json={"email": "  Grace@EXAMPLE.com  ", "password": "graces-strong-pw"},
+        )
+    assert r.status_code == 200
+
+
+# ----------------------------------------------------------------------------
+# Schema sanity
+# ----------------------------------------------------------------------------
+
+
+async def test_native_users_and_sessions_tables_exist(engine):
+    """The auth_001 migration must create both tables."""
+
+    def _introspect(sync_conn):
+        from sqlalchemy import inspect
+
+        insp = inspect(sync_conn)
+        return set(insp.get_table_names())
+
+    async with engine.connect() as conn:
+        names = await conn.run_sync(_introspect)
+
+    assert "native_users" in names
+    assert "native_sessions" in names
+
+
+@pytest.mark.parametrize("table", ["native_users", "native_sessions"])
+async def test_native_tables_have_expected_columns(engine, table):
+    def _introspect(sync_conn, table_name=table):
+        from sqlalchemy import inspect
+
+        insp = inspect(sync_conn)
+        return {c["name"]: c for c in insp.get_columns(table_name)}
+
+    async with engine.connect() as conn:
+        cols = await conn.run_sync(_introspect)
+
+    if table == "native_users":
+        assert {"id", "email", "password_hash", "created_at"}.issubset(cols.keys())
+    else:
+        assert {
+            "token_hash",
+            "user_id",
+            "created_at",
+            "expires_at",
+            "revoked_at",
+        }.issubset(cols.keys())
+
+
+# ----------------------------------------------------------------------------
+# register() helper: dedup constraint
+# ----------------------------------------------------------------------------
+
+
+async def test_native_user_unique_email_constraint(client_factory, app):
+    async with client_factory(**_NATIVE_KW):
+        await _register(app, email="dup@example.com", password="x-strong-pw")
+        from sqlalchemy.exc import IntegrityError
+
+        with pytest.raises(IntegrityError):
+            await _register(app, email="dup@example.com", password="other-strong-pw")
+        # Confirm only one row landed.
+        backend: NativeAuth = app.state.auth_backend  # type: ignore[assignment]
+        async with backend._sf() as s:  # type: ignore[attr-defined]
+            rows = (
+                await s.execute(
+                    select(NativeUser).where(NativeUser.email == "dup@example.com")
+                )
+            ).scalars().all()
+        assert len(rows) == 1

--- a/server/tests/integration/test_auth_backend.py
+++ b/server/tests/integration/test_auth_backend.py
@@ -39,6 +39,12 @@ from quire_server.db.models import NativeSession, NativeUser
 _NATIVE_KW = {
     "auth_backend": "native",
     "ai_enabled": "false",
+    # Force the library router on so the token-round-trip / logout / expired
+    # tests can exercise a real `current_user_id`-protected endpoint
+    # (`GET /library/v1/items`) under the `test (ai_only)` CI matrix entry,
+    # which sets `progress_enabled=false` globally. Tests that only hit
+    # `/auth/v1/*` are unaffected by the extra router being mounted.
+    "progress_enabled": "true",
     "skip_auth_overrides": True,
 }
 
@@ -62,9 +68,7 @@ async def _register(app, *, email: str, password: str) -> int:
 async def test_calibreweb_mode_does_not_mount_auth_router(client_factory):
     """In OSS / default mode the auth router is invisible."""
     async with client_factory() as client:
-        r = await client.post(
-            "/auth/v1/login", json={"email": "x@y.z", "password": "p"}
-        )
+        r = await client.post("/auth/v1/login", json={"email": "x@y.z", "password": "p"})
     assert r.status_code == 404
 
 
@@ -112,9 +116,7 @@ async def test_native_login_token_round_trips_protected_endpoint(client_factory,
 # ----------------------------------------------------------------------------
 
 
-async def test_unknown_email_and_wrong_password_return_identical_401(
-    client_factory, app
-):
+async def test_unknown_email_and_wrong_password_return_identical_401(client_factory, app):
     """The response body shape must be byte-identical for both failures."""
     async with client_factory(**_NATIVE_KW) as client:
         await _register(app, email="carol@example.com", password="carols-strong-pw")
@@ -142,9 +144,7 @@ async def test_unknown_email_triggers_dummy_hash_verify(monkeypatch, client_fact
         calls.append(stored_hash)
         return False
 
-    monkeypatch.setattr(
-        "quire_server.core.auth_backend.verify_password", _spy_verify
-    )
+    monkeypatch.setattr("quire_server.core.auth_backend.verify_password", _spy_verify)
 
     async with client_factory(**_NATIVE_KW) as client:
         r = await client.post(
@@ -218,11 +218,7 @@ async def test_expired_session_is_rejected(client_factory, app, engine):
         sf = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
         async with sf() as s:
             row = (
-                await s.execute(
-                    select(NativeSession).where(
-                        NativeSession.token_hash == token_hash
-                    )
-                )
+                await s.execute(select(NativeSession).where(NativeSession.token_hash == token_hash))
             ).scalar_one()
             row.expires_at = datetime.now(UTC) - timedelta(seconds=1)
             await s.commit()
@@ -241,9 +237,7 @@ async def test_expired_session_is_rejected(client_factory, app, engine):
 
 async def test_magic_link_request_returns_202_stub(client_factory):
     async with client_factory(**_NATIVE_KW) as client:
-        r = await client.post(
-            "/auth/v1/magic-link/request", json={"email": "x@y.z"}
-        )
+        r = await client.post("/auth/v1/magic-link/request", json={"email": "x@y.z"})
     assert r.status_code == 202
     body = r.json()
     assert body["status"] == "accepted"
@@ -335,8 +329,8 @@ async def test_native_user_unique_email_constraint(client_factory, app):
         backend: NativeAuth = app.state.auth_backend  # type: ignore[assignment]
         async with backend._sf() as s:  # type: ignore[attr-defined]
             rows = (
-                await s.execute(
-                    select(NativeUser).where(NativeUser.email == "dup@example.com")
-                )
-            ).scalars().all()
+                (await s.execute(select(NativeUser).where(NativeUser.email == "dup@example.com")))
+                .scalars()
+                .all()
+            )
         assert len(rows) == 1

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,12 +29,14 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # ai branch is at ai_007 (Phase 0 / task F-1 added
-    # `book_insights.identity_hash_version`); the progress branch is at
-    # progress_003 (same task, added `identity_hash_version` to
-    # `documents` + `library_items`). With the default-true mode flags,
-    # both branch heads are reported, sorted.
-    assert body["heads_applied"] == ["ai_007", "progress_003"]
+    # Phase 0 branch heads, sorted alphabetically:
+    #   * ai_007 (F-1, added `book_insights.identity_hash_version`)
+    #   * auth_001 (S-1, added `native_users` + `native_sessions`; the
+    #     ``auth`` branch is unconditionally upgraded — see
+    #     `scripts/migrate.py` and `health._required_heads`)
+    #   * progress_003 (F-1, added `identity_hash_version` to
+    #     `documents` + `library_items`)
+    assert body["heads_applied"] == ["ai_007", "auth_001", "progress_003"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,11 +29,12 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # ai branch is at ai_006 (pr-β added the audit-log generalization +
-    # profile_count column); the progress branch is at progress_002 (pr-α
-    # added abandoned_at). With the default-true mode flags, both branch
-    # heads are reported, sorted.
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`); the progress branch is at
+    # progress_003 (same task, added `identity_hash_version` to
+    # `documents` + `library_items`). With the default-true mode flags,
+    # both branch heads are reported, sorted.
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_library_items.py
+++ b/server/tests/integration/test_library_items.py
@@ -392,3 +392,87 @@ async def test_unauthenticated_request_rejected(app_under_test, unique_user):
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         r = await c.get("/library/v1/items")
     assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning on /library/v1/items.
+# ---------------------------------------------------------------------------
+# Three behaviours travel together:
+#   1. Default round-trip: omitting `identity_hash_version` in the PUT body
+#      persists as `1` and the GET response carries it.
+#   2. Explicit value round-trip: sending `identity_hash_version=2` persists
+#      `2` and the response/GET reflect it.
+#   3. Downgrade protection: after writing version `2`, a later PUT that
+#      defaults to `1` (or explicitly sends `1`) MUST keep the row at `2`.
+#      This is the `max(existing, incoming)` rule that prevents an old
+#      client from clobbering a newer client's row.
+
+
+async def test_identity_hash_version_defaults_to_1_when_absent(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 1
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.status_code == 200
+        items = r2.json()["items"]
+        assert len(items) == 1
+        assert items[0]["identity_hash_version"] == 1
+
+
+async def test_identity_hash_version_round_trips_explicit_value(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 2
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.json()["items"][0]["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_protects_against_downgrade(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Newer client writes v2.
+        r1 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r1.json()["identity_hash_version"] == 2
+
+        # Older client sends nothing (defaults to v1) — must NOT downgrade.
+        r2 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r2.status_code == 200
+        assert r2.json()["identity_hash_version"] == 2
+
+        # Explicit v1 must also not downgrade.
+        r3 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=1),
+            headers=headers,
+        )
+        assert r3.json()["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_rejects_zero(app_under_test, unique_user):
+    """Pydantic `ge=1` returns 422 for non-positive versions."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=0),
+            headers=headers,
+        )
+    assert r.status_code == 422, r.text

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -2,11 +2,11 @@
 
 Cases covered:
 1. Default state with real migrations: wrapper upgrades backbone + ai branch,
-   DB ends at ai@head (currently `ai_006`).
+   DB ends at ai@head (currently `ai_007`).
 2. Idempotent: running twice in a row is a no-op.
-3. Synthetic branched script directory (tmp copy of migrations + an ai_test_006
-   revision chained off the current ai@head):
-   - ai_enabled=true → upgrades to ai_test_006.
+3. Synthetic branched script directory (tmp copy of migrations + an
+   ai_test_008 revision chained off the current ai@head):
+   - ai_enabled=true → upgrades to ai_test_008.
    - ai_enabled=false → stays at 0004 (no ai branch applied).
 """
 
@@ -53,7 +53,7 @@ async def _downgrade_in_thread(cfg, target: str) -> None:
 
 
 async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str):
-    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_006)."""
+    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_007)."""
 
     # Wipe DB to fresh state.
     eng = create_async_engine(postgres_url, future=True)
@@ -66,9 +66,11 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch is at ai_006 (pr-β / Bundle 3 added the audit-log generalization
-    # + profile_count column). The progress branch is at progress_002.
-    assert versions == {"ai_006", "progress_002"}
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`). The progress branch is at
+    # progress_003 (same task, added the column to `documents` and
+    # `library_items`).
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
@@ -81,14 +83,14 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_006", "progress_002"}
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
-    """Copy real migrations to tmp + add a synthetic ai_test_007 chained off
-    ai_006; verify enabled run advances to ai_test_007 (the new ai@head)."""
+    """Copy real migrations to tmp + add a synthetic ai_test_008 chained off
+    ai_007; verify enabled run advances to ai_test_008 (the new ai@head)."""
 
-    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_006).
+    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_007).
     real_cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
 
@@ -96,22 +98,23 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
     versions_dir = synth_dir / "versions"
-    # Chain off ai_006 (the current ai@head after pr-β) with branch_labels=None.
-    (versions_dir / "ai_test_007.py").write_text(
+    # Chain off ai_007 (the current ai@head after Phase 0 / F-1) with
+    # branch_labels=None.
+    (versions_dir / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration.
 
-            Revision ID: ai_test_007
-            Revises: ai_006
-            Create Date: 2026-05-21 00:00:00.000000
+            Revision ID: ai_test_008
+            Revises: ai_007
+            Create Date: 2026-05-22 00:00:00.000000
             """
 
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -132,18 +135,18 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     # ai branch advances to the new tip.
-    assert "ai_test_007" in versions, versions
+    assert "ai_test_008" in versions, versions
     await eng.dispose()
 
     # Cleanup: roll back the synthetic migration so other tests aren't affected.
-    await _downgrade_in_thread(cfg, "ai_006")
+    await _downgrade_in_thread(cfg, "ai_007")
 
 
 async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
     """With ai_enabled=False, the wrapper skips advancing the ai branch.
 
     Pre-condition: DB is rolled back to 0004 (no ai branch applied), then the
-    wrapper is invoked with ai_enabled=False. ai_test_007 (the synthetic head)
+    wrapper is invoked with ai_enabled=False. ai_test_008 (the synthetic head)
     must NOT be applied; the backbone stays at 0004.
     """
     # Stamp DB back to backbone (pre-ai-branch state) for this test.
@@ -152,15 +155,15 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
 
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
-    (synth_dir / "versions" / "ai_test_007.py").write_text(
+    (synth_dir / "versions" / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration."""
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -179,17 +182,19 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch skipped → ai_test_007 not applied, ai_006 not applied,
-    # ai_001 not applied. The `progress` branch still advanced.
-    assert "ai_test_007" not in versions
+    # ai branch skipped → ai_test_008 not applied, ai_007 not applied,
+    # ai_006 not applied, ai_001 not applied. The `progress` branch still
+    # advanced.
+    assert "ai_test_008" not in versions
+    assert "ai_007" not in versions
     assert "ai_006" not in versions
     assert "ai_005" not in versions
     assert "ai_004" not in versions
     assert "ai_003" not in versions
     assert "ai_001" not in versions
     # progress branch advanced (progress_enabled=True). The backbone itself
-    # is no longer a head once progress_002 sits on top of 0004.
-    assert "progress_002" in versions
+    # is no longer a head once progress_003 sits on top of 0004.
+    assert "progress_003" in versions
 
     # Restore DB for subsequent tests.
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -66,11 +66,12 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch is at ai_007 (Phase 0 / task F-1 added
-    # `book_insights.identity_hash_version`). The progress branch is at
-    # progress_003 (same task, added the column to `documents` and
-    # `library_items`).
-    assert versions == {"ai_007", "progress_003"}
+    # Phase 0 branch heads:
+    #   * ai_007 — F-1 added `book_insights.identity_hash_version`
+    #   * auth_001 — S-1 added native_users + native_sessions (always-on
+    #     `auth` branch, materialized regardless of mode flags)
+    #   * progress_003 — F-1 added the column to `documents` + `library_items`
+    assert versions == {"ai_007", "auth_001", "progress_003"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
@@ -83,7 +84,7 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_007", "progress_003"}
+    assert versions == {"ai_007", "auth_001", "progress_003"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
@@ -184,7 +185,7 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     await eng.dispose()
     # ai branch skipped → ai_test_008 not applied, ai_007 not applied,
     # ai_006 not applied, ai_001 not applied. The `progress` branch still
-    # advanced.
+    # advanced; the always-on `auth` branch (Phase 0 / S-1) also advanced.
     assert "ai_test_008" not in versions
     assert "ai_007" not in versions
     assert "ai_006" not in versions
@@ -195,6 +196,8 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     # progress branch advanced (progress_enabled=True). The backbone itself
     # is no longer a head once progress_003 sits on top of 0004.
     assert "progress_003" in versions
+    # The always-on `auth` branch advances regardless of mode flags.
+    assert "auth_001" in versions
 
     # Restore DB for subsequent tests.
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -24,25 +24,32 @@ def _build_app(monkeypatch, postgres_url: str, *, progress: bool, ai: bool):
     return create_app()
 
 
-async def _stamp(postgres_url: str, revision: str) -> None:
-    """Forcibly set alembic_version to the given revision (single row).
+async def _stamp(postgres_url: str, revision: str | tuple[str, ...]) -> None:
+    """Forcibly set alembic_version to the given revision(s).
 
-    Bypasses Alembic so we can put the DB into states it wouldn't normally
-    reach via legal upgrade paths.
+    Accepts a single revision or a tuple of revisions (Alembic stores one
+    row per head, so multi-head DBs need a tuple). Bypasses Alembic so we
+    can put the DB into states it wouldn't normally reach via legal
+    upgrade paths.
     """
+    revs = (revision,) if isinstance(revision, str) else tuple(revision)
     eng = create_async_engine(postgres_url, future=True)
     async with eng.begin() as conn:
         await conn.execute(text("DELETE FROM alembic_version"))
-        await conn.execute(
-            text("INSERT INTO alembic_version (version_num) VALUES (:r)"),
-            {"r": revision},
-        )
+        for r in revs:
+            await conn.execute(
+                text("INSERT INTO alembic_version (version_num) VALUES (:r)"),
+                {"r": r},
+            )
     await eng.dispose()
 
 
 async def _restore_to_0004(postgres_url: str) -> None:
-    """Set alembic_version row back to 0004 (the real schema state)."""
-    await _stamp(postgres_url, "0004")
+    """Set alembic_version rows back to {0004, auth_001} — the canonical
+    "backbone + always-on auth branch" state expected by the rest of the
+    suite (which depends on the session-scoped alembic_upgrade fixture).
+    """
+    await _stamp(postgres_url, ("0004", "auth_001"))
 
 
 @pytest.fixture
@@ -73,15 +80,18 @@ async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upg
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_007", "progress_003"]
+    # Phase 0, task S-1 added the always-materialized `auth` branch:
+    # `auth_001` joins `ai_007` / `progress_003` in `heads_applied`.
+    assert body["heads_applied"] == ["ai_007", "auth_001", "progress_003"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
-    """DB stamped below backbone; with both modes enabled, required head is
-    ai_007 (ai@head after Phase 0 / F-1) — that's what should be reported
-    missing."""
+    """DB stamped below backbone; with both modes enabled, required heads
+    include ai_007 (ai@head after Phase 0 / F-1) and auth_001 (auth@head
+    after Phase 0 / S-1) — both should be reported missing.
+    """
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -90,25 +100,29 @@ async def test_readyz_503_when_db_below_backbone(
     body = r.json()
     assert body["ready"] is False
     assert "ai_007" in body["missing"]
+    assert "auth_001" in body["missing"]
 
 
 async def test_readyz_200_with_neither_mode_at_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
-    """With neither mode enabled, backbone tip (0004) is the only required head.
+    """With neither feature-mode enabled, the required heads collapse to
+    {backbone, auth} — `auth` is unconditionally required (Phase 0 / S-1).
 
-    Stamp the DB to 0004 explicitly because the session-scoped fixture brings
-    everything up to ai@head; we want to exercise the "fresh sync-only deploy
-    that never materialized the ai branch" code path.
+    Stamp the DB to ``(0004, auth_001)`` to exercise the "fresh sync-only
+    deploy that never materialized the ai or progress branches" code path.
     """
-    await _stamp(postgres_url, "0004")
+    await _stamp(postgres_url, ("0004", "auth_001"))
     app = _build_app(monkeypatch, postgres_url, progress=False, ai=False)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.get("/readyz")
     assert r.status_code == 200
     body = r.json()
     assert body["modes"] == []
-    assert body["heads_applied"] == ["0004"]
+    # ``heads_applied`` lists every row in ``alembic_version`` (sorted).
+    # We stamped both to simulate a deploy that explicitly walked the
+    # backbone + always-on ``auth`` branch.
+    assert body["heads_applied"] == ["0004", "auth_001"]
 
 
 async def test_readyz_503_with_neither_mode_below_backbone(
@@ -120,4 +134,5 @@ async def test_readyz_503_with_neither_mode_below_backbone(
         r = await c.get("/readyz")
     assert r.status_code == 503
     body = r.json()
-    assert "0004" in body["missing"]
+    # Both the backbone tip and the always-on `auth` head are missing.
+    assert "auth_001" in body["missing"]

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -53,8 +53,9 @@ async def restore_after(postgres_url: str, alembic_upgrade):
 
 
 async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
-    """With ai@head (ai_006) + progress@head (progress_002) materialized,
-    /readyz reports both heads. (ai_006 added by pr-β.)
+    """With ai@head (ai_007) + progress@head (progress_003) materialized,
+    /readyz reports both heads. (ai_007 / progress_003 added by Phase 0
+    task F-1: server identity-hash schema versioning.)
     """
     # Some earlier test in the session may have downgraded the DB
     # (test_migrate_script.py exercises rollback). Ensure both branches are
@@ -72,14 +73,15 @@ async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upg
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
     """DB stamped below backbone; with both modes enabled, required head is
-    ai_006 (ai@head after pr-β) — that's what should be reported missing."""
+    ai_007 (ai@head after Phase 0 / F-1) — that's what should be reported
+    missing."""
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -87,7 +89,7 @@ async def test_readyz_503_when_db_below_backbone(
     assert r.status_code == 503
     body = r.json()
     assert body["ready"] is False
-    assert "ai_006" in body["missing"]
+    assert "ai_007" in body["missing"]
 
 
 async def test_readyz_200_with_neither_mode_at_backbone(

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -154,6 +154,65 @@ async def test_library_items_table_exists(engine) -> None:
     assert where_alive is not None and "deleted_at" in str(where_alive).lower()
 
 
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning (server side).
+# ---------------------------------------------------------------------------
+# Two migrations land the same `identity_hash_version INTEGER NOT NULL DEFAULT 1`
+# column with `CHECK (>= 1)`:
+#   * `progress_003` → `documents`, `library_items`.
+#   * `ai_007`       → `book_insights`.
+# These tests reflect the live schema (post-migration) and assert the column
+# shape on every table that should carry it.
+
+
+def _identity_hash_version_column_meta(sync_conn, table: str) -> dict:
+    insp = inspect(sync_conn)
+    cols = {c["name"]: c for c in insp.get_columns(table)}
+    checks = {c["name"]: c for c in insp.get_check_constraints(table)}
+    return {"col": cols.get("identity_hash_version"), "checks": checks}
+
+
+async def test_documents_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "documents")
+    col = info["col"]
+    assert col is not None, "documents.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_documents_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_progress
+async def test_library_items_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "library_items")
+    col = info["col"]
+    assert col is not None, "library_items.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_library_items_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_ai
+async def test_book_insights_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "book_insights")
+    col = info["col"]
+    assert col is not None, "book_insights.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_book_insights_identity_hash_version_ge_1" in info["checks"]
+
+
+async def test_documents_identity_hash_version_default_round_trip(session) -> None:
+    """A row created without supplying `identity_hash_version` defaults to 1."""
+    doc = Document(user_id="alice-v1", metadata_id="md-ver-1", content_hash="ch-ver-1")
+    session.add(doc)
+    await session.commit()
+    await session.refresh(doc)
+    assert doc.identity_hash_version == 1
+
+
 @pytest.mark.requires_ai
 async def test_ai_generation_log_round_trip(session) -> None:
     """ORM model writes and reads ai_generation_log rows."""

--- a/server/tests/unit/test_auth_backend_config.py
+++ b/server/tests/unit/test_auth_backend_config.py
@@ -1,0 +1,161 @@
+"""Unit tests for ``QUIRE_SERVER_AUTH_BACKEND`` wiring and the cross-config
+guard between primary auth and AI auth.
+
+These tests exercise the real ``create_app()`` factory but never touch the
+DB (the engine is constructed lazily), so they belong with the other
+``test_main_*_validation`` files in tests/unit/.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from quire_server.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Strip every auth-related env var so each test starts from defaults."""
+    for var in (
+        "QUIRE_SERVER_AUTH_BACKEND",
+        "QUIRE_SERVER_AI_ENABLED",
+        "QUIRE_SERVER_AI_AUTH_MODE",
+        "QUIRE_SERVER_AI_TOKEN_SECRETS",
+        "QUIRE_SERVER_AI_TOKEN_ISSUER",
+        "QUIRE_SERVER_AI_TOKEN_AUDIENCE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("QUIRE_SERVER_DATABASE_URL", "postgresql+asyncpg://x/y")
+    monkeypatch.setenv("QUIRE_SERVER_CWA_BASE_URL", "http://stub")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _create_app():
+    from quire_server.main import create_app
+
+    return create_app()
+
+
+# ----------------------------------------------------------------------------
+# Default: CalibreWeb Basic
+# ----------------------------------------------------------------------------
+
+
+def test_default_backend_is_calibreweb():
+    app = _create_app()
+    from quire_server.core.auth_backend import CalibreWebBasicAuth
+
+    assert isinstance(app.state.auth_backend, CalibreWebBasicAuth)
+
+
+def test_calibreweb_backend_does_not_mount_auth_router():
+    """OSS deployments should not surface ``/auth/v1/*`` at all."""
+    app = _create_app()
+    routes = [r.path for r in app.routes if hasattr(r, "path")]
+    assert not any(p.startswith("/auth/v1") for p in routes), routes
+
+
+# ----------------------------------------------------------------------------
+# Native backend opt-in
+# ----------------------------------------------------------------------------
+
+
+def test_native_backend_via_env(monkeypatch):
+    monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
+    # Native + AI-enabled-basic would trigger the guard; pair with AI off.
+    monkeypatch.setenv("QUIRE_SERVER_AI_ENABLED", "false")
+    app = _create_app()
+    from quire_server.core.auth_backend import NativeAuth
+
+    assert isinstance(app.state.auth_backend, NativeAuth)
+
+
+def test_native_backend_mounts_auth_router(monkeypatch):
+    monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
+    monkeypatch.setenv("QUIRE_SERVER_AI_ENABLED", "false")
+    app = _create_app()
+    routes = [r.path for r in app.routes if hasattr(r, "path")]
+    assert any(p == "/auth/v1/login" for p in routes), routes
+    assert any(p == "/auth/v1/logout" for p in routes), routes
+    assert any(p == "/auth/v1/magic-link/request" for p in routes), routes
+    assert any(p == "/auth/v1/magic-link/consume" for p in routes), routes
+
+
+# ----------------------------------------------------------------------------
+# Cross-config guard: native + AI-on + basic AI auth must crashloop
+# ----------------------------------------------------------------------------
+
+
+def test_native_with_ai_basic_auth_raises(monkeypatch):
+    """Native primary auth + AI on + ``ai_auth_mode=basic`` would silently
+    route AI requests through CalibreWeb. The factory must refuse.
+    """
+    monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
+    monkeypatch.setenv("QUIRE_SERVER_AI_ENABLED", "true")
+    # ai_auth_mode defaults to "basic"; leave unset.
+    with pytest.raises(RuntimeError, match="AI_AUTH_MODE=basic"):
+        _create_app()
+
+
+def test_native_with_ai_token_auth_is_ok(monkeypatch):
+    """Token-mode AI auth is independent from primary auth → no guard hit."""
+    monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
+    monkeypatch.setenv("QUIRE_SERVER_AI_ENABLED", "true")
+    monkeypatch.setenv("QUIRE_SERVER_AI_AUTH_MODE", "token")
+    monkeypatch.setenv(
+        "QUIRE_SERVER_AI_TOKEN_SECRETS", '{"k1": "' + "x" * 32 + '"}'
+    )
+    monkeypatch.setenv("QUIRE_SERVER_AI_TOKEN_ISSUER", "quire-cloud")
+    monkeypatch.setenv("QUIRE_SERVER_AI_TOKEN_AUDIENCE", "quire-server")
+    app = _create_app()
+    from quire_server.core.auth_backend import NativeAuth
+
+    assert isinstance(app.state.auth_backend, NativeAuth)
+
+
+def test_native_with_ai_off_is_ok(monkeypatch):
+    """AI disabled → guard does not fire regardless of ai_auth_mode default."""
+    monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
+    monkeypatch.setenv("QUIRE_SERVER_AI_ENABLED", "false")
+    app = _create_app()
+    from quire_server.core.auth_backend import NativeAuth
+
+    assert isinstance(app.state.auth_backend, NativeAuth)
+
+
+def test_calibreweb_with_ai_basic_is_ok():
+    """The pre-S-1 default combination must keep working byte-for-byte."""
+    # All env stripped → defaults apply.
+    app = _create_app()
+    from quire_server.core.auth_backend import CalibreWebBasicAuth
+
+    assert isinstance(app.state.auth_backend, CalibreWebBasicAuth)
+
+
+# ----------------------------------------------------------------------------
+# Settings exposure
+# ----------------------------------------------------------------------------
+
+
+def test_settings_auth_backend_default():
+    from quire_server.config import Settings
+
+    s = Settings()
+    assert s.auth_backend == "calibreweb"
+
+
+def test_settings_auth_backend_env_override(monkeypatch):
+    monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
+    from quire_server.config import Settings
+
+    s = Settings()
+    assert s.auth_backend == "native"
+
+
+def test_settings_native_session_ttl_default():
+    from quire_server.config import Settings
+
+    s = Settings()
+    assert s.native_session_ttl_s == 30 * 24 * 3600

--- a/server/tests/unit/test_auth_backend_config.py
+++ b/server/tests/unit/test_auth_backend_config.py
@@ -104,9 +104,7 @@ def test_native_with_ai_token_auth_is_ok(monkeypatch):
     monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
     monkeypatch.setenv("QUIRE_SERVER_AI_ENABLED", "true")
     monkeypatch.setenv("QUIRE_SERVER_AI_AUTH_MODE", "token")
-    monkeypatch.setenv(
-        "QUIRE_SERVER_AI_TOKEN_SECRETS", '{"k1": "' + "x" * 32 + '"}'
-    )
+    monkeypatch.setenv("QUIRE_SERVER_AI_TOKEN_SECRETS", '{"k1": "' + "x" * 32 + '"}')
     monkeypatch.setenv("QUIRE_SERVER_AI_TOKEN_ISSUER", "quire-cloud")
     monkeypatch.setenv("QUIRE_SERVER_AI_TOKEN_AUDIENCE", "quire-server")
     app = _create_app()

--- a/server/tests/unit/test_main_ai_auth_validation.py
+++ b/server/tests/unit/test_main_ai_auth_validation.py
@@ -29,6 +29,9 @@ def _isolate_env(monkeypatch):
         "QUIRE_SERVER_AI_BASE_URL",
         "QUIRE_SERVER_AI_MODEL",
         "QUIRE_SERVER_AI_API_KEY",
+        # Phase 0, task S-1: keep these tests focused on AI auth wiring;
+        # the primary auth backend must stay at its default ``calibreweb``.
+        "QUIRE_SERVER_AUTH_BACKEND",
     ):
         monkeypatch.delenv(var, raising=False)
     # Avoid the real DB / CWA wiring touching the network in create_app.

--- a/server/tests/unit/test_native_auth.py
+++ b/server/tests/unit/test_native_auth.py
@@ -1,0 +1,148 @@
+"""Unit tests for :mod:`quire_server.core.native_auth`.
+
+Scope: side-effect-free primitives only. The NativeAuth backend itself
+(login/logout DB interactions) is covered by the integration suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from quire_server.core.native_auth import (
+    ARGON2_MEMORY_COST_KIB,
+    ARGON2_PARALLELISM,
+    ARGON2_TIME_COST,
+    MAX_PASSWORD_BYTES,
+    canonical_email,
+    generate_session_token,
+    get_dummy_hash,
+    get_password_hasher,
+    hash_password,
+    hash_session_token,
+    verify_password,
+)
+
+# ----------------------------------------------------------------------------
+# Argon2 parameter pinning
+# ----------------------------------------------------------------------------
+
+
+def test_argon2_parameters_match_owasp_strong_profile():
+    """The deployed argon2id parameters sit above OWASP's current minimum.
+
+    Tests pin the exact values so a future drive-by tweak to the constants
+    surfaces in code review rather than silently weakening every new hash.
+    """
+    assert ARGON2_TIME_COST == 3
+    assert ARGON2_MEMORY_COST_KIB == 64 * 1024  # 64 MiB
+    assert ARGON2_PARALLELISM == 4
+
+
+def test_hasher_singleton_uses_configured_parameters():
+    h = get_password_hasher()
+    assert h.time_cost == ARGON2_TIME_COST
+    assert h.memory_cost == ARGON2_MEMORY_COST_KIB
+    assert h.parallelism == ARGON2_PARALLELISM
+
+
+def test_dummy_hash_is_a_valid_phc_string():
+    """The dummy hash must be a real argon2id PHC string so verify() against
+    it follows the same code path as a verify against a real user row.
+    """
+    dummy = get_dummy_hash()
+    assert dummy.startswith("$argon2id$"), dummy
+    # Same hasher must recognise the dummy as well-formed (returns False on
+    # mismatch, not an exception).
+    h = get_password_hasher()
+    from argon2.exceptions import VerifyMismatchError
+
+    with pytest.raises(VerifyMismatchError):
+        h.verify(dummy, "definitely not the dummy plaintext")
+
+
+# ----------------------------------------------------------------------------
+# hash_password / verify_password
+# ----------------------------------------------------------------------------
+
+
+async def test_hash_and_verify_round_trip():
+    pw = "correct horse battery staple"
+    h = await hash_password(pw)
+    assert await verify_password(h, pw) is True
+
+
+async def test_verify_wrong_password_is_false():
+    h = await hash_password("hunter2")
+    assert await verify_password(h, "hunter3") is False
+
+
+async def test_verify_malformed_hash_is_false_not_exception():
+    """A garbage stored hash must not crash login; it returns False."""
+    assert await verify_password("not-a-real-argon2-string", "anything") is False
+
+
+async def test_hash_password_rejects_oversize_input():
+    pw = "a" * (MAX_PASSWORD_BYTES + 1)
+    with pytest.raises(ValueError, match="too long"):
+        await hash_password(pw)
+
+
+async def test_verify_oversize_returns_false_silently():
+    """A login attempt with an absurdly-long password must not raise; the
+    response shape stays identical to a plain wrong-password attempt."""
+    h = await hash_password("short")
+    over = "a" * (MAX_PASSWORD_BYTES + 1)
+    assert await verify_password(h, over) is False
+
+
+# ----------------------------------------------------------------------------
+# Email canonicalization
+# ----------------------------------------------------------------------------
+
+
+def test_canonical_email_strips_whitespace_and_casefolds():
+    assert canonical_email("  Alice@Example.COM ") == "alice@example.com"
+
+
+def test_canonical_email_nfkc_normalizes_compatibility_forms():
+    # `ﬃ` is the U+FB03 ligature; NFKC decomposes it to "ffi".
+    assert canonical_email("oﬃce@x.com") == "office@x.com"
+
+
+def test_canonical_email_does_not_strip_gmail_plus_tag():
+    """Intentional non-feature: gmail-style tag handling is out of scope."""
+    assert canonical_email("Bob+spam@example.com") == "bob+spam@example.com"
+
+
+def test_canonical_email_empty_returns_empty():
+    assert canonical_email("   ") == ""
+
+
+# ----------------------------------------------------------------------------
+# Session tokens
+# ----------------------------------------------------------------------------
+
+
+def test_generate_session_token_returns_distinct_pair():
+    t1, h1 = generate_session_token()
+    t2, h2 = generate_session_token()
+    assert t1 != t2
+    assert h1 != h2
+    # Token uses urlsafe alphabet only.
+    assert all(c.isalnum() or c in "-_" for c in t1)
+
+
+def test_hash_session_token_is_sha256_hex():
+    token = "deadbeef"
+    h = hash_session_token(token)
+    # 64 hex chars = 256 bits of SHA-256.
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_hash_session_token_matches_generator_hash():
+    """The pair-generator and the standalone hasher must agree byte-for-byte
+    so the DB lookup at validate-time finds the row written at login-time.
+    """
+    token, expected_hash = generate_session_token()
+    assert hash_session_token(token) == expected_hash


### PR DESCRIPTION
## Summary

Implements Phase 0 task **S-1** of the Quire monetization plan: refactors the OSS server's primary authentication from the hard-coded CalibreWeb-Basic flow into a thin `AuthBackend` Protocol with two implementations, and adds a minimum-viable `NativeAuth` backend for the future Quire Cloud product.

**OSS users are unaffected.** `CalibreWebBasicAuth` remains the default, wrapping the existing `CalibreAuthValidator` byte-for-byte. The new `NativeAuth` backend activates only when an operator sets `QUIRE_SERVER_AUTH_BACKEND=native`.

> **Stacking note:** this PR is stacked on top of [PR #47 (F-1)](https://github.com/vitofico/quire/pull/47). Until F-1 merges, the diff displayed by GitHub will include F-1's commits; the S-1 work is the three commits at the tip of this branch.

## Spec references

- Spec authority: `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`
  - "Architectural changes -> Thin auth abstraction in `quire_server`"
  - "Build sequence -> Phase 0" item (3)

## What ships

### `AuthBackend` seam (`quire_server.core.auth_backend`)

- `AuthUser` frozen dataclass: `user_id`, `backend`, `session_token_hash`.
- `AuthBackend` Protocol: `async current_user(request) -> AuthUser`.
- `CalibreWebBasicAuth` wraps the existing validator; emits `user_id` = lowercase CWA username.
- `NativeAuth` with explicit public `register` / `login` / `revoke` / `current_user`. Emits `user_id` = `"native:<NativeUser.id>"` so the storage namespace never collides with CalibreWeb users.

### NativeAuth primitives (`quire_server.core.native_auth`)

- argon2id `PasswordHasher` singleton, parameters **t=3, m=64 MiB, p=4, hash_len=32, salt_len=16** -- above OWASP's Argon2id minimum and inside RFC 9106's recommended profile.
- `hash_password` / `verify_password` run argon2 off the event loop via `anyio.to_thread.run_sync`.
- Constant-time unknown-email path: a precomputed dummy PHC hash is verified against on every login attempt where the email is unknown, so wrong-password and unknown-email responses are indistinguishable in cost and in body.
- Email canonicalization: `strip + NFKC + casefold`. (No gmail-tag stripping, no domain aliasing.)
- Session tokens: 32 bytes from `secrets.token_urlsafe`, stored as `sha256(token)` hex. Plaintext lives only in the client.

### Public dependency wiring (`quire_server.core.auth`)

- `current_user_id` keeps its `-> str` signature; existing route consumers and dependency overrides are untouched. Internally it resolves through the configured `AuthBackend`.
- `current_auth_user` is a new dependency for endpoints (logout) that need the full `AuthUser` + session token hash.

### `/auth/v1/*` router (mounted only under Native mode)

- `POST /login` -- verify creds, return `{token, expires_at}`. All failures collapse to `401 {"detail": "invalid credentials"}`.
- `POST /logout` -- revoke the current bearer. 204.
- `POST /magic-link/request` -- **STUB.** Always 202; sends nothing. Documented in body and code.
- `GET /magic-link/consume` -- **STUB.** Always 501.

### Schema (`auth_001_native_users_and_sessions`)

New `auth` Alembic branch labeled at the first revision, descended from backbone tip `0004`. The branch is **always materialized** (no env gate) so switching backends is a config-only flip.

- `native_users(id, email UNIQUE + CHECK lower(email), password_hash, created_at)`
- `native_sessions(token_hash PK, user_id FK CASCADE, created_at, expires_at, revoked_at)`. Indexed on `user_id` and `expires_at`.

`scripts/migrate.py` upgrades `auth@head` unconditionally; `health._required_heads` lists `auth` so `/readyz` reports missing heads to deployers who forget to migrate.

### App-factory cross-config guard

`auth_backend=native` + `ai_enabled=true` + `ai_auth_mode=basic` raises `RuntimeError` at startup. Without this, AI requests in a Cloud-style deployment would silently route through the CalibreWeb verifier that no longer exists upstream.

### New env knobs

- `QUIRE_SERVER_AUTH_BACKEND` -- `calibreweb` (default) or `native`.
- `QUIRE_SERVER_NATIVE_SESSION_TTL_S` -- session lifetime; default 30 days.

### Dependency

`argon2-cffi >= 23.1` -- canonical Python argon2 binding.

## Scope discipline (per spec)

**Deferred -- explicitly not in this PR:**

- Signup endpoint (Cloud's control plane owns signup; `register` exists only as a backend method for tests + control plane to call out-of-band).
- Password reset / recovery / email change flows.
- Real magic-link email delivery.
- Refresh tokens.
- Rate limiting, lockout, CAPTCHA.
- MFA, OAuth, CSRF.
- Account-deletion / DSAR endpoints.
- Audit-log surfacing.
- Session sweeper.

## Files changed

- `server/migrations/versions/auth_001_native_users_and_sessions.py` (new)
- `server/quire_server/core/native_auth.py` (new)
- `server/quire_server/core/auth_backend.py` (new)
- `server/quire_server/api/auth.py` (new)
- `server/quire_server/core/auth.py` -- `current_user_id` now resolves through the configured backend; added `current_auth_user`.
- `server/quire_server/db/models.py` -- `NativeUser`, `NativeSession`.
- `server/quire_server/config.py` -- `auth_backend`, `native_session_ttl_s`.
- `server/quire_server/main.py` -- backend selection, conditional auth router mount, cross-config guard.
- `server/quire_server/api/health.py` -- `auth` is always-required in `_required_heads`.
- `server/scripts/migrate.py` -- always upgrade `auth@head`.
- `server/pyproject.toml` -- `argon2-cffi` dependency.
- `server/tests/unit/test_native_auth.py` (new)
- `server/tests/unit/test_auth_backend_config.py` (new)
- `server/tests/integration/test_auth_backend.py` (new)
- `server/tests/conftest.py`, `server/tests/integration/conftest.py` -- truncate list extension, fixture refresh for backend rebuild.
- `server/tests/integration/test_health.py`, `test_readyz_migration_state.py`, `test_migrate_script.py` -- pinned heads include `auth_001`.
- `server/tests/unit/test_main_ai_auth_validation.py` -- isolate fixture also strips `QUIRE_SERVER_AUTH_BACKEND`.

## Verification

```
cd server && uv run pytest && uv run ruff check
```

```
====================== 466 passed, 306 warnings in 18.45s ======================
All checks passed!
```

## Test plan

- [x] `uv run pytest` passes (466 tests, includes the new unit + integration coverage)
- [x] `uv run ruff check` clean
- [x] Existing CalibreWeb-Basic behavior preserved (every prior integration test still green)
- [x] New unit coverage for argon2 params, password round-trip, email canonicalization, token hashing
- [x] New unit coverage for backend selection, router mounting, cross-config guard
- [x] New integration coverage for login success, login failure parity, dummy-hash determinism, logout revocation, idempotent re-logout, expired session, magic-link stubs, mixed-case email match, table schema, unique-email constraint
- [ ] Manual smoke before paid Cloud launch (deferred to Phase 1)

## Unresolved questions for the coordinator

1. **Cloud signup endpoint placement.** `NativeAuth.register()` exists as a backend method but is not exposed via HTTP. Phase 1 needs to decide whether the closed control plane calls it via cross-process RPC, via a private admin endpoint in the OSS server gated by a service token, or by sharing the Postgres connection. I have not picked a path; the spec leaves it open.
2. **Identity-hash version on auth tables.** F-1 added `identity_hash_version` to every record carrying an identity hash. The auth tables carry none, so they were left untouched -- if the coordinator wants user records to also carry an audit-version column for analogous reasons, that's a separate, follow-up migration.
3. **Email validator dependency.** I deliberately avoided `pydantic.EmailStr` (it pulls in `email-validator`). Cloud's signup flow will need format validation somewhere; if we want it server-side here, that's a separate, opt-in addition.

## Merge-order hints for the coordinator

- This branch is stacked on `phase0/F-1-server-identity-hash-versioning`. **Merge F-1 (PR #47) first**, then this PR's effective diff collapses to the S-1 work alone.
- No other Phase 0 task touches `core/auth*`, `api/auth.py`, `api/health.py`, `scripts/migrate.py`, or `db/models.py` in a way I'm aware of, so post-F-1 the rebase should be clean.