### PR TITLE
feat(android): sideload pipeline — share-sheet + import (Phase 0, task A-3)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,5 +30,35 @@
             </intent-filter>
         </activity>
 
+        <!-- Phase 0 / A-3: sideload sink. Receives ACTION_SEND from the share
+             sheet (any app sharing an EPUB) and ACTION_VIEW from file managers
+             (user opens an .epub). Kept off the MainActivity task stack and
+             out of recents so a quick share doesn't pollute the user's task
+             switcher with Quire. The actual import is awaited on the
+             activity's lifecycleScope so the content-URI grant outlives the
+             read. -->
+        <activity
+            android:name="io.theficos.ereader.sideload.ImportActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
+            android:theme="@style/Theme.Quire"
+            android:label="@string/sideload_import_label">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/epub+zip" />
+                <data android:mimeType="application/zip" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
+                <data android:mimeType="application/epub+zip" />
+            </intent-filter>
+        </activity>
+
     </application>
 </manifest>

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -18,9 +18,11 @@ import io.theficos.ereader.data.opds.OpdsClient
 import io.theficos.ereader.data.opds.OpdsHttpClient
 import io.theficos.ereader.data.sync.SyncClient
 import io.theficos.ereader.data.sync.SyncDependencies
+import io.theficos.ereader.data.sync.SyncEnqueuer
 import io.theficos.ereader.data.sync.SyncOrchestrator
 import io.theficos.ereader.reader.ReaderPreferencesStore
 import io.theficos.ereader.reader.ReadiumFactory
+import io.theficos.ereader.sideload.SideloadImporter
 import io.theficos.ereader.ui.bookdetail.AppInsightAuditSource
 import io.theficos.ereader.ui.bookdetail.BookDetailViewModel
 import io.theficos.ereader.ui.bookdetail.InsightAuditViewModel
@@ -120,6 +122,31 @@ class AppContainer(context: Context) {
         client = libraryClient,
         dao = db.documentDao(),
         scope = libraryUploaderScope,
+    )
+
+    /**
+     * Phase-0 / A-3: ingest pipeline for share-sheet + `+ Import` button.
+     * Constructed after [documentRepository], [libraryUploader], and
+     * [booksDir] so it can reuse the same physical book directory and
+     * upload pump the catalog download path uses — sideloaded rows behave
+     * identically to OPDS-downloaded rows post-insert.
+     */
+    val sideloadImporter: SideloadImporter = SideloadImporter(
+        documentRepository = documentRepository,
+        libraryUploader = libraryUploader,
+        booksDir = booksDir,
+        contentResolver = appContext.contentResolver,
+        uploaderScope = libraryUploaderScope,
+        onSuccessfulImport = {
+            // Catalog-download parity: a returning user may have
+            // server-side progress for this identity that an earlier pull
+            // dropped (no local doc to attach to). Resetting the cursor +
+            // expedited enqueue lets the next pull re-attach from epoch 0.
+            runCatching { syncStateDao.clearAll() }
+            runCatching {
+                SyncEnqueuer.enqueue(appContext, expedited = true, replaceExisting = true)
+            }
+        },
     )
 
     val aiRepository: AiRepository = AiRepository(
@@ -227,6 +254,10 @@ class AppContainer(context: Context) {
 
     init {
         SyncDependencies.holder = SyncDependencies.Holder(syncOrchestrator)
+        // Phase-0 / A-3: clean up any `*.epub.part` files leaked by an
+        // import that was killed mid-copy (process death between
+        // openInputStream and renameTo). Cheap, best-effort, silent.
+        libraryUploaderScope.launch { sideloadImporter.sweepStaleParts() }
         // PR-ζ: clear the catalog stash whenever the server base URL
         // changes (different deploy → entries are no longer relevant). The
         // AI opt-out toggle hook lives in PR-δ (Bundle 3); until then a

--- a/app/src/main/java/io/theficos/ereader/sideload/ImportActivity.kt
+++ b/app/src/main/java/io/theficos/ereader/sideload/ImportActivity.kt
@@ -1,0 +1,51 @@
+package io.theficos.ereader.sideload
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import io.theficos.ereader.EReaderApp
+import kotlinx.coroutines.launch
+
+/**
+ * Transient sink activity for share-sheet (`ACTION_SEND`) and file-manager
+ * (`ACTION_VIEW`) intents pointed at the app. Stays alive only as long as
+ * needed to copy the content URI bytes into app-private storage — content
+ * URI grants are tied to this activity's lifecycle, so we MUST NOT hand the
+ * URI to a background WorkManager job and finish() early.
+ *
+ * Manifest config: `taskAffinity=""` + `excludeFromRecents="true"` keeps the
+ * import flow out of the user's MainActivity task stack and out of recents,
+ * so a user who shared a book from another app doesn't end up with Quire
+ * sitting in their multitasker switcher.
+ *
+ * UI: deliberately minimal — a toast on completion. Spec forbids any
+ * curation / metadata-confirm UI in v1.
+ */
+class ImportActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val uri = extractImportUri(intent)
+        if (uri == null) {
+            Toast.makeText(this, "Couldn't read the shared file.", Toast.LENGTH_LONG).show()
+            finish()
+            return
+        }
+        val importer = (application as EReaderApp).container.sideloadImporter
+        val displayName = SideloadImporter.queryDisplayName(contentResolver, uri)
+        lifecycleScope.launch {
+            val result = importer.import(uri, displayName)
+            val msg = when (result) {
+                is SideloadResult.Imported -> "Imported: ${result.title}"
+                is SideloadResult.AlreadyImported -> "Already in your library: ${result.title}"
+                is SideloadResult.Failed -> when (result.reason) {
+                    SideloadFailure.InvalidEpub -> "Not a valid EPUB."
+                    SideloadFailure.UriUnreadable -> "Couldn't read the shared file."
+                    SideloadFailure.IoError -> "Import failed — try again."
+                }
+            }
+            Toast.makeText(this@ImportActivity, msg, Toast.LENGTH_LONG).show()
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/io/theficos/ereader/sideload/ImportIntents.kt
+++ b/app/src/main/java/io/theficos/ereader/sideload/ImportIntents.kt
@@ -1,0 +1,36 @@
+package io.theficos.ereader.sideload
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+
+/**
+ * Extracts the EPUB content URI from an intent that targets [ImportActivity].
+ *
+ * Two shapes are accepted:
+ *   - `ACTION_VIEW`: the URI lives on `intent.data`. Used by file managers
+ *     opening an `.epub` file.
+ *   - `ACTION_SEND`: the URI lives in `EXTRA_STREAM`. Used by share-sheet.
+ *
+ * Returns `null` if the intent doesn't carry a usable URI. Lives in its own
+ * file so the activity's job is reduced to thin glue and the parsing logic
+ * stays unit-testable without needing to launch an Activity.
+ */
+fun extractImportUri(intent: Intent?): Uri? {
+    if (intent == null) return null
+    return when (intent.action) {
+        Intent.ACTION_VIEW -> intent.data
+        Intent.ACTION_SEND -> {
+            // getParcelableExtra(String) is deprecated on API 33+ in favor of
+            // the type-safe overload. Both branches handle the same payload —
+            // SDK_INT gates the API surface, not the semantics.
+            @Suppress("DEPRECATION")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+            } else {
+                intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri
+            }
+        }
+        else -> null
+    }
+}

--- a/app/src/main/java/io/theficos/ereader/sideload/SideloadImporter.kt
+++ b/app/src/main/java/io/theficos/ereader/sideload/SideloadImporter.kt
@@ -1,0 +1,275 @@
+package io.theficos.ereader.sideload
+
+import android.content.ContentResolver
+import android.database.sqlite.SQLiteConstraintException
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.util.Log
+import io.theficos.ereader.core.identity.extractIdentity
+import io.theficos.ereader.core.metadata.readOpfBundle
+import io.theficos.ereader.core.model.CURRENT_IDENTITY_HASH_VERSION
+import io.theficos.ereader.core.model.DocumentIdentity
+import io.theficos.ereader.data.library.LibraryUploader
+import io.theficos.ereader.data.local.DocumentRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.w3c.dom.Element
+import java.io.File
+import java.io.IOException
+import java.util.UUID
+import java.util.zip.ZipException
+import java.util.zip.ZipFile
+import javax.xml.parsers.DocumentBuilderFactory
+import org.xml.sax.SAXException
+
+/**
+ * Phase-0 / A-3: ingest path for sideloaded EPUBs (share-sheet + `+ Import`).
+ *
+ * The pipeline is intentionally minimal per spec ("no curation /
+ * library-management flourishes in v1"):
+ *   1. Stream-copy the [Uri] into [booksDir] under a UUID filename so
+ *      everything downstream operates on a real seekable [File] (required by
+ *      [extractIdentity] / [contentHash], which use [java.io.RandomAccessFile]).
+ *   2. Validate the bytes are an EPUB container (META-INF/container.xml +
+ *      rootfile OPF present) before touching Room. Without this gate, any zip
+ *      or even arbitrary file would get hashed and inserted.
+ *   3. Compute the identity hash via [extractIdentity] — DO NOT inline copy
+ *      that logic; spec/F-2 contract demand the shared module is the only
+ *      source of truth.
+ *   4. Dedup against existing rows by identity (uses the same `findByIdentity`
+ *      the catalog path uses) and as a last line of defense catch the
+ *      `SQLiteConstraintException` from the unique index on `contentHash`
+ *      (the schema-level uniqueness is the actual correctness boundary).
+ *   5. Stamp [CURRENT_IDENTITY_HASH_VERSION] on insert — F-2 wiring.
+ *
+ * Failures clean up the staged `.part` file and any renamed `.epub` file we
+ * created but failed to commit, so process-death recovery only has to sweep
+ * leaked `.part` artifacts ([sweepStaleParts]).
+ */
+class SideloadImporter(
+    private val documentRepository: DocumentRepository,
+    private val libraryUploader: LibraryUploader,
+    private val booksDir: File,
+    private val contentResolver: ContentResolver,
+    private val uploaderScope: CoroutineScope,
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+    /**
+     * Best-effort hook fired ONLY after a successful (non-duplicate) import,
+     * to mirror the catalog download path's
+     * `syncStateDao.clearAll() + SyncEnqueuer.enqueue(...)` parity step.
+     * A returning user may have server-side progress for the newly
+     * sideloaded book's identity that an earlier pull silently dropped (no
+     * local doc to attach to); clearing the cursor + re-enqueuing lets the
+     * next pull re-fetch from epoch 0 and attach. AppContainer wires this
+     * up; tests can leave it as the default no-op.
+     */
+    private val onSuccessfulImport: suspend () -> Unit = {},
+) {
+    /**
+     * Serializes concurrent imports against each other. The schema-level
+     * unique index on `contentHash` is the correctness boundary, but this
+     * mutex avoids two parallel imports both copying + hashing the same
+     * 200MB EPUB just to have the second one rejected. Strictly an
+     * optimization / UX nicety.
+     */
+    private val importMutex = Mutex()
+
+    init { booksDir.mkdirs() }
+
+    suspend fun import(uri: Uri, displayNameHint: String? = null): SideloadResult =
+        importMutex.withLock { importLocked(uri, displayNameHint) }
+
+    private suspend fun importLocked(uri: Uri, displayNameHint: String?): SideloadResult =
+        withContext(Dispatchers.IO) {
+            val baseName = UUID.randomUUID().toString()
+            val partFile = File(booksDir, "$baseName.epub.part")
+            val finalFile = File(booksDir, "$baseName.epub")
+
+            val copyOk = runCatching {
+                contentResolver.openInputStream(uri)?.use { input ->
+                    partFile.outputStream().use { out -> input.copyTo(out) }
+                    true
+                } ?: false
+            }.getOrElse { t ->
+                Log.w(TAG, "openInputStream failed for $uri", t)
+                false
+            }
+            if (!copyOk) {
+                partFile.delete()
+                return@withContext SideloadResult.Failed(SideloadFailure.UriUnreadable)
+            }
+
+            if (!validateEpubContainer(partFile)) {
+                partFile.delete()
+                return@withContext SideloadResult.Failed(SideloadFailure.InvalidEpub)
+            }
+
+            if (!partFile.renameTo(finalFile)) {
+                partFile.delete()
+                return@withContext SideloadResult.Failed(SideloadFailure.IoError)
+            }
+
+            val identity = try {
+                extractIdentity(finalFile)
+            } catch (t: Throwable) {
+                Log.w(TAG, "extractIdentity threw for $finalFile", t)
+                finalFile.delete()
+                return@withContext SideloadResult.Failed(SideloadFailure.InvalidEpub)
+            }
+            if (identity.contentHash.isNullOrBlank()) {
+                finalFile.delete()
+                return@withContext SideloadResult.Failed(SideloadFailure.InvalidEpub)
+            }
+
+            documentRepository.findByIdentity(identity)?.let { existing ->
+                finalFile.delete()
+                return@withContext SideloadResult.AlreadyImported(existing.id, existing.title)
+            }
+
+            val bundle = readOpfBundle(finalFile, fallbackTitle = displayNameHint?.takeIf { it.isNotBlank() }
+                ?: finalFile.nameWithoutExtension)
+
+            val insertedId = try {
+                documentRepository.insert(
+                    identity = DocumentIdentity(
+                        metadataId = identity.metadataId,
+                        contentHash = identity.contentHash,
+                        identityHashVersion = CURRENT_IDENTITY_HASH_VERSION,
+                    ),
+                    title = bundle.title,
+                    author = bundle.author,
+                    // Sideloaded books have no source URL. Use a synthetic
+                    // `sideload://` URI keyed by content hash so the NOT NULL
+                    // `downloadUrl` column stays satisfied and the value is
+                    // distinguishable from real OPDS hrefs. Stable across
+                    // re-imports of the same bytes — useful if we ever want
+                    // a "this is a sideload" filter without a schema column.
+                    downloadUrl = "sideload://v1/${identity.contentHash}",
+                    localPath = finalFile.absolutePath,
+                    coverPath = null,
+                    downloadedAt = nowMillis(),
+                    seriesName = bundle.seriesName,
+                    seriesIndex = bundle.seriesPosition?.toDouble(),
+                    identityHashVersion = CURRENT_IDENTITY_HASH_VERSION,
+                )
+            } catch (e: SQLiteConstraintException) {
+                // Race: a parallel import won the insert. Treat as duplicate.
+                Log.d(TAG, "constraint hit on sideload insert (race against parallel import)", e)
+                finalFile.delete()
+                val existing = documentRepository.findByIdentity(identity)
+                return@withContext if (existing != null) {
+                    SideloadResult.AlreadyImported(existing.id, existing.title)
+                } else {
+                    SideloadResult.Failed(SideloadFailure.IoError)
+                }
+            }
+
+            // Fire-and-forget library upload so the server learns about the
+            // new identity. Mirrors the catalog path; failures are logged
+            // inside the uploader and the next app-start backfill retries.
+            uploaderScope.launch {
+                runCatching { libraryUploader.enqueueOne(insertedId).join() }
+                    .onFailure { Log.w(TAG, "enqueueOne failed for sideload id=$insertedId", it) }
+            }
+
+            runCatching { onSuccessfulImport() }
+                .onFailure { Log.w(TAG, "onSuccessfulImport hook failed", it) }
+
+            SideloadResult.Imported(insertedId, bundle.title)
+        }
+
+    /**
+     * Removes any leaked `*.epub.part` files in [booksDir]. Called at app
+     * startup so process death mid-import doesn't leak storage. Best-effort;
+     * failures are silent (the next sweep will retry).
+     */
+    suspend fun sweepStaleParts() = withContext(Dispatchers.IO) {
+        runCatching {
+            booksDir.listFiles { f -> f.isFile && f.name.endsWith(".epub.part") }
+                ?.forEach { it.delete() }
+        }
+    }
+
+    /**
+     * EPUB structural validation gate. Required because MIME-typed senders
+     * (and bare ACTION_VIEW filters) don't actually prove the bytes are an
+     * EPUB — a sender can claim `application/epub+zip` for any zip, or even
+     * for non-zip content. Without this gate, [extractIdentity] would still
+     * happily hash arbitrary bytes and we'd write garbage rows.
+     *
+     * Checks: opens as ZIP, finds `META-INF/container.xml`, parses out the
+     * rootfile `full-path`, and confirms that OPF entry exists. XML parsing
+     * uses the same XXE-hardened factory pattern as
+     * [io.theficos.ereader.core.identity.extractMetadataId] — sideloaded
+     * EPUBs are user-trusted but not verified, and an attacker-controlled
+     * `container.xml` could otherwise hang the parser or trigger network IO.
+     */
+    private fun validateEpubContainer(file: File): Boolean = try {
+        ZipFile(file).use { zip ->
+            val containerEntry = zip.getEntry("META-INF/container.xml") ?: return@use false
+            val opfPath = zip.getInputStream(containerEntry).use { input ->
+                val doc = newSafeDocumentBuilder().parse(input)
+                val rootfile = doc.getElementsByTagNameNS(CONTAINER_NS, "rootfile").item(0) as? Element
+                    ?: return@use null
+                rootfile.getAttribute("full-path").ifEmpty { return@use null }
+            } ?: return@use false
+            zip.getEntry(opfPath) != null
+        }
+    } catch (_: ZipException) { false
+    } catch (_: IOException) { false
+    } catch (_: SAXException) { false
+    } catch (t: Throwable) {
+        Log.w(TAG, "validateEpubContainer threw", t)
+        false
+    }
+
+    private fun newSafeDocumentBuilder(): javax.xml.parsers.DocumentBuilder {
+        val factory = DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+            runCatching { setFeature("http://apache.org/xml/features/disallow-doctype-decl", true) }
+            runCatching { setFeature("http://xml.org/sax/features/external-general-entities", false) }
+            runCatching { setFeature("http://xml.org/sax/features/external-parameter-entities", false) }
+            runCatching { setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false) }
+            runCatching { isXIncludeAware = false }
+            runCatching { isExpandEntityReferences = false }
+        }
+        return factory.newDocumentBuilder()
+    }
+
+    companion object {
+        private const val TAG = "SideloadImporter"
+        private const val CONTAINER_NS = "urn:oasis:names:tc:opendocument:xmlns:container"
+
+        /**
+         * Best-effort lookup of a human-readable display name for a content URI,
+         * used as the fallback EPUB title when OPF metadata is missing.
+         */
+        fun queryDisplayName(resolver: ContentResolver, uri: Uri): String? = try {
+            resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { c ->
+                if (c.moveToFirst()) c.getString(0)?.takeIf { it.isNotBlank() } else null
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "queryDisplayName failed for $uri", t)
+            null
+        }
+    }
+}
+
+sealed interface SideloadResult {
+    data class Imported(val documentId: Long, val title: String) : SideloadResult
+    data class AlreadyImported(val documentId: Long, val title: String) : SideloadResult
+    data class Failed(val reason: SideloadFailure) : SideloadResult
+}
+
+enum class SideloadFailure {
+    /** The content URI couldn't be opened or read at all. */
+    UriUnreadable,
+    /** The file isn't a structurally valid EPUB (no container, no OPF, etc.). */
+    InvalidEpub,
+    /** Local I/O failure: rename failed, disk full, etc. */
+    IoError,
+}

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -96,6 +96,7 @@ fun AppNavGraph(container: AppContainer) {
                         onShowStats = { nav.navigate("library/stats") },
                         onShowInsights = { nav.navigate("library/insights") },
                         aiConfigured = aiConfig?.configured == true,
+                        sideloadImporter = container.sideloadImporter,
                         contentPadding = padding,
                     )
                     Tab.CATALOG -> CatalogScreen(

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
@@ -19,12 +19,16 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FilterAlt
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material3.Button
 import androidx.compose.material.icons.outlined.FilterAlt
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.AlertDialog
@@ -64,6 +68,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.data.sync.SyncEnqueuer
+import io.theficos.ereader.sideload.SideloadFailure
+import io.theficos.ereader.sideload.SideloadImporter
+import io.theficos.ereader.sideload.SideloadResult
 import io.theficos.ereader.ui.components.CoverImage
 import io.theficos.ereader.ui.components.SectionLabel
 import io.theficos.ereader.ui.theme.Lora
@@ -76,6 +83,19 @@ private val sortLabels: List<Pair<LibrarySort, String>> = listOf(
     LibrarySort.AUTHOR to "Author",
 )
 
+/**
+ * MIME types the `+ Import` picker accepts. EPUB officially registers as
+ * `application/epub+zip`; the fallback `application/zip` covers file pickers
+ * (notably some stock Android Files apps) that fall back to a generic zip
+ * MIME for `.epub`. The structural EPUB validation in `SideloadImporter`
+ * filters out actual non-EPUB zips later — this filter is just to keep the
+ * picker UX from listing every file on the device.
+ */
+private val IMPORT_MIME_FILTER: Array<String> = arrayOf(
+    "application/epub+zip",
+    "application/zip",
+)
+
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun LibraryScreen(
@@ -85,6 +105,7 @@ fun LibraryScreen(
     onShowStats: () -> Unit = {},
     onShowInsights: () -> Unit = {},
     aiConfigured: Boolean = false,
+    sideloadImporter: SideloadImporter? = null,
     contentPadding: PaddingValues,
 ) {
     val context = LocalContext.current
@@ -111,8 +132,40 @@ fun LibraryScreen(
         }
     }
 
+    // Phase-0 / A-3: `+ Import` button. Picker launches OpenDocument with an
+    // EPUB MIME filter; result Uri is fed into the same SideloadImporter the
+    // share-sheet ImportActivity uses. Importer may be null in previews/tests
+    // — the button is suppressed in that case.
+    val importLauncher = if (sideloadImporter != null) {
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            if (uri != null) {
+                scope.launch {
+                    val displayName = SideloadImporter.queryDisplayName(context.contentResolver, uri)
+                    val result = sideloadImporter.import(uri, displayName)
+                    val msg = when (result) {
+                        is SideloadResult.Imported -> "Imported: ${result.title}"
+                        is SideloadResult.AlreadyImported -> "Already in your library: ${result.title}"
+                        is SideloadResult.Failed -> when (result.reason) {
+                            SideloadFailure.InvalidEpub -> "Not a valid EPUB."
+                            SideloadFailure.UriUnreadable -> "Couldn't read the file."
+                            SideloadFailure.IoError -> "Import failed — try again."
+                        }
+                    }
+                    snackbarHostState.showSnackbar(msg)
+                }
+            }
+        }
+    } else null
+
+    val launchPicker: (() -> Unit)? = importLauncher?.let { l ->
+        { l.launch(IMPORT_MIME_FILTER) }
+    }
+
     if (items.isEmpty() && !searchActive && query.isBlank()) {
-        EmptyState(modifier = Modifier.padding(contentPadding))
+        EmptyState(
+            modifier = Modifier.padding(contentPadding),
+            onImport = launchPicker,
+        )
         return
     }
 
@@ -137,6 +190,11 @@ fun LibraryScreen(
                     )
                     IconButton(onClick = { searchActive = true }) {
                         Icon(Icons.Filled.Search, contentDescription = "Search")
+                    }
+                    launchPicker?.let { picker ->
+                        IconButton(onClick = picker) {
+                            Icon(Icons.Filled.Add, contentDescription = "Import EPUB")
+                        }
                     }
                     var sortMenuOpen by rememberSaveable { mutableStateOf(false) }
                     val currentSort by viewModel.sort.collectAsState()
@@ -478,7 +536,7 @@ fun LibraryScreen(
 }
 
 @Composable
-private fun EmptyState(modifier: Modifier = Modifier) {
+private fun EmptyState(modifier: Modifier = Modifier, onImport: (() -> Unit)? = null) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
@@ -494,11 +552,23 @@ private fun EmptyState(modifier: Modifier = Modifier) {
                 style = MaterialTheme.typography.titleMedium,
             )
             Text(
-                text = "Open the Catalog tab to find books.",
+                text = "Open the Catalog tab to find books, or import an EPUB.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 4.dp),
             )
+            // Phase-0 / A-3: the top-bar `+ Import` button is hidden when the
+            // library is empty (top bar isn't rendered at all in that branch),
+            // so surface the same action here for first-time-sideload users.
+            onImport?.let { picker ->
+                Button(
+                    onClick = picker,
+                    modifier = Modifier.padding(top = 16.dp),
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = null)
+                    Text(text = "Import EPUB", modifier = Modifier.padding(start = 8.dp))
+                }
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Quire</string>
+    <string name="sideload_import_label">Import EPUB</string>
 </resources>

--- a/app/src/test/java/io/theficos/ereader/sideload/ImportIntentsTest.kt
+++ b/app/src/test/java/io/theficos/ereader/sideload/ImportIntentsTest.kt
@@ -1,0 +1,48 @@
+package io.theficos.ereader.sideload
+
+import android.content.Intent
+import android.net.Uri
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pure-unit tests for [extractImportUri]. Kept as a top-level function (not
+ * an Activity method) precisely so we can cover both intent shapes without
+ * launching an Activity — Robolectric activity launches are flaky around
+ * `lifecycleScope` + suspend imports, and there is no mocking framework on
+ * the `:app` test classpath.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class ImportIntentsTest {
+
+    @Test fun `ACTION_VIEW pulls Uri from intent_data`() {
+        val uri = Uri.parse("content://com.example/foo.epub")
+        val intent = Intent(Intent.ACTION_VIEW).setData(uri)
+        assertThat(extractImportUri(intent)).isEqualTo(uri)
+    }
+
+    @Test fun `ACTION_SEND pulls Uri from EXTRA_STREAM`() {
+        val uri = Uri.parse("content://com.example/share/bar.epub")
+        val intent = Intent(Intent.ACTION_SEND).putExtra(Intent.EXTRA_STREAM, uri)
+        assertThat(extractImportUri(intent)).isEqualTo(uri)
+    }
+
+    @Test fun `ACTION_SEND without EXTRA_STREAM returns null`() {
+        val intent = Intent(Intent.ACTION_SEND).setType("application/epub+zip")
+        assertThat(extractImportUri(intent)).isNull()
+    }
+
+    @Test fun `unknown action returns null even with intent data`() {
+        val intent = Intent("io.theficos.ereader.UNRELATED")
+            .setData(Uri.parse("content://com.example/x.epub"))
+        assertThat(extractImportUri(intent)).isNull()
+    }
+
+    @Test fun `null intent returns null`() {
+        assertThat(extractImportUri(null)).isNull()
+    }
+}

--- a/app/src/test/java/io/theficos/ereader/sideload/SideloadImporterTest.kt
+++ b/app/src/test/java/io/theficos/ereader/sideload/SideloadImporterTest.kt
@@ -1,0 +1,182 @@
+package io.theficos.ereader.sideload
+
+import android.net.Uri
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.core.model.CURRENT_IDENTITY_HASH_VERSION
+import io.theficos.ereader.data.library.LibraryClient
+import io.theficos.ereader.data.library.LibraryUploader
+import io.theficos.ereader.data.local.DocumentRepository
+import io.theficos.ereader.data.local.db.EReaderDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class SideloadImporterTest {
+    @get:Rule val tmp = TemporaryFolder()
+
+    private lateinit var db: EReaderDatabase
+    private lateinit var documentRepository: DocumentRepository
+    private lateinit var libraryUploader: LibraryUploader
+    private lateinit var importer: SideloadImporter
+    private lateinit var booksDir: File
+    private lateinit var uploaderScope: CoroutineScope
+
+    @Before fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, EReaderDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        documentRepository = DocumentRepository(db.documentDao())
+        booksDir = tmp.newFolder("books")
+        uploaderScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        // Real LibraryUploader is constructed with a no-op base URL, so its
+        // enqueueOne fires a launch into uploaderScope that 404s harmlessly.
+        // The importer only needs `enqueueOne` to not throw synchronously.
+        libraryUploader = LibraryUploader(
+            client = LibraryClient(
+                baseUrlProvider = { null },
+                http = OkHttpClient(),
+            ),
+            dao = db.documentDao(),
+            scope = uploaderScope,
+        )
+        importer = SideloadImporter(
+            documentRepository = documentRepository,
+            libraryUploader = libraryUploader,
+            booksDir = booksDir,
+            contentResolver = ctx.contentResolver,
+            uploaderScope = uploaderScope,
+            nowMillis = { 1_700_000_000_000L },
+        )
+    }
+
+    @After fun tearDown() {
+        db.close()
+        uploaderScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+    }
+
+    @Test fun `imports a valid epub and persists a document row`() = runTest {
+        val epub = makeValidEpub(name = "happy", id = "urn:isbn:9780000000001", title = "Happy Path")
+
+        val result = importer.import(Uri.fromFile(epub), displayNameHint = "Happy.epub")
+
+        assertThat(result).isInstanceOf(SideloadResult.Imported::class.java)
+        val imported = result as SideloadResult.Imported
+        val rows = documentRepository.observeLibrary().first()
+        assertThat(rows).hasSize(1)
+        val row = rows.single()
+        assertThat(row.id).isEqualTo(imported.documentId)
+        // F-2 regression: every fresh sideloaded row is stamped with the
+        // current hash version, not a hard-coded `1`.
+        assertThat(row.identityHashVersion).isEqualTo(CURRENT_IDENTITY_HASH_VERSION)
+        // The synthetic download URL is keyed by the content hash so duplicate
+        // imports of the same bytes are distinguishable from real OPDS hrefs.
+        assertThat(row.downloadUrl).startsWith("sideload://v1/")
+        assertThat(row.downloadUrl).endsWith(row.identity.contentHash!!)
+        // Sideload doesn't extract covers in v1 — fallback rendering is fine.
+        assertThat(row.coverPath).isNull()
+    }
+
+    @Test fun `duplicate import of the same epub is reported as AlreadyImported`() = runTest {
+        val epub1 = makeValidEpub(name = "dup1", id = "urn:isbn:9780000000002", title = "Dup")
+        // Same bytes a second time would not be allowed (same Uri once consumed).
+        // Build a second copy with identical OPF so the metadataId match short-circuits findByIdentity.
+        val epub2 = makeValidEpub(name = "dup2", id = "urn:isbn:9780000000002", title = "Dup")
+
+        val first = importer.import(Uri.fromFile(epub1), displayNameHint = null)
+        val second = importer.import(Uri.fromFile(epub2), displayNameHint = null)
+
+        assertThat(first).isInstanceOf(SideloadResult.Imported::class.java)
+        assertThat(second).isInstanceOf(SideloadResult.AlreadyImported::class.java)
+        val rows = documentRepository.observeLibrary().first()
+        assertThat(rows).hasSize(1)
+    }
+
+    @Test fun `invalid epub (no container) is rejected and leaves no file or row`() = runTest {
+        val bogus = tmp.newFile("bogus.epub").apply {
+            ZipOutputStream(outputStream()).use { zip ->
+                zip.putNextEntry(ZipEntry("README.txt"))
+                zip.write("not an epub".toByteArray())
+                zip.closeEntry()
+            }
+        }
+
+        val result = importer.import(Uri.fromFile(bogus), displayNameHint = "bogus.epub")
+
+        assertThat(result).isEqualTo(SideloadResult.Failed(SideloadFailure.InvalidEpub))
+        assertThat(documentRepository.observeLibrary().first()).isEmpty()
+        // No `.epub` or `.epub.part` should be left behind in booksDir.
+        assertThat(booksDir.listFiles()?.toList().orEmpty()).isEmpty()
+    }
+
+    @Test fun `non-zip bytes are rejected as InvalidEpub`() = runTest {
+        val notZip = tmp.newFile("plain.epub").apply { writeText("not even a zip") }
+
+        val result = importer.import(Uri.fromFile(notZip), displayNameHint = null)
+
+        assertThat(result).isEqualTo(SideloadResult.Failed(SideloadFailure.InvalidEpub))
+        assertThat(booksDir.listFiles()?.toList().orEmpty()).isEmpty()
+    }
+
+    @Test fun `sweepStaleParts removes leaked epub_part files`() = runTest {
+        val leaked = File(booksDir, "leaked.epub.part").apply { writeText("partial") }
+        val realBook = File(booksDir, "ok.epub").apply { writeText("not touched") }
+
+        importer.sweepStaleParts()
+
+        assertThat(leaked.exists()).isFalse()
+        assertThat(realBook.exists()).isTrue()
+    }
+
+    /** Builds a minimal but structurally valid EPUB zip on disk. */
+    private fun makeValidEpub(name: String, id: String, title: String): File {
+        val epub = tmp.newFile("$name.epub")
+        ZipOutputStream(epub.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry("META-INF/container.xml"))
+            zip.write(
+                """
+                <?xml version="1.0"?>
+                <container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+                  <rootfiles>
+                    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+                  </rootfiles>
+                </container>
+                """.trimIndent().toByteArray(),
+            )
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("OEBPS/content.opf"))
+            zip.write(
+                """
+                <?xml version="1.0"?>
+                <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="bid">
+                  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                    <dc:identifier id="bid">$id</dc:identifier>
+                    <dc:title>$title</dc:title>
+                    <dc:creator>Author</dc:creator>
+                  </metadata>
+                </package>
+                """.trimIndent().toByteArray(),
+            )
+            zip.closeEntry()
+        }
+        return epub
+    }
+}

--- a/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
@@ -11,4 +11,10 @@ data class Document(
     val downloadedAt: Long,
     val seriesName: String? = null,
     val seriesIndex: Double? = null,
+    /**
+     * Schema version of the client-side hash function that produced
+     * `identity.contentHash` for this document. See
+     * [CURRENT_IDENTITY_HASH_VERSION]; today every Document is v1.
+     */
+    val identityHashVersion: Int = CURRENT_IDENTITY_HASH_VERSION,
 )

--- a/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
@@ -4,6 +4,35 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Schema version of the client-side identity-hash function. Stamped on every
+ * record that carries an identity hash (Room rows + outbound DTOs) so a future
+ * change to the hash function (edition merging, normalization fixes, etc.)
+ * doesn't break sync, caches, recs, export, or deletion across persisted data.
+ *
+ * Phase-0 task F-2 introduces this constant at value `1` — the current MD5-
+ * sampled hash in `core/identity/ContentHash.kt`. Bumping this constant later
+ * requires:
+ *   1. Updating the hash function.
+ *   2. A migration that re-computes hashes for local rows and re-uploads them.
+ *   3. Server-side acceptance of the new version (sibling task F-1 introduces
+ *      the wire field; further bumps are coordinated with the server team).
+ *
+ * The companion [isStaleHashVersion] predicate is the explicit "needs rehash"
+ * check; today it is a no-op (no rows exist at version < 1) but the mechanism
+ * is wired so a future version bump only needs to flip the constant.
+ */
+const val CURRENT_IDENTITY_HASH_VERSION: Int = 1
+
+/**
+ * True iff a record stamped with [rowVersion] was produced by an older client
+ * hash function and should be re-hashed before its next push to the server.
+ *
+ * Today this is `rowVersion < 1`, which is always false — bumping
+ * [CURRENT_IDENTITY_HASH_VERSION] activates the predicate for legacy rows.
+ */
+fun isStaleHashVersion(rowVersion: Int): Boolean = rowVersion < CURRENT_IDENTITY_HASH_VERSION
+
+/**
  * Mirrors `DocumentIdentity` in `server/quire_server/api/ai_schemas.py`.
  *
  * Canonical schemes (`metadataId`, `contentHash`) identify a downloaded EPUB
@@ -16,6 +45,13 @@ import kotlinx.serialization.Serializable
  * invariant (`contentHash` non-empty) is enforced by the call site
  * (`EpubIdentityExtractor`), not the type — pre-download paths legitimately
  * have no `contentHash`.
+ *
+ * `identityHashVersion` (Phase-0 / F-2) stamps which version of the
+ * client-side hash function produced [contentHash]. Defaults to
+ * [CURRENT_IDENTITY_HASH_VERSION] so callers building an identity from a
+ * freshly-computed hash get the right value automatically; defaults to `1`
+ * on the wire so an older server that doesn't emit the field decodes
+ * correctly (every existing hash on the network is v1).
  */
 @Serializable
 data class DocumentIdentity(
@@ -25,6 +61,7 @@ data class DocumentIdentity(
     @SerialName("opds_href") val opdsHref: String? = null,
     @SerialName("calibre_book_id") val calibreBookId: String? = null,
     val isbn: String? = null,
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 ) {
     init {
         require(

--- a/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
+++ b/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
@@ -1,9 +1,12 @@
 package io.theficos.ereader.core.model
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
 import org.junit.Test
 
 class DocumentIdentityTest {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
     @Test fun `accepts contentHash-only`() {
         val id = DocumentIdentity(metadataId = null, contentHash = "abc123")
         assertThat(id.contentHash).isEqualTo("abc123")
@@ -40,5 +43,46 @@ class DocumentIdentityTest {
     @Test fun `accepts isbn-only alias payload`() {
         val id = DocumentIdentity(isbn = "9780553293357")
         assertThat(id.isbn).isEqualTo("9780553293357")
+    }
+
+    // ---------- Phase-0 / F-2: identity hash version ----------
+
+    @Test fun `identityHashVersion defaults to current version`() {
+        val id = DocumentIdentity(contentHash = "abc")
+        assertThat(id.identityHashVersion).isEqualTo(CURRENT_IDENTITY_HASH_VERSION)
+        assertThat(CURRENT_IDENTITY_HASH_VERSION).isEqualTo(1)
+    }
+
+    @Test fun `isStaleHashVersion is no-op at current version`() {
+        assertThat(isStaleHashVersion(1)).isFalse()
+        // A future v2 row decoded by a v1 client is NOT stale (not the
+        // direction the predicate cares about).
+        assertThat(isStaleHashVersion(2)).isFalse()
+    }
+
+    @Test fun `isStaleHashVersion detects pre-current versions`() {
+        // Hypothetical bump to v2: a v1 row is now stale and needs a rehash.
+        // Asserted via the underlying inequality so the test is robust against
+        // a future constant change.
+        assertThat(0 < CURRENT_IDENTITY_HASH_VERSION).isTrue()
+        assertThat(isStaleHashVersion(0)).isTrue()
+    }
+
+    @Test fun `identity_hash_version round-trips on the wire`() {
+        val id = DocumentIdentity(contentHash = "abc", identityHashVersion = 7)
+        val encoded = json.encodeToString(DocumentIdentity.serializer(), id)
+        assertThat(encoded).contains("\"identity_hash_version\":7")
+        val decoded = json.decodeFromString(DocumentIdentity.serializer(), encoded)
+        assertThat(decoded.identityHashVersion).isEqualTo(7)
+        assertThat(decoded.contentHash).isEqualTo("abc")
+    }
+
+    @Test fun `missing identity_hash_version decodes to 1 for back-compat`() {
+        // An older server that doesn't yet emit the field (pre-F-1) must
+        // still decode cleanly. Every hash on the wire today is v1.
+        val legacyWire = """{"content_hash":"abc"}"""
+        val decoded = json.decodeFromString(DocumentIdentity.serializer(), legacyWire)
+        assertThat(decoded.identityHashVersion).isEqualTo(1)
+        assertThat(decoded.contentHash).isEqualTo("abc")
     }
 }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
@@ -301,6 +301,9 @@ class AiRepository(
             serverId = 0L,
             generatedAt = parseIsoMillis(resp.generatedAt) ?: clock(),
             syncedAt = clock(),
+            // Phase-0 / F-2: stamp the cache row with the hash version of
+            // the identity used to fetch it. See `InsightEntity.identityHashVersion`.
+            identityHashVersion = identity.identityHashVersion,
         )
         insightDao.upsert(entity)
     }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/InsightSyncRepository.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/InsightSyncRepository.kt
@@ -131,5 +131,8 @@ internal fun InsightSyncItem.toEntity(syncedAtMs: Long, json: Json): InsightEnti
         serverId = id,
         generatedAt = parseIsoMillis(generatedAt) ?: syncedAtMs,
         syncedAt = syncedAtMs,
+        // Phase-0 / F-2: cache row inherits the hash version stamped by
+        // the server on the source identity.
+        identityHashVersion = identity.identityHashVersion,
     )
 }

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
@@ -56,6 +56,10 @@ data class LibraryItemRequest(
     val language: String? = null,
     val subjects: List<String> = emptyList(),
     @SerialName("opds_href") val opdsHref: String? = null,
+    // Phase-0 / F-2: stamps which client hash-function version produced
+    // `contentHash`. Defaults to `1` for wire back-compat with an older
+    // server that doesn't yet emit the field (F-1 lands it server-side).
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
 
 /**
@@ -90,4 +94,7 @@ data class LibraryItemResponse(
     @SerialName("created_at") val createdAt: String,
     @SerialName("updated_at") val updatedAt: String,
     @SerialName("deleted_at") val deletedAt: String? = null,
+    // Phase-0 / F-2: defaults to `1` so an older server (pre-F-1) decodes
+    // safely — every hash on the wire today is v1.
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
@@ -119,6 +119,10 @@ class LibraryUploader(
             language = null,    // v2: parse from OPF
             subjects = emptyList(), // v2: parse from OPF
             opdsHref = downloadUrl,
+            // Phase-0 / F-2: forward the row's stored hash version. Today
+            // this is always 1; a future hash-function bump will set it to
+            // the version that was current when this row was hashed.
+            identityHashVersion = identityHashVersion,
         )
 
     private companion object {

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
@@ -63,4 +63,48 @@ class LibraryDtosTest {
         assertThat(parsed.totalBooks).isEqualTo(3)
         assertThat(parsed.abandonedCount).isEqualTo(0)
     }
+
+    // ---------- Phase-0 / F-2: identity_hash_version ----------
+
+    @Test
+    fun `LibraryItemRequest carries identity_hash_version on the wire`() {
+        // Round-trip with encodeDefaults=true so we can see what would
+        // travel over the wire if an AI-style client were used (the real
+        // LibraryClient uses default encodeDefaults=false, so the field
+        // is omitted on encode there — that's fine, the server applies
+        // its own DEFAULT 1).
+        val encJson = Json { encodeDefaults = true }
+        val req = LibraryItemRequest(
+            contentHash = "abc",
+            title = "T",
+            identityHashVersion = 2,
+        )
+        val encoded = encJson.encodeToString(LibraryItemRequest.serializer(), req)
+        assertThat(encoded).contains("\"identity_hash_version\":2")
+    }
+
+    @Test
+    fun `LibraryItemResponse decodes default 1 when server omits identity_hash_version`() {
+        // Older server (pre-F-1) doesn't emit the field. Every existing
+        // hash on the wire is v1, so the default `= 1` is correct.
+        val body = """
+            {
+              "content_hash":"h1","title":"T","authors":[],"created_at":"2026-01-01T00:00:00+00:00","updated_at":"2026-01-01T00:00:00+00:00"
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryItemResponse.serializer(), body)
+        assertThat(parsed.identityHashVersion).isEqualTo(1)
+    }
+
+    @Test
+    fun `LibraryItemResponse decodes non-default identity_hash_version`() {
+        val body = """
+            {
+              "content_hash":"h1","title":"T","authors":[],"identity_hash_version":3,
+              "created_at":"2026-01-01T00:00:00+00:00","updated_at":"2026-01-01T00:00:00+00:00"
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryItemResponse.serializer(), body)
+        assertThat(parsed.identityHashVersion).isEqualTo(3)
+    }
 }

--- a/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json
+++ b/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json
@@ -1,0 +1,393 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "40c4987051d2f31f8f5aeb107d62d857",
+    "entities": [
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `metadataId` TEXT, `contentHash` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `downloadUrl` TEXT NOT NULL, `localPath` TEXT NOT NULL, `coverPath` TEXT, `downloadedAt` INTEGER NOT NULL, `seriesName` TEXT, `seriesIndex` REAL, `librarySyncedAt` INTEGER, `identityHashVersion` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "librarySyncedAt",
+            "columnName": "librarySyncedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "identityHashVersion",
+            "columnName": "identityHashVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_documents_metadataId",
+            "unique": true,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_documents_contentHash",
+            "unique": true,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_documents_seriesName_seriesIndex",
+            "unique": false,
+            "columnNames": [
+              "seriesName",
+              "seriesIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_documents_seriesName_seriesIndex` ON `${TABLE_NAME}` (`seriesName`, `seriesIndex`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `documentId` INTEGER NOT NULL, `locator` TEXT NOT NULL, `percent` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `finishedAt` INTEGER, `abandonedAt` INTEGER, FOREIGN KEY(`documentId`) REFERENCES `documents`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locator",
+            "columnName": "locator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percent",
+            "columnName": "percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "abandonedAt",
+            "columnName": "abandonedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_documentId",
+            "unique": true,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_progress_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "documents",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `lastPulledAt` INTEGER NOT NULL, PRIMARY KEY(`tableName`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPulledAt",
+            "columnName": "lastPulledAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "book_insights",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identityKey` TEXT NOT NULL, `metadataId` TEXT, `contentHash` TEXT, `modelId` TEXT NOT NULL, `promptVersion` TEXT NOT NULL, `tone` TEXT NOT NULL, `language` TEXT NOT NULL, `payloadJson` TEXT NOT NULL, `sourcesJson` TEXT NOT NULL, `schemaVersion` INTEGER NOT NULL, `serverId` INTEGER NOT NULL, `generatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `identityHashVersion` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`identityKey`, `modelId`, `promptVersion`, `tone`, `language`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptVersion",
+            "columnName": "promptVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tone",
+            "columnName": "tone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedAt",
+            "columnName": "generatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHashVersion",
+            "columnName": "identityHashVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identityKey",
+            "modelId",
+            "promptVersion",
+            "tone",
+            "language"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_insights_syncedAt",
+            "unique": false,
+            "columnNames": [
+              "syncedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_syncedAt` ON `${TABLE_NAME}` (`syncedAt`)"
+          },
+          {
+            "name": "index_book_insights_metadataId",
+            "unique": false,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_book_insights_contentHash",
+            "unique": false,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_book_insights_cursor",
+            "unique": false,
+            "columnNames": [
+              "generatedAt",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_cursor` ON `${TABLE_NAME}` (`generatedAt`, `serverId`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '40c4987051d2f31f8f5aeb107d62d857')"
+    ]
+  }
+}

--- a/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local
 
+import io.theficos.ereader.core.model.CURRENT_IDENTITY_HASH_VERSION
 import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.core.model.DocumentIdentity
 import io.theficos.ereader.data.local.db.DocumentDao
@@ -80,6 +81,7 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt: Long,
         seriesName: String? = null,
         seriesIndex: Double? = null,
+        identityHashVersion: Int = CURRENT_IDENTITY_HASH_VERSION,
     ): Long = dao.insert(DocumentEntity(
         metadataId = identity.metadataId,
         contentHash = requireNotNull(identity.contentHash) {
@@ -93,11 +95,16 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt = downloadedAt,
         seriesName = seriesName?.takeIf { it.isNotBlank() },
         seriesIndex = seriesIndex,
+        identityHashVersion = identityHashVersion,
     ))
 
     private fun DocumentEntity.toDomain(): Document = Document(
         id = id,
-        identity = DocumentIdentity(metadataId = metadataId, contentHash = contentHash),
+        identity = DocumentIdentity(
+            metadataId = metadataId,
+            contentHash = contentHash,
+            identityHashVersion = identityHashVersion,
+        ),
         title = title,
         author = author,
         downloadUrl = downloadUrl,
@@ -106,6 +113,7 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt = downloadedAt,
         seriesName = seriesName,
         seriesIndex = seriesIndex,
+        identityHashVersion = identityHashVersion,
     )
 
     companion object {

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -37,4 +38,14 @@ data class DocumentEntity(
      * presence marker; we never compare it against server timestamps.
      */
     val librarySyncedAt: Long? = null,
+    /**
+     * Phase-0 / F-2: schema version of the client-side hash function that
+     * produced [contentHash]. `INTEGER NOT NULL DEFAULT 1` on disk so the
+     * 8→9 migration can backfill pre-existing rows in a single ALTER TABLE.
+     * Today every row is v1; the field exists so a future hash-function
+     * change can be detected via
+     * `io.theficos.ereader.core.model.isStaleHashVersion`.
+     */
+    @ColumnInfo(defaultValue = "1")
+    val identityHashVersion: Int = 1,
 )

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
@@ -14,7 +14,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         SyncStateEntity::class,
         InsightEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
 )
 abstract class EReaderDatabase : RoomDatabase() {
@@ -143,6 +143,33 @@ abstract class EReaderDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Phase-0 / F-2: stamps every identity-hash-carrying row with the
+         * schema version of the hash function that produced it. Backfills
+         * existing rows to `1` (the current MD5-sampled hash in
+         * `core/identity/ContentHash.kt`). Paired with
+         * `core.model.CURRENT_IDENTITY_HASH_VERSION` and
+         * `core.model.isStaleHashVersion`. Server-side change is handled by
+         * the sibling F-1 task.
+         *
+         * Two ALTER TABLEs: `documents` (the primary owner — also drives
+         * re-upload via `LibraryUploader` when stale) and `book_insights`
+         * (metadata only; this DAO cannot re-key its rows, so a future v2
+         * bump will be handled by re-syncing the cache from the server).
+         */
+        internal val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE documents ADD COLUMN identityHashVersion " +
+                        "INTEGER NOT NULL DEFAULT 1"
+                )
+                db.execSQL(
+                    "ALTER TABLE book_insights ADD COLUMN identityHashVersion " +
+                        "INTEGER NOT NULL DEFAULT 1"
+                )
+            }
+        }
+
         fun build(context: Context): EReaderDatabase =
             Room.databaseBuilder(context, EReaderDatabase::class.java, "ereader.db")
                 .addMigrations(
@@ -153,6 +180,7 @@ abstract class EReaderDatabase : RoomDatabase() {
                     MIGRATION_5_6,
                     MIGRATION_6_7,
                     MIGRATION_7_8,
+                    MIGRATION_8_9,
                 )
                 .build()
     }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/InsightEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/InsightEntity.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 
@@ -41,4 +42,17 @@ data class InsightEntity(
     val generatedAt: Long,
     /** When this row was upserted locally; wall clock millis. */
     val syncedAt: Long,
+    /**
+     * Phase-0 / F-2: schema version of the client-side hash function that
+     * produced the [contentHash] / [identityKey] this row is filed under.
+     * `INTEGER NOT NULL DEFAULT 1` on disk.
+     *
+     * Stored as metadata only — this DAO cannot re-key existing rows when
+     * the hash function bumps because the `identityKey` is part of the
+     * primary key and the source EPUB is not addressable from here. A
+     * future hash-function change will be handled by re-syncing the cache
+     * (server-driven) rather than by mutating this column in place.
+     */
+    @ColumnInfo(defaultValue = "1")
+    val identityHashVersion: Int = 1,
 )

--- a/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
@@ -258,5 +258,116 @@ class MigrationTest {
         }
     }
 
+    @Test fun `migrate 8 to 9 stamps identityHashVersion=1 on documents and book_insights`() {
+        // v8 fixture: seed one row in `documents` and one in `book_insights`
+        // (both tables exist at v8). identityHashVersion does NOT exist yet.
+        helper.createDatabase(DB, 8).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (41, 'm41', 'h41', 'Pre-F2 title', NULL, 'u', 'p', NULL, 51, NULL, NULL, NULL)"
+            )
+            db.execSQL(
+                "INSERT INTO book_insights (identityKey, metadataId, contentHash, modelId, " +
+                    "promptVersion, tone, language, payloadJson, sourcesJson, schemaVersion, " +
+                    "serverId, generatedAt, syncedAt) VALUES " +
+                    "('m41', 'm41', 'h41', 'llama3.1', '4', 'neutral', 'auto', '{}', '[]', 4, " +
+                    "100, 1000, 1100)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(DB, 9, true, EReaderDatabase.MIGRATION_8_9).use { db ->
+            // Both tables gained the column.
+            for (table in listOf("documents", "book_insights")) {
+                db.query("PRAGMA table_info('$table')").use { c ->
+                    val cols = mutableSetOf<String>()
+                    while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                    assertThat(cols).contains("identityHashVersion")
+                }
+            }
+            // Existing rows backfill to 1 via the DEFAULT clause.
+            db.query("SELECT identityHashVersion FROM documents WHERE id=41").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            db.query(
+                "SELECT identityHashVersion FROM book_insights " +
+                    "WHERE identityKey='m41' AND modelId='llama3.1' AND promptVersion='4'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            // New rows round-trip a non-default value.
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt, " +
+                    "identityHashVersion) " +
+                    "VALUES (42, 'm42', 'h42', 'Post-F2 title', NULL, 'u', 'p', NULL, 52, NULL, " +
+                    "NULL, NULL, 2)"
+            )
+            db.query("SELECT identityHashVersion FROM documents WHERE id=42").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(2)
+            }
+            db.execSQL(
+                "INSERT INTO book_insights (identityKey, metadataId, contentHash, modelId, " +
+                    "promptVersion, tone, language, payloadJson, sourcesJson, schemaVersion, " +
+                    "serverId, generatedAt, syncedAt, identityHashVersion) VALUES " +
+                    "('m42', 'm42', 'h42', 'llama3.1', '4', 'neutral', 'auto', '{}', '[]', 4, " +
+                    "200, 2000, 2100, 3)"
+            )
+            db.query(
+                "SELECT identityHashVersion FROM book_insights " +
+                    "WHERE identityKey='m42' AND modelId='llama3.1' AND promptVersion='4'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(3)
+            }
+        }
+    }
+
+    @Test fun `migrate 6 to 9 chains all additive migrations`() {
+        // Long-tail upgrade path: a v6 install (pre-PR-η) jumps straight to
+        // v9 (post-F-2). Every additive migration in between must survive.
+        helper.createDatabase(DB, 6).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (51, 'm51', 'h51', 'Pre-F2 chain title', NULL, 'u', 'p', NULL, 61, NULL, NULL, NULL)"
+            )
+            db.execSQL(
+                "INSERT INTO progress (id, documentId, locator, percent, updatedAt, " +
+                    "localUpdatedAt, syncedAt, finishedAt) " +
+                    "VALUES (51, 51, 'loc', 0.8, 100, 100, 0, NULL)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(
+            DB,
+            9,
+            true,
+            EReaderDatabase.MIGRATION_6_7,
+            EReaderDatabase.MIGRATION_7_8,
+            EReaderDatabase.MIGRATION_8_9,
+        ).use { db ->
+            // F-2 column landed on both tables.
+            db.query("SELECT identityHashVersion FROM documents WHERE id=51").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            db.query("PRAGMA table_info('book_insights')").use { c ->
+                val cols = mutableSetOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("identityHashVersion")
+            }
+            // Earlier additive migrations still present.
+            db.query("PRAGMA table_info('progress')").use { c ->
+                val cols = mutableSetOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("abandonedAt")
+            }
+        }
+    }
+
     private companion object { const val DB = "migration-test.db" }
 }

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
@@ -7,6 +7,11 @@ import kotlinx.serialization.Serializable
 data class DocumentIdDto(
     @SerialName("metadata_id") val metadataId: String? = null,
     @SerialName("content_hash") val contentHash: String,
+    // Phase-0 / F-2: schema version of the client-side hash function that
+    // produced `contentHash`. Defaults to `1` so an older server that does
+    // not yet emit the field (pre-F-1) decodes safely — every existing
+    // hash on the wire is v1.
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
 
 @Serializable

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
@@ -31,6 +31,9 @@ class SyncOrchestrator(
                         contentHash = requireNotNull(doc.identity.contentHash) {
                             "downloaded document must have a contentHash"
                         },
+                        // Phase-0 / F-2: stamp every outbound progress push
+                        // with the hash version of the row it references.
+                        identityHashVersion = doc.identityHashVersion,
                     ),
                     locator = progress.locator,
                     percent = progress.percent,
@@ -65,7 +68,15 @@ class SyncOrchestrator(
     }
 
     private suspend fun applyPulled(item: ProgressItemDto) {
-        val identity = DocumentIdentity(metadataId = item.document.metadataId, contentHash = item.document.contentHash)
+        // Phase-0 / F-2: forward the server-reported identity_hash_version
+        // into the DocumentIdentity used for local lookup. We don't act on
+        // it here (progress doesn't carry a hash on disk; doc rows are
+        // looked up by metadataId/contentHash) — but the field travels.
+        val identity = DocumentIdentity(
+            metadataId = item.document.metadataId,
+            contentHash = item.document.contentHash,
+            identityHashVersion = item.document.identityHashVersion,
+        )
         val doc = documentRepo.findByIdentity(identity) ?: return
         val incomingUpdatedAt = Instant.parse(item.clientUpdatedAt).toEpochMilli()
         val incomingFinishedAt = item.finishedAt?.let { Instant.parse(it).toEpochMilli() }

--- a/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
+++ b/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
@@ -113,4 +113,23 @@ class ProgressDtosTest {
         assertThat(r.items.first().abandonedAt).isEqualTo("2026-05-20T12:00:00+00:00")
         assertThat(r.items.first().finishedAt).isNull()
     }
+
+    // ---------- Phase-0 / F-2: identity_hash_version ----------
+
+    @Test fun `DocumentIdDto carries identity_hash_version on the wire`() {
+        val encJson = Json { encodeDefaults = true }
+        val dto = DocumentIdDto(metadataId = "m1", contentHash = "h1", identityHashVersion = 2)
+        val encoded = encJson.encodeToString(DocumentIdDto.serializer(), dto)
+        assertThat(encoded).contains("\"identity_hash_version\":2")
+        val decoded = encJson.decodeFromString(DocumentIdDto.serializer(), encoded)
+        assertThat(decoded.identityHashVersion).isEqualTo(2)
+    }
+
+    @Test fun `DocumentIdDto missing identity_hash_version defaults to 1`() {
+        // Pre-F-1 server payload — the field hasn't landed server-side yet
+        // (or the deploy lags). Every hash on the wire today is v1.
+        val raw = """{"metadata_id":"m1","content_hash":"h1"}"""
+        val decoded = json.decodeFromString(DocumentIdDto.serializer(), raw)
+        assertThat(decoded.identityHashVersion).isEqualTo(1)
+    }
 }


### PR DESCRIPTION
## Summary

Implements **Phase 0, task A-3** of the Quire monetization plan: a share-sheet ingest + an in-app `+ Import` button so users can pull EPUBs into their library without going through OPDS. Lands as a strictly additive feature alongside the existing catalog/download path. Spec deliberately forbids any post-import curation, tag editor, or metadata-confirm UI in v1.

Spec reference: [`docs/superpowers/specs/2026-05-22-quire-monetization-design.md`](../blob/main/docs/superpowers/specs/2026-05-22-quire-monetization-design.md) — "First-launch flow (Android)" (last paragraph) and "Build sequence" → "Phase 0" item 4.

## What landed

- **`ImportActivity`** (`taskAffinity=""`, `excludeFromRecents=true`) sinks `ACTION_SEND` (`application/epub+zip`, `application/zip`) and `ACTION_VIEW` (`application/epub+zip` over `content`/`file` schemes). Stays alive on its `lifecycleScope` until the import completes so the temporary content-URI grant outlives the read — handing the URI to WorkManager would have lost the grant.
- **`+ Import` IconButton** on the library top bar **and** on the empty-library state (the top bar is hidden when the library is empty, so first-time-sideload users would otherwise have no entry point). Both use `OpenDocument` with `arrayOf("application/epub+zip", "application/zip")`.
- **`SideloadImporter`** is the single funnel. Pipeline:
  1. Stream-copy to `<uuid>.epub.part` in `booksDir`.
  2. Structural EPUB validation (XXE-hardened `container.xml` + rootfile + OPF entry check) — refuses arbitrary zips before they reach the identity hasher.
  3. `extractIdentity()` via the existing `:core:identity` module (unchanged).
  4. De-dup against `documentRepository.findByIdentity()`, with `SQLiteConstraintException` as a fallback for parallel-import races against the unique `contentHash` index.
  5. Insert with `identityHashVersion = CURRENT_IDENTITY_HASH_VERSION` (the F-2 constant), `downloadUrl = "sideload://v1/<contentHash>"` (synthetic — the schema is unchanged and `downloadUrl` is NOT NULL), `coverPath = null`.
  6. Fire `libraryUploader.enqueueOne()` for parity with the catalog path; reset the progress-sync cursor + expedited `SyncEnqueuer.enqueue` so a returning user's server-side progress can re-attach to the new local row.
- **`sweepStaleParts()`** runs at app start to GC `.epub.part` files leaked by process death mid-copy.
- **Snackbar feedback** only: "Imported: <title>" / "Already in your library: <title>" / "Not a valid EPUB." etc. No curation, no tag editor, no metadata-confirm step.

## Files changed

- `app/src/main/AndroidManifest.xml` — new `ImportActivity` with two intent filters.
- `app/src/main/java/io/theficos/ereader/sideload/SideloadImporter.kt` — pipeline.
- `app/src/main/java/io/theficos/ereader/sideload/ImportActivity.kt` — share-sheet / VIEW sink.
- `app/src/main/java/io/theficos/ereader/sideload/ImportIntents.kt` — pure-function `extractImportUri(Intent?)` for testability.
- `app/src/main/java/io/theficos/ereader/di/AppContainer.kt` — wires the importer + sweep + sync-cursor reset hook.
- `app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt` — `+ Import` button on top bar + empty state.
- `app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt` — passes `sideloadImporter` into `LibraryScreen`.
- `app/src/main/res/values/strings.xml` — `sideload_import_label`.
- `app/src/test/java/io/theficos/ereader/sideload/SideloadImporterTest.kt` — 5 tests (happy path, duplicate, two invalid shapes, stale-part sweep).
- `app/src/test/java/io/theficos/ereader/sideload/ImportIntentsTest.kt` — 5 tests covering both intent shapes + edge cases.

## Activity / UI surface (for A-2 wire-up)

The first-launch flow (task A-2) can introduce sideload from either of two entry points, both already wired:

- **Compose**: pass `container.sideloadImporter` into `LibraryScreen(... sideloadImporter = ..., ...)`. The button auto-appears in the top bar and empty-state. Or expose the launcher pattern (`rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri -> scope.launch { importer.import(uri, displayName) } }`) anywhere else (e.g., a "first launch — try a sample / import your first book" gate).
- **Manifest**: nothing more needed. The share-sheet + file-manager paths work the moment the APK is installed.

## Stacking

This PR is **stacked on #48** (F-2: identity-hash versioning). A-3 consumes the `CURRENT_IDENTITY_HASH_VERSION` constant F-2 introduced. **Merge F-2 first.** Once F-2 lands on main, this branch should rebase onto main and become a normal PR.

## Verification

```
scripts/dgradle :app:testDebugUnitTest :data:local:testDebugUnitTest :core:identity:test :core:metadata:test
BUILD SUCCESSFUL in 57s

scripts/dgradle :app:testReleaseUnitTest
BUILD SUCCESSFUL in 1m 55s
```

10 new sideload tests pass; full `:app` regression passes on both debug and release variants.

## Unresolved / followups (deferred deliberately)

- **No `ACTION_SEND_MULTIPLE`** in v1. Architect verdict: single-file v1 is cleaner; adding it later is trivial because the importer is already serialized via a `Mutex`.
- **No EPUB cover extraction.** `coverPath = null`; the existing `CoverImage` fallback renders title/author. Spec-flagged as a v2 flourish.
- **No `takePersistableUriPermission` for `OpenDocument`.** We copy the bytes inside the launcher callback before any suspension, so the temporary grant is sufficient. If we later defer the import to background work, this needs to change.
- **Catalog "already downloaded" detection still keys on `downloadUrl`.** A book sideloaded *and* present in the OPDS catalog won't show as "downloaded" in the catalog UI. Out of scope for A-3; a future change to that lookup can use `findByIdentity` instead.