### PR TITLE
feat(android): WorkManager library-mirror push job (Phase 0, task A-4)

### DIFF
--- a/app/src/main/java/io/theficos/ereader/EReaderApp.kt
+++ b/app/src/main/java/io/theficos/ereader/EReaderApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import coil.ImageLoader
 import coil.ImageLoaderFactory
+import io.theficos.ereader.data.library.sync.LibraryMirrorPushScheduler
 import io.theficos.ereader.di.AppContainer
 import kotlinx.coroutines.launch
 
@@ -34,6 +35,23 @@ class EReaderApp : Application(), ImageLoaderFactory {
                 container.insightSyncRepository.requestSync("app_start_post_upload")
             }
         }
+
+        // Phase 0 / A-4: schedule the library-mirror push worker.
+        //
+        // The per-item PUT path above (`LibraryUploader`) is unchanged
+        // and stays the fast path for "this specific download just
+        // landed". The new bulk-push job is the durable mirror of
+        // everything the user has — it survives app restarts, runs
+        // daily under WorkManager's Doze-aware scheduler, and pushes
+        // through transient network failures via WorkManager's built-in
+        // exponential backoff.
+        //
+        // Expedited on app start so the user-perceptible delay between
+        // "fresh install / re-launch after a long pause" and "server
+        // catches up" is minimised. `RUN_AS_NON_EXPEDITED_WORK_REQUEST`
+        // (set inside the scheduler) handles expedited-quota exhaustion.
+        LibraryMirrorPushScheduler.enqueueOneTime(this, expedited = true)
+        LibraryMirrorPushScheduler.enqueuePeriodic(this)
     }
 
     override fun newImageLoader(): ImageLoader =

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -10,6 +10,8 @@ import io.theficos.ereader.data.ai.CatalogInsightStash
 import io.theficos.ereader.data.ai.InsightSyncRepository
 import io.theficos.ereader.data.library.LibraryClient
 import io.theficos.ereader.data.library.LibraryUploader
+import io.theficos.ereader.data.library.sync.CredentialsProvider
+import io.theficos.ereader.data.library.sync.LibraryMirrorPushDependencies
 import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.ProgressRepository
 import io.theficos.ereader.data.local.db.EReaderDatabase
@@ -227,6 +229,15 @@ class AppContainer(context: Context) {
 
     init {
         SyncDependencies.holder = SyncDependencies.Holder(syncOrchestrator)
+        // Phase 0 / A-4: wire the library-mirror push worker's DI before
+        // any WorkManager run can fire. Same pattern as SyncDependencies
+        // above. The `CredentialsProvider` indirection keeps the worker
+        // testable without touching the Android KeyStore-backed store.
+        LibraryMirrorPushDependencies.holder = LibraryMirrorPushDependencies.Holder(
+            client = libraryClient,
+            dao = db.documentDao(),
+            credentials = CredentialsProvider { credentialStore.get() != null },
+        )
         // PR-ζ: clear the catalog stash whenever the server base URL
         // changes (different deploy → entries are no longer relevant). The
         // AI opt-out toggle hook lives in PR-δ (Bundle 3); until then a

--- a/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
@@ -11,4 +11,10 @@ data class Document(
     val downloadedAt: Long,
     val seriesName: String? = null,
     val seriesIndex: Double? = null,
+    /**
+     * Schema version of the client-side hash function that produced
+     * `identity.contentHash` for this document. See
+     * [CURRENT_IDENTITY_HASH_VERSION]; today every Document is v1.
+     */
+    val identityHashVersion: Int = CURRENT_IDENTITY_HASH_VERSION,
 )

--- a/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
@@ -4,6 +4,35 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Schema version of the client-side identity-hash function. Stamped on every
+ * record that carries an identity hash (Room rows + outbound DTOs) so a future
+ * change to the hash function (edition merging, normalization fixes, etc.)
+ * doesn't break sync, caches, recs, export, or deletion across persisted data.
+ *
+ * Phase-0 task F-2 introduces this constant at value `1` — the current MD5-
+ * sampled hash in `core/identity/ContentHash.kt`. Bumping this constant later
+ * requires:
+ *   1. Updating the hash function.
+ *   2. A migration that re-computes hashes for local rows and re-uploads them.
+ *   3. Server-side acceptance of the new version (sibling task F-1 introduces
+ *      the wire field; further bumps are coordinated with the server team).
+ *
+ * The companion [isStaleHashVersion] predicate is the explicit "needs rehash"
+ * check; today it is a no-op (no rows exist at version < 1) but the mechanism
+ * is wired so a future version bump only needs to flip the constant.
+ */
+const val CURRENT_IDENTITY_HASH_VERSION: Int = 1
+
+/**
+ * True iff a record stamped with [rowVersion] was produced by an older client
+ * hash function and should be re-hashed before its next push to the server.
+ *
+ * Today this is `rowVersion < 1`, which is always false — bumping
+ * [CURRENT_IDENTITY_HASH_VERSION] activates the predicate for legacy rows.
+ */
+fun isStaleHashVersion(rowVersion: Int): Boolean = rowVersion < CURRENT_IDENTITY_HASH_VERSION
+
+/**
  * Mirrors `DocumentIdentity` in `server/quire_server/api/ai_schemas.py`.
  *
  * Canonical schemes (`metadataId`, `contentHash`) identify a downloaded EPUB
@@ -16,6 +45,13 @@ import kotlinx.serialization.Serializable
  * invariant (`contentHash` non-empty) is enforced by the call site
  * (`EpubIdentityExtractor`), not the type — pre-download paths legitimately
  * have no `contentHash`.
+ *
+ * `identityHashVersion` (Phase-0 / F-2) stamps which version of the
+ * client-side hash function produced [contentHash]. Defaults to
+ * [CURRENT_IDENTITY_HASH_VERSION] so callers building an identity from a
+ * freshly-computed hash get the right value automatically; defaults to `1`
+ * on the wire so an older server that doesn't emit the field decodes
+ * correctly (every existing hash on the network is v1).
  */
 @Serializable
 data class DocumentIdentity(
@@ -25,6 +61,7 @@ data class DocumentIdentity(
     @SerialName("opds_href") val opdsHref: String? = null,
     @SerialName("calibre_book_id") val calibreBookId: String? = null,
     val isbn: String? = null,
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 ) {
     init {
         require(

--- a/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
+++ b/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
@@ -1,9 +1,12 @@
 package io.theficos.ereader.core.model
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
 import org.junit.Test
 
 class DocumentIdentityTest {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
     @Test fun `accepts contentHash-only`() {
         val id = DocumentIdentity(metadataId = null, contentHash = "abc123")
         assertThat(id.contentHash).isEqualTo("abc123")
@@ -40,5 +43,46 @@ class DocumentIdentityTest {
     @Test fun `accepts isbn-only alias payload`() {
         val id = DocumentIdentity(isbn = "9780553293357")
         assertThat(id.isbn).isEqualTo("9780553293357")
+    }
+
+    // ---------- Phase-0 / F-2: identity hash version ----------
+
+    @Test fun `identityHashVersion defaults to current version`() {
+        val id = DocumentIdentity(contentHash = "abc")
+        assertThat(id.identityHashVersion).isEqualTo(CURRENT_IDENTITY_HASH_VERSION)
+        assertThat(CURRENT_IDENTITY_HASH_VERSION).isEqualTo(1)
+    }
+
+    @Test fun `isStaleHashVersion is no-op at current version`() {
+        assertThat(isStaleHashVersion(1)).isFalse()
+        // A future v2 row decoded by a v1 client is NOT stale (not the
+        // direction the predicate cares about).
+        assertThat(isStaleHashVersion(2)).isFalse()
+    }
+
+    @Test fun `isStaleHashVersion detects pre-current versions`() {
+        // Hypothetical bump to v2: a v1 row is now stale and needs a rehash.
+        // Asserted via the underlying inequality so the test is robust against
+        // a future constant change.
+        assertThat(0 < CURRENT_IDENTITY_HASH_VERSION).isTrue()
+        assertThat(isStaleHashVersion(0)).isTrue()
+    }
+
+    @Test fun `identity_hash_version round-trips on the wire`() {
+        val id = DocumentIdentity(contentHash = "abc", identityHashVersion = 7)
+        val encoded = json.encodeToString(DocumentIdentity.serializer(), id)
+        assertThat(encoded).contains("\"identity_hash_version\":7")
+        val decoded = json.decodeFromString(DocumentIdentity.serializer(), encoded)
+        assertThat(decoded.identityHashVersion).isEqualTo(7)
+        assertThat(decoded.contentHash).isEqualTo("abc")
+    }
+
+    @Test fun `missing identity_hash_version decodes to 1 for back-compat`() {
+        // An older server that doesn't yet emit the field (pre-F-1) must
+        // still decode cleanly. Every hash on the wire today is v1.
+        val legacyWire = """{"content_hash":"abc"}"""
+        val decoded = json.decodeFromString(DocumentIdentity.serializer(), legacyWire)
+        assertThat(decoded.identityHashVersion).isEqualTo(1)
+        assertThat(decoded.contentHash).isEqualTo("abc")
     }
 }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
@@ -301,6 +301,9 @@ class AiRepository(
             serverId = 0L,
             generatedAt = parseIsoMillis(resp.generatedAt) ?: clock(),
             syncedAt = clock(),
+            // Phase-0 / F-2: stamp the cache row with the hash version of
+            // the identity used to fetch it. See `InsightEntity.identityHashVersion`.
+            identityHashVersion = identity.identityHashVersion,
         )
         insightDao.upsert(entity)
     }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/InsightSyncRepository.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/InsightSyncRepository.kt
@@ -131,5 +131,8 @@ internal fun InsightSyncItem.toEntity(syncedAtMs: Long, json: Json): InsightEnti
         serverId = id,
         generatedAt = parseIsoMillis(generatedAt) ?: syncedAtMs,
         syncedAt = syncedAtMs,
+        // Phase-0 / F-2: cache row inherits the hash version stamped by
+        // the server on the source identity.
+        identityHashVersion = identity.identityHashVersion,
     )
 }

--- a/data/library/build.gradle.kts
+++ b/data/library/build.gradle.kts
@@ -26,10 +26,13 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
+    implementation(libs.work.runtime.ktx)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.work.testing)
+    testImplementation(libs.androidx.test.core)
 }

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt
@@ -3,4 +3,6 @@ package io.theficos.ereader.data.library
 object LibraryApi {
     const val PATH_STATS = "/library/v1/stats"
     const val PATH_ITEMS = "/library/v1/items"
+    // Phase 0 / S-2 (server) + A-4 (Android): bulk library-mirror push.
+    const val PATH_SYNC = "/library/v1/sync"
 }

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
@@ -25,6 +25,26 @@ class LibraryClient(
     private val http: OkHttpClient,
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
+    /**
+     * Json instance used for `/library/v1/sync` (Phase 0, task A-4).
+     *
+     * Strict mode (`encodeDefaults = true`) so every entry serializes
+     * with the full X-1 wire shape — explicit `identity_hash_version`,
+     * explicit `status`, empty `authors`/`subjects` lists — rather than
+     * relying on the server's default-fill paths. The server uses
+     * Pydantic `extra="forbid"` so any unknown field becomes a 422, but
+     * missing-with-default fields are accepted; emitting them explicitly
+     * keeps the wire trace auditable and decouples Android from any
+     * future server default changes.
+     *
+     * `ignoreUnknownKeys = true` on response decode lets a Phase-1 server
+     * add new summary counters without breaking older clients.
+     */
+    private val syncJson: Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
     private fun resolveBaseUrl(): String {
         val raw = baseUrlProvider()
         if (raw.isNullOrBlank()) {
@@ -70,6 +90,37 @@ class LibraryClient(
             val body = resp.body?.string().orEmpty()
             if (!resp.isSuccessful) throw LibraryHttpException(resp.code, body)
             json.decodeFromString(LibraryItemResponse.serializer(), body)
+        }
+    }
+
+    /**
+     * Push a batch of library mirror entries to `POST /library/v1/sync`.
+     *
+     * Wire contract (Phase 0 / X-1):
+     * - Body shape: `{"items": [LibrarySyncEntry, ...]}`.
+     * - Identity field is `identity_hash`. Sending `content_hash` here is
+     *   rejected with 422 (Pydantic `extra="forbid"`).
+     * - Caller is responsible for chunking — server enforces a 500-item
+     *   ceiling per request (`library_sync_max_items`); over → 422.
+     *
+     * Failure modes (callers map these to WorkManager outcomes):
+     * - 401 → `LibraryHttpException(401)` — caller should fail without
+     *   retry; credentials need attention.
+     * - 4xx (other than 401/429) → `LibraryHttpException(code)` — caller
+     *   should log + drop the batch, not retry forever.
+     * - 429 / 5xx / network — `LibraryHttpException` or `IOException`
+     *   propagated; caller should retry with backoff.
+     */
+    suspend fun syncBatch(payload: LibrarySyncRequest): LibrarySyncSummary = withContext(Dispatchers.IO) {
+        val bodyJson = syncJson.encodeToString(LibrarySyncRequest.serializer(), payload)
+        val req = Request.Builder()
+            .url(resolveBaseUrl() + LibraryApi.PATH_SYNC)
+            .post(bodyJson.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        http.newCall(req).execute().use { resp ->
+            val body = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) throw LibraryHttpException(resp.code, body)
+            syncJson.decodeFromString(LibrarySyncSummary.serializer(), body)
         }
     }
 

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
@@ -56,6 +56,10 @@ data class LibraryItemRequest(
     val language: String? = null,
     val subjects: List<String> = emptyList(),
     @SerialName("opds_href") val opdsHref: String? = null,
+    // Phase-0 / F-2: stamps which client hash-function version produced
+    // `contentHash`. Defaults to `1` for wire back-compat with an older
+    // server that doesn't yet emit the field (F-1 lands it server-side).
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
 
 /**
@@ -90,4 +94,7 @@ data class LibraryItemResponse(
     @SerialName("created_at") val createdAt: String,
     @SerialName("updated_at") val updatedAt: String,
     @SerialName("deleted_at") val deletedAt: String? = null,
+    // Phase-0 / F-2: defaults to `1` so an older server (pre-F-1) decodes
+    // safely — every hash on the wire today is v1.
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibrarySyncDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibrarySyncDtos.kt
@@ -1,0 +1,97 @@
+package io.theficos.ereader.data.library
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire DTOs for `POST /library/v1/sync` — the bulk library-mirror push
+ * introduced by Phase 0 task S-2 server-side and consumed by Phase 0 task
+ * A-4 (Android library-mirror push WorkManager job).
+ *
+ * Identity-naming contract (Phase 0 / X-1): the JSON field for book identity
+ * on this endpoint is `identity_hash`. The legacy server DB column is still
+ * `content_hash`; the server bridges the rename at the ORM boundary. The
+ * Pydantic model uses `extra="forbid"`, so any unknown wire field — most
+ * importantly `content_hash` on this endpoint — fails the whole request
+ * with a 422. The `LibrarySyncEntry` below uses `identity_hash` exclusively.
+ *
+ * Shape is FLAT — the server's `LibrarySyncEntry` carries metadata fields
+ * at the top level rather than under a nested `metadata` object. We mirror
+ * that here so kotlinx-serialization round-trips byte-identical to the
+ * server's wire contract.
+ */
+
+@Serializable
+enum class LibrarySyncStatus {
+    @SerialName("present") PRESENT,
+    @SerialName("deleted") DELETED,
+}
+
+/**
+ * One book in a `POST /library/v1/sync` request body.
+ *
+ * Status semantics:
+ * - `PRESENT` carries metadata and behaves like an upsert. `title` is
+ *   required server-side for `present` entries.
+ * - `DELETED` carries identity only and tombstones the row. Metadata
+ *   fields on a `DELETED` entry are accepted by the server but ignored.
+ *
+ * `lastSeenAt` is a wire-only freshness signal: the server validates it
+ * (tz-aware ISO-8601) but does NOT persist it in v1. The worker reuses a
+ * single value across every entry in one run so logs and server-side
+ * debugging stay coherent.
+ *
+ * `identityHashVersion` defaults to `1` for wire back-compat with older
+ * servers; on F-2+ clients the field is propagated from
+ * `DocumentEntity.identityHashVersion`.
+ */
+@Serializable
+data class LibrarySyncEntry(
+    @SerialName("identity_hash") val identityHash: String,
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
+    val status: LibrarySyncStatus = LibrarySyncStatus.PRESENT,
+    // ISO-8601 with timezone (e.g. "2026-05-22T15:00:00Z"). Generated once
+    // per worker run and reused across chunks.
+    @SerialName("last_seen_at") val lastSeenAt: String? = null,
+    @SerialName("metadata_id") val metadataId: String? = null,
+    val title: String? = null,
+    val authors: List<String> = emptyList(),
+    @SerialName("series_name") val seriesName: String? = null,
+    @SerialName("series_index") val seriesIndex: Double? = null,
+    val isbn: String? = null,
+    val language: String? = null,
+    val subjects: List<String> = emptyList(),
+    @SerialName("opds_href") val opdsHref: String? = null,
+)
+
+/**
+ * Body of `POST /library/v1/sync`. The server enforces a per-request cap
+ * (`library_sync_max_items = 500`); callers chunk before hitting this wire.
+ * An empty `items` list is a valid heartbeat ping.
+ */
+@Serializable
+data class LibrarySyncRequest(val items: List<LibrarySyncEntry>)
+
+/**
+ * Response body of `POST /library/v1/sync` — aggregate counts only.
+ *
+ * The server intentionally does NOT echo per-entry results; clients that
+ * want row-level state poll `GET /library/v1/items?since=`. `serverTime`
+ * mirrors that endpoint's cursor shape so the client can chain delta-fetch
+ * after a successful push.
+ *
+ * `ignoreUnknownKeys = true` on the [LibraryClient] Json instance means a
+ * server that adds new counters (Phase 1+) won't break older clients.
+ */
+@Serializable
+data class LibrarySyncSummary(
+    val received: Int,
+    val processed: Int,
+    val created: Int,
+    val updated: Int,
+    val reactivated: Int,
+    val deleted: Int,
+    val skipped: Int,
+    @SerialName("missing_deleted") val missingDeleted: Int,
+    @SerialName("server_time") val serverTime: String,
+)

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
@@ -119,6 +119,10 @@ class LibraryUploader(
             language = null,    // v2: parse from OPF
             subjects = emptyList(), // v2: parse from OPF
             opdsHref = downloadUrl,
+            // Phase-0 / F-2: forward the row's stored hash version. Today
+            // this is always 1; a future hash-function bump will set it to
+            // the version that was current when this row was hashed.
+            identityHashVersion = identityHashVersion,
         )
 
     private companion object {

--- a/data/library/src/main/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushScheduler.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushScheduler.kt
@@ -1,0 +1,90 @@
+package io.theficos.ereader.data.library.sync
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+/**
+ * WorkManager scheduling surface for [LibraryMirrorPushWorker] — Phase 0
+ * task A-4.
+ *
+ * Three trigger entrypoints:
+ * - [enqueueOneTime] — used at app start (with `expedited = true`) and
+ *   for ad-hoc "sync now" semantics. Coalesces via unique work so
+ *   concurrent triggers don't fire overlapping workers.
+ * - [enqueueAfterLibraryChange] — alias for a non-expedited one-time
+ *   push. Called from any code path that materially changes the local
+ *   library (sideload import, future bulk-delete flow). Sideload
+ *   integration with A-3 is deferred to reconciliation time.
+ * - [enqueuePeriodic] — daily heartbeat. Best-effort under Doze /
+ *   battery-optimization buckets; the daily cadence is sufficient
+ *   because the worker is fully idempotent (a no-op replay just bumps
+ *   the server's `skipped` counter and returns).
+ */
+object LibraryMirrorPushScheduler {
+
+    const val UNIQUE_ONE_TIME = "library-mirror-push-now"
+    const val UNIQUE_PERIODIC = "library-mirror-push-periodic"
+
+    private fun networkConstraints(): Constraints =
+        Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+
+    /**
+     * Enqueue a one-time push.
+     *
+     * `KEEP` policy: if a previous one-time push is still pending or
+     * running, leave it alone — the new trigger reads the same Room
+     * snapshot at execution time, so kicking off a second worker would
+     * just duplicate the POST.
+     *
+     * `expedited = true` opts into [OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST]
+     * so quota-exhaustion downgrades gracefully rather than dropping the
+     * sync entirely. Use only for triggers where promptness matters
+     * (app start), not for ambient triggers.
+     */
+    fun enqueueOneTime(context: Context, expedited: Boolean = false) {
+        val req = OneTimeWorkRequestBuilder<LibraryMirrorPushWorker>()
+            .setConstraints(networkConstraints())
+            .apply {
+                if (expedited) {
+                    setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                }
+            }
+            .build()
+        WorkManager.getInstance(context.applicationContext)
+            .enqueueUniqueWork(UNIQUE_ONE_TIME, ExistingWorkPolicy.KEEP, req)
+    }
+
+    /**
+     * Convenience entry point for callers that just learned the library
+     * changed (e.g. a sideload import landed). Non-expedited because the
+     * caller is already on the foreground UI path; promptness is "next
+     * available network window" rather than "right now".
+     */
+    fun enqueueAfterLibraryChange(context: Context) {
+        enqueueOneTime(context, expedited = false)
+    }
+
+    /**
+     * Enqueue the daily periodic push. Idempotent — calling this every
+     * `Application.onCreate` is intentional. `KEEP` means a second call
+     * is a no-op while the previous periodic registration is alive.
+     */
+    fun enqueuePeriodic(context: Context) {
+        val req = PeriodicWorkRequestBuilder<LibraryMirrorPushWorker>(
+            1,
+            TimeUnit.DAYS,
+        )
+            .setConstraints(networkConstraints())
+            .build()
+        WorkManager.getInstance(context.applicationContext)
+            .enqueueUniquePeriodicWork(UNIQUE_PERIODIC, ExistingPeriodicWorkPolicy.KEEP, req)
+    }
+}

--- a/data/library/src/main/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorker.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorker.kt
@@ -1,0 +1,235 @@
+package io.theficos.ereader.data.library.sync
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import io.theficos.ereader.data.library.LibraryClient
+import io.theficos.ereader.data.library.LibraryHttpException
+import io.theficos.ereader.data.library.LibrarySyncEntry
+import io.theficos.ereader.data.library.LibrarySyncRequest
+import io.theficos.ereader.data.library.LibrarySyncStatus
+import io.theficos.ereader.data.library.parseAuthors
+import io.theficos.ereader.data.local.db.DocumentDao
+import io.theficos.ereader.data.local.db.DocumentEntity
+import java.io.IOException
+import java.time.Instant
+import kotlinx.coroutines.flow.first
+
+/**
+ * WorkManager job that POSTs the user's full library mirror to
+ * `POST /library/v1/sync` — Phase 0 task A-4.
+ *
+ * Trigger model (callers in [LibraryMirrorPushScheduler]):
+ * - **App start** — one-time expedited (with non-expedited fallback so
+ *   quota exhaustion never silently drops the sync).
+ * - **After library changes (sideload import)** — one-time. Callers can
+ *   use [LibraryMirrorPushScheduler.enqueueAfterLibraryChange]. Wiring
+ *   from A-3's `SideloadImporter` is deferred to reconciliation time
+ *   because A-3 lives on a parallel branch.
+ * - **Daily periodic** — best-effort heartbeat with `NetworkType.CONNECTED`.
+ *
+ * Failure semantics:
+ * - **No credentials** → `Result.success()` no-op. Don't keep retrying
+ *   when there's no account to push under.
+ * - **401** → `Result.failure()`. WorkManager won't retry; user needs to
+ *   re-auth (the next app-start enqueue will pick up new credentials).
+ * - **403 / 4xx (other than 401/429)** → log + drop the offending chunk
+ *   and continue with the rest of the batches. Returns `Result.success()`
+ *   if no chunk forced a retry. The server explicitly rejected this
+ *   payload; retrying forever just spams logs.
+ * - **429 / 5xx / IOException** → `Result.retry()`. WorkManager handles
+ *   exponential backoff. We do not honour `Retry-After` headers in v1.
+ *
+ * Atomicity & ordering:
+ * - The library is read as a single Room snapshot (`observeAll().first()`).
+ *   A sideload finishing mid-job doesn't disturb the in-flight snapshot —
+ *   it enqueues a follow-up sync via the library-change hook.
+ * - Entries are sorted by `identity_hash` (stable string ordering) so
+ *   replays send the same chunk boundaries. Identical chunks make replay
+ *   safe under the server's diff-skip semantics.
+ * - `last_seen_at` is computed once per run and reused across all chunks
+ *   so logs and server-side debugging see one cursor per run rather than
+ *   per chunk.
+ *
+ * Privacy: this worker logs counts, HTTP status codes, chunk indices, and
+ * an 8-char hash prefix only. Never titles, authors, file paths, or full
+ * identity hashes.
+ */
+class LibraryMirrorPushWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val deps = LibraryMirrorPushDependencies.holder ?: run {
+            // DI not initialised (Application.onCreate() not run yet, or
+            // process restart between WorkManager scheduling and execution
+            // in a way that lost the holder). Failing here is preferable
+            // to retrying forever against a missing dependency.
+            Log.w(TAG, "doWork: dependencies not initialised")
+            return Result.failure()
+        }
+
+        // Snapshot credentials once — mid-run credential changes (logout
+        // etc.) should not flip the worker's behaviour part-way through.
+        val hasAccount = deps.credentials.hasAccount()
+        if (!hasAccount) {
+            Log.i(TAG, "doWork: no account configured; skipping push")
+            return Result.success()
+        }
+
+        val runStartedAt = Instant.now()
+        val lastSeenAt = ISO_FORMATTER.format(runStartedAt)
+
+        // Snapshot the library as a single Room read. `.first()` on the
+        // Flow returns the current value immediately; we do not stay
+        // subscribed across chunks (a mid-run library change would
+        // otherwise produce inconsistent chunks).
+        val docs: List<DocumentEntity> = deps.dao.observeAll().first()
+        if (docs.isEmpty()) {
+            Log.i(TAG, "doWork: library is empty; nothing to push")
+            return Result.success()
+        }
+
+        // Stable order across replays. The diff-skip in the server's
+        // `_row_matches_payload` check means an unchanged chunk replay is
+        // a free no-op for the DB — but only if we send the same chunk
+        // boundaries each time. Sorting by identity_hash gives us that.
+        val sorted = docs.sortedBy { it.contentHash }
+        val chunks = sorted.chunked(MAX_BATCH_SIZE)
+        Log.i(
+            TAG,
+            "doWork: starting push books=${sorted.size} chunks=${chunks.size} runStartedAt=$lastSeenAt",
+        )
+
+        var droppedChunks = 0
+        for ((index, chunk) in chunks.withIndex()) {
+            val payload = LibrarySyncRequest(items = chunk.map { it.toSyncEntry(lastSeenAt) })
+            val chunkLabel = "chunk=${index + 1}/${chunks.size} size=${chunk.size}"
+            try {
+                val summary = deps.client.syncBatch(payload)
+                Log.i(
+                    TAG,
+                    "doWork: $chunkLabel ok received=${summary.received} processed=${summary.processed} " +
+                        "created=${summary.created} updated=${summary.updated} reactivated=${summary.reactivated} " +
+                        "deleted=${summary.deleted} skipped=${summary.skipped} " +
+                        "missing_deleted=${summary.missingDeleted}",
+                )
+            } catch (e: LibraryHttpException) {
+                when {
+                    e.code == HTTP_UNAUTHORIZED -> {
+                        Log.w(TAG, "doWork: $chunkLabel 401; failing without retry", e)
+                        return Result.failure()
+                    }
+                    e.code == HTTP_TOO_MANY_REQUESTS || e.code in HTTP_5XX_RANGE -> {
+                        // Transient: bail out and let WorkManager retry
+                        // the whole run with exponential backoff. We do
+                        // NOT continue to subsequent chunks because
+                        // there's no server signal that they'd succeed
+                        // and a partial-progress retry double-pushes the
+                        // earlier chunks (harmless under diff-skip, but
+                        // wasted bytes).
+                        Log.w(TAG, "doWork: $chunkLabel code=${e.code}; scheduling retry", e)
+                        return Result.retry()
+                    }
+                    e.code in HTTP_4XX_RANGE -> {
+                        // The server explicitly rejected this chunk. No
+                        // retry — keep going with subsequent chunks so a
+                        // single poison entry doesn't block the rest of
+                        // the library from syncing.
+                        Log.w(
+                            TAG,
+                            "doWork: $chunkLabel rejected code=${e.code}; dropping chunk and continuing",
+                            e,
+                        )
+                        droppedChunks += 1
+                    }
+                    else -> {
+                        // Defensive: a non-2xx that didn't fit any known
+                        // bucket. Treat as transient.
+                        Log.w(TAG, "doWork: $chunkLabel unexpected code=${e.code}; scheduling retry", e)
+                        return Result.retry()
+                    }
+                }
+            } catch (e: IOException) {
+                // Network failure, TLS error, DNS, etc. The current
+                // chunk's bytes may or may not have reached the server;
+                // future runs send the full mirror again, so a duplicate
+                // POST is idempotent.
+                Log.w(TAG, "doWork: $chunkLabel network failure; scheduling retry", e)
+                return Result.retry()
+            }
+        }
+
+        if (droppedChunks > 0) {
+            Log.w(TAG, "doWork: complete with droppedChunks=$droppedChunks; not retrying")
+        }
+        return Result.success()
+    }
+
+    private fun DocumentEntity.toSyncEntry(lastSeenAt: String): LibrarySyncEntry =
+        LibrarySyncEntry(
+            identityHash = contentHash,
+            identityHashVersion = identityHashVersion,
+            status = LibrarySyncStatus.PRESENT,
+            lastSeenAt = lastSeenAt,
+            metadataId = metadataId,
+            title = title,
+            authors = parseAuthors(author),
+            seriesName = seriesName,
+            seriesIndex = seriesIndex,
+            // Not stored on DocumentEntity in Phase 0 — wire spec allows
+            // them to be null/empty. Server treats absent metadata
+            // fields as "no value", same as the per-item PUT endpoint.
+            isbn = null,
+            language = null,
+            subjects = emptyList(),
+            opdsHref = downloadUrl,
+        )
+
+    private companion object {
+        const val TAG = "LibraryMirrorPush"
+        // Mirrors `library_sync_max_items` (default 500) in the server's
+        // Settings — we chunk client-side rather than catching a 422 on
+        // oversize batches.
+        const val MAX_BATCH_SIZE = 500
+        const val HTTP_UNAUTHORIZED = 401
+        const val HTTP_TOO_MANY_REQUESTS = 429
+        val HTTP_4XX_RANGE = 400..499
+        val HTTP_5XX_RANGE = 500..599
+        // ISO-8601 with explicit `Z` (UTC). Matches Pydantic's tz-aware
+        // parse rule on the server side.
+        val ISO_FORMATTER: java.time.format.DateTimeFormatter =
+            java.time.format.DateTimeFormatter.ISO_INSTANT
+    }
+}
+
+/**
+ * Process-wide DI holder for [LibraryMirrorPushWorker]. Set once in
+ * `AppContainer.init`; the worker reads it from each `doWork` call. This
+ * mirrors `SyncDependencies` over in `:data:sync` so the two
+ * WorkManager-driven workers share a single bootstrapping pattern.
+ *
+ * `CredentialsProvider` is a tiny indirection so tests can stub the
+ * credential check without instantiating `CalibreCredentialStore` (which
+ * touches the Android KeyStore).
+ */
+object LibraryMirrorPushDependencies {
+    @Volatile var holder: Holder? = null
+    data class Holder(
+        val client: LibraryClient,
+        val dao: DocumentDao,
+        val credentials: CredentialsProvider,
+    )
+}
+
+/**
+ * Minimal credential surface the worker needs — just "is an account
+ * configured right now". The shared `OkHttpClient` already injects the
+ * Authorization header from the same store, so this worker doesn't need
+ * to read the password itself.
+ */
+fun interface CredentialsProvider {
+    fun hasAccount(): Boolean
+}

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
@@ -63,4 +63,48 @@ class LibraryDtosTest {
         assertThat(parsed.totalBooks).isEqualTo(3)
         assertThat(parsed.abandonedCount).isEqualTo(0)
     }
+
+    // ---------- Phase-0 / F-2: identity_hash_version ----------
+
+    @Test
+    fun `LibraryItemRequest carries identity_hash_version on the wire`() {
+        // Round-trip with encodeDefaults=true so we can see what would
+        // travel over the wire if an AI-style client were used (the real
+        // LibraryClient uses default encodeDefaults=false, so the field
+        // is omitted on encode there — that's fine, the server applies
+        // its own DEFAULT 1).
+        val encJson = Json { encodeDefaults = true }
+        val req = LibraryItemRequest(
+            contentHash = "abc",
+            title = "T",
+            identityHashVersion = 2,
+        )
+        val encoded = encJson.encodeToString(LibraryItemRequest.serializer(), req)
+        assertThat(encoded).contains("\"identity_hash_version\":2")
+    }
+
+    @Test
+    fun `LibraryItemResponse decodes default 1 when server omits identity_hash_version`() {
+        // Older server (pre-F-1) doesn't emit the field. Every existing
+        // hash on the wire is v1, so the default `= 1` is correct.
+        val body = """
+            {
+              "content_hash":"h1","title":"T","authors":[],"created_at":"2026-01-01T00:00:00+00:00","updated_at":"2026-01-01T00:00:00+00:00"
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryItemResponse.serializer(), body)
+        assertThat(parsed.identityHashVersion).isEqualTo(1)
+    }
+
+    @Test
+    fun `LibraryItemResponse decodes non-default identity_hash_version`() {
+        val body = """
+            {
+              "content_hash":"h1","title":"T","authors":[],"identity_hash_version":3,
+              "created_at":"2026-01-01T00:00:00+00:00","updated_at":"2026-01-01T00:00:00+00:00"
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryItemResponse.serializer(), body)
+        assertThat(parsed.identityHashVersion).isEqualTo(3)
+    }
 }

--- a/data/library/src/test/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushSchedulerTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushSchedulerTest.kt
@@ -1,0 +1,101 @@
+package io.theficos.ereader.data.library.sync
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Smoke tests for [LibraryMirrorPushScheduler] — verifies that one-time
+ * and periodic enqueues actually register work under their unique names.
+ *
+ * We don't drive the worker to completion here (the worker has its own
+ * thorough tests in [LibraryMirrorPushWorkerTest]); we just confirm the
+ * scheduling shape.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class LibraryMirrorPushSchedulerTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before fun setUp() {
+        // SynchronousExecutor + an INFO-level logger makes WorkManager
+        // behave predictably in unit tests — no thread pool, no async
+        // dispatch, no surprises during enqueue.
+        val config = Configuration.Builder()
+            .setMinimumLoggingLevel(android.util.Log.INFO)
+            .setExecutor(SynchronousExecutor())
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+    }
+
+    @Test
+    fun `enqueueOneTime registers work under the one-time unique name`() {
+        LibraryMirrorPushScheduler.enqueueOneTime(context, expedited = false)
+
+        val infos = WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWork(LibraryMirrorPushScheduler.UNIQUE_ONE_TIME)
+            .get()
+        assertThat(infos).isNotEmpty()
+        // Either ENQUEUED (waiting for constraints) or RUNNING (driver
+        // started the worker before the assertion). SUCCEEDED is also
+        // valid if the worker happens to no-op fast (no deps installed →
+        // failure, but failure has terminal state we don't care about).
+        val state = infos.first().state
+        assertThat(state).isAnyOf(
+            WorkInfo.State.ENQUEUED,
+            WorkInfo.State.RUNNING,
+            WorkInfo.State.SUCCEEDED,
+            WorkInfo.State.FAILED,
+        )
+    }
+
+    @Test
+    fun `enqueuePeriodic registers periodic work under the periodic unique name`() {
+        LibraryMirrorPushScheduler.enqueuePeriodic(context)
+
+        val infos = WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWork(LibraryMirrorPushScheduler.UNIQUE_PERIODIC)
+            .get()
+        assertThat(infos).isNotEmpty()
+    }
+
+    @Test
+    fun `enqueueAfterLibraryChange shares the one-time unique name with enqueueOneTime`() {
+        LibraryMirrorPushScheduler.enqueueAfterLibraryChange(context)
+
+        val infos = WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWork(LibraryMirrorPushScheduler.UNIQUE_ONE_TIME)
+            .get()
+        assertThat(infos).isNotEmpty()
+    }
+
+    @Test
+    fun `repeated one-time enqueues coalesce via KEEP policy under the same unique name`() {
+        LibraryMirrorPushScheduler.enqueueOneTime(context, expedited = false)
+        val firstInfos = WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWork(LibraryMirrorPushScheduler.UNIQUE_ONE_TIME)
+            .get()
+        val firstId = firstInfos.first().id
+
+        // Second enqueue with the same unique name and KEEP policy must
+        // NOT create a second work entry — the existing one wins.
+        LibraryMirrorPushScheduler.enqueueOneTime(context, expedited = false)
+        val secondInfos = WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWork(LibraryMirrorPushScheduler.UNIQUE_ONE_TIME)
+            .get()
+
+        // The first ID is preserved; we don't spawn a parallel push.
+        assertThat(secondInfos.map { it.id }).contains(firstId)
+    }
+}

--- a/data/library/src/test/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorkerTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorkerTest.kt
@@ -1,0 +1,374 @@
+package io.theficos.ereader.data.library.sync
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.data.library.LibraryClient
+import io.theficos.ereader.data.local.db.DocumentDao
+import io.theficos.ereader.data.local.db.DocumentEntity
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [LibraryMirrorPushWorker] — Phase 0 task A-4. Robolectric is
+ * required for the WorkManager scaffolding (`TestListenableWorkerBuilder`
+ * needs a Context with the Application framework wired up).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class LibraryMirrorPushWorkerTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: LibraryClient
+    private lateinit var dao: FakeDocumentDao
+    private val context get() = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = LibraryClient(
+            baseUrlProvider = { server.url("").toString().trimEnd('/') },
+            http = OkHttpClient.Builder().callTimeout(5, TimeUnit.SECONDS).build(),
+        )
+        dao = FakeDocumentDao()
+    }
+
+    @After fun tearDown() {
+        server.shutdown()
+        LibraryMirrorPushDependencies.holder = null
+    }
+
+    private fun installDeps(hasAccount: Boolean = true) {
+        LibraryMirrorPushDependencies.holder = LibraryMirrorPushDependencies.Holder(
+            client = client,
+            dao = dao,
+            credentials = CredentialsProvider { hasAccount },
+        )
+    }
+
+    private fun summaryBody(received: Int, processed: Int = received): String = """
+        {
+          "received":$received,
+          "processed":$processed,
+          "created":$processed,
+          "updated":0,
+          "reactivated":0,
+          "deleted":0,
+          "skipped":0,
+          "missing_deleted":0,
+          "server_time":"2026-05-22T15:00:00+00:00"
+        }
+    """.trimIndent()
+
+    private fun buildWorker(): LibraryMirrorPushWorker =
+        TestListenableWorkerBuilder<LibraryMirrorPushWorker>(context).build()
+
+    // -------------------- success / wire shape --------------------
+
+    @Test
+    fun `success path pushes one chunk with exactly the X-1 wire shape`() = runTest {
+        installDeps()
+        dao.rows.add(docEntity(id = 1, contentHash = "h1", title = "Dune"))
+        dao.rows.add(docEntity(id = 2, contentHash = "h2", title = "Foundation"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(summaryBody(2)))
+
+        val result = buildWorker().doWork()
+
+        assertThat(result).isInstanceOf(ListenableWorker.Result.Success::class.java)
+        assertThat(server.requestCount).isEqualTo(1)
+
+        val req = server.takeRequest()
+        assertThat(req.path).isEqualTo("/library/v1/sync")
+        assertThat(req.method).isEqualTo("POST")
+        val body = req.body.readUtf8()
+        val parsed = Json.parseToJsonElement(body).jsonObject
+
+        // Root wrapper.
+        assertThat(parsed.keys).containsExactly("items")
+        val items = parsed["items"]!!.jsonArray
+        assertThat(items).hasSize(2)
+
+        // Every entry must carry exactly the X-1 wire shape: no
+        // `content_hash`, no nested `metadata`, no enum-internal fields.
+        // Pydantic `extra="forbid"` rejects unknown keys.
+        val expectedKeys = setOf(
+            "identity_hash",
+            "identity_hash_version",
+            "status",
+            "last_seen_at",
+            "metadata_id",
+            "title",
+            "authors",
+            "series_name",
+            "series_index",
+            "isbn",
+            "language",
+            "subjects",
+            "opds_href",
+        )
+        items.forEach { entry ->
+            val obj = entry.jsonObject
+            assertThat(obj.keys).isEqualTo(expectedKeys)
+            // The renamed-to-`identity_hash` contract; X-1 rejects `content_hash`.
+            assertThat(obj.containsKey("content_hash")).isFalse()
+            // No nested `metadata` block — server expects FLAT entries.
+            assertThat(obj.containsKey("metadata")).isFalse()
+            assertThat(obj["status"]!!.jsonPrimitive.contentOrNull).isEqualTo("present")
+            assertThat(obj["identity_hash_version"]!!.jsonPrimitive.intOrNull).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `wire payload contains identity_hash never content_hash even as a substring of the JSON`() = runTest {
+        installDeps()
+        dao.rows.add(docEntity(id = 1, contentHash = "abc"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(summaryBody(1)))
+
+        buildWorker().doWork()
+
+        val body = server.takeRequest().body.readUtf8()
+        // Defense in depth: the legacy server column name must never
+        // appear on this endpoint's wire — Pydantic rejects it.
+        assertThat(body).doesNotContain("content_hash")
+        assertThat(body).contains("\"identity_hash\":\"abc\"")
+    }
+
+    // -------------------- chunking --------------------
+
+    @Test
+    fun `chunking splits 1200 books into 500+500+200 POSTs`() = runTest {
+        installDeps()
+        val books = (1..1200).map { i -> docEntity(id = i.toLong(), contentHash = "h%04d".format(i)) }
+        dao.rows.addAll(books)
+        repeat(3) { idx ->
+            val size = if (idx < 2) 500 else 200
+            server.enqueue(MockResponse().setResponseCode(200).setBody(summaryBody(size)))
+        }
+
+        val result = buildWorker().doWork()
+
+        assertThat(result).isInstanceOf(ListenableWorker.Result.Success::class.java)
+        assertThat(server.requestCount).isEqualTo(3)
+        val sizes = (1..3).map {
+            val req = server.takeRequest()
+            val items = Json.parseToJsonElement(req.body.readUtf8()).jsonObject["items"]!!.jsonArray
+            items.size
+        }
+        assertThat(sizes).containsExactly(500, 500, 200).inOrder()
+    }
+
+    @Test
+    fun `last_seen_at is identical across every chunk in a single run`() = runTest {
+        installDeps()
+        val books = (1..600).map { i -> docEntity(id = i.toLong(), contentHash = "h%04d".format(i)) }
+        dao.rows.addAll(books)
+        repeat(2) { server.enqueue(MockResponse().setResponseCode(200).setBody(summaryBody(500))) }
+
+        buildWorker().doWork()
+
+        val ts1 = firstLastSeenAt(server.takeRequest())
+        val ts2 = firstLastSeenAt(server.takeRequest())
+        assertThat(ts1).isNotNull()
+        assertThat(ts1).isEqualTo(ts2)
+    }
+
+    private fun firstLastSeenAt(req: RecordedRequest): String? {
+        val items = Json.parseToJsonElement(req.body.readUtf8()).jsonObject["items"]!!.jsonArray
+        return items.firstOrNull()?.jsonObject?.get("last_seen_at")?.jsonPrimitive?.contentOrNull
+    }
+
+    // -------------------- failure semantics --------------------
+
+    @Test
+    fun `4xx drops the offending chunk and continues with the rest`() = runTest {
+        installDeps()
+        // 600 books → 2 chunks. First returns 422, second returns 200.
+        val books = (1..600).map { i -> docEntity(id = i.toLong(), contentHash = "h%04d".format(i)) }
+        dao.rows.addAll(books)
+        server.enqueue(MockResponse().setResponseCode(422).setBody("""{"detail":"bad"}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(summaryBody(100)))
+
+        val result = buildWorker().doWork()
+
+        // 4xx is "the server rejected this batch" — we drop it and move
+        // on. The overall run is still a Success because retrying
+        // forever on a server-rejected payload is wrong.
+        assertThat(result).isInstanceOf(ListenableWorker.Result.Success::class.java)
+        assertThat(server.requestCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `5xx requests a WorkManager retry without continuing to the next chunk`() = runTest {
+        installDeps()
+        val books = (1..600).map { i -> docEntity(id = i.toLong(), contentHash = "h%04d".format(i)) }
+        dao.rows.addAll(books)
+        server.enqueue(MockResponse().setResponseCode(500).setBody("server is on fire"))
+        // Second response intentionally NOT enqueued — worker must bail
+        // out after the 500 rather than continuing.
+
+        val result = buildWorker().doWork()
+
+        assertThat(result).isInstanceOf(ListenableWorker.Result.Retry::class.java)
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `401 fails the worker without retry`() = runTest {
+        installDeps()
+        dao.rows.add(docEntity(id = 1, contentHash = "h1"))
+        server.enqueue(MockResponse().setResponseCode(401).setBody("nope"))
+
+        val result = buildWorker().doWork()
+
+        assertThat(result).isInstanceOf(ListenableWorker.Result.Failure::class.java)
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `no account configured is a quick success no-op`() = runTest {
+        installDeps(hasAccount = false)
+        dao.rows.add(docEntity(id = 1, contentHash = "h1"))
+
+        val result = buildWorker().doWork()
+
+        assertThat(result).isInstanceOf(ListenableWorker.Result.Success::class.java)
+        assertThat(server.requestCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `empty library is a quick success with no network calls`() = runTest {
+        installDeps()
+
+        val result = buildWorker().doWork()
+
+        assertThat(result).isInstanceOf(ListenableWorker.Result.Success::class.java)
+        assertThat(server.requestCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `missing dependencies returns failure`() = runTest {
+        // Intentionally do NOT installDeps() — holder is null.
+        LibraryMirrorPushDependencies.holder = null
+
+        val result = buildWorker().doWork()
+
+        assertThat(result).isInstanceOf(ListenableWorker.Result.Failure::class.java)
+    }
+
+    // -------------------- entry mapping --------------------
+
+    @Test
+    fun `entries carry identity_hash_version from the DocumentEntity not always 1`() = runTest {
+        installDeps()
+        // Mixed versions: today identityHashVersion is always 1, but the
+        // field must round-trip. F-2's schema makes this user-data, so
+        // we lock the behaviour now.
+        dao.rows.add(docEntity(id = 1, contentHash = "h1", identityHashVersion = 1))
+        dao.rows.add(docEntity(id = 2, contentHash = "h2", identityHashVersion = 5))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(summaryBody(2)))
+
+        buildWorker().doWork()
+
+        val items = Json.parseToJsonElement(server.takeRequest().body.readUtf8())
+            .jsonObject["items"]!!.jsonArray
+        val byHash = items.associateBy { it.jsonObject["identity_hash"]!!.jsonPrimitive.content }
+        assertThat(byHash["h1"]!!.jsonObject["identity_hash_version"]!!.jsonPrimitive.int())
+            .isEqualTo(1)
+        assertThat(byHash["h2"]!!.jsonObject["identity_hash_version"]!!.jsonPrimitive.int())
+            .isEqualTo(5)
+    }
+
+    @Test
+    fun `author string is split into the authors list`() = runTest {
+        installDeps()
+        dao.rows.add(docEntity(id = 1, contentHash = "h1", author = "A & B"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(summaryBody(1)))
+
+        buildWorker().doWork()
+
+        val items = Json.parseToJsonElement(server.takeRequest().body.readUtf8())
+            .jsonObject["items"]!!.jsonArray
+        val authors = items[0].jsonObject["authors"]!!.jsonArray
+        assertThat(authors.map { it.jsonPrimitive.content }).containsExactly("A", "B").inOrder()
+    }
+}
+
+// kotlinx.serialization 1.7 doesn't expose JsonPrimitive.int directly without
+// the import we already pull in via `intOrNull`; alias for readability.
+private fun JsonPrimitive.int(): Int = intOrNull ?: error("expected int, got $content")
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+private fun docEntity(
+    id: Long,
+    contentHash: String,
+    title: String = "t",
+    author: String? = null,
+    identityHashVersion: Int = 1,
+): DocumentEntity = DocumentEntity(
+    id = id,
+    metadataId = null,
+    contentHash = contentHash,
+    title = title,
+    author = author,
+    downloadUrl = "https://example/$contentHash",
+    localPath = "/p/$contentHash",
+    coverPath = null,
+    downloadedAt = id,
+    seriesName = null,
+    seriesIndex = null,
+    librarySyncedAt = null,
+    identityHashVersion = identityHashVersion,
+)
+
+/**
+ * Minimal in-memory DocumentDao. Only the methods the worker uses are
+ * implemented; the rest throw so accidental future calls are loud.
+ */
+private class FakeDocumentDao : DocumentDao {
+    val rows: MutableList<DocumentEntity> = mutableListOf()
+
+    override fun observeAll(): Flow<List<DocumentEntity>> = flowOf(rows.toList())
+
+    // ---- everything else is unused in these tests ----
+
+    override suspend fun insert(doc: DocumentEntity): Long = throw nope("insert")
+    override suspend fun update(doc: DocumentEntity): Unit = throw nope("update")
+    override suspend fun findByMetadataId(id: String): DocumentEntity? = throw nope("findByMetadataId")
+    override suspend fun findByContentHash(hash: String): DocumentEntity? = throw nope("findByContentHash")
+    override suspend fun findByDownloadUrl(url: String): DocumentEntity? = throw nope("findByDownloadUrl")
+    override suspend fun findById(id: Long): DocumentEntity? = throw nope("findById")
+    override fun observeSeriesContinuationCandidates(
+        startedThreshold: Double,
+        maxItems: Int,
+    ): Flow<List<DocumentEntity>> = flowOf(emptyList())
+    override suspend fun deleteById(id: Long): Int = throw nope("deleteById")
+    override suspend fun deleteAll(): Unit = throw nope("deleteAll")
+    override suspend fun findUnsyncedToLibrary(): List<DocumentEntity> = throw nope("findUnsyncedToLibrary")
+    override suspend fun markLibrarySynced(id: Long, at: Long): Unit = throw nope("markLibrarySynced")
+
+    private fun nope(name: String) =
+        UnsupportedOperationException("FakeDocumentDao.$name not implemented for this test")
+}

--- a/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json
+++ b/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json
@@ -1,0 +1,393 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "40c4987051d2f31f8f5aeb107d62d857",
+    "entities": [
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `metadataId` TEXT, `contentHash` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `downloadUrl` TEXT NOT NULL, `localPath` TEXT NOT NULL, `coverPath` TEXT, `downloadedAt` INTEGER NOT NULL, `seriesName` TEXT, `seriesIndex` REAL, `librarySyncedAt` INTEGER, `identityHashVersion` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "librarySyncedAt",
+            "columnName": "librarySyncedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "identityHashVersion",
+            "columnName": "identityHashVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_documents_metadataId",
+            "unique": true,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_documents_contentHash",
+            "unique": true,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_documents_seriesName_seriesIndex",
+            "unique": false,
+            "columnNames": [
+              "seriesName",
+              "seriesIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_documents_seriesName_seriesIndex` ON `${TABLE_NAME}` (`seriesName`, `seriesIndex`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `documentId` INTEGER NOT NULL, `locator` TEXT NOT NULL, `percent` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `finishedAt` INTEGER, `abandonedAt` INTEGER, FOREIGN KEY(`documentId`) REFERENCES `documents`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locator",
+            "columnName": "locator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percent",
+            "columnName": "percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "abandonedAt",
+            "columnName": "abandonedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_documentId",
+            "unique": true,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_progress_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "documents",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `lastPulledAt` INTEGER NOT NULL, PRIMARY KEY(`tableName`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPulledAt",
+            "columnName": "lastPulledAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "book_insights",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identityKey` TEXT NOT NULL, `metadataId` TEXT, `contentHash` TEXT, `modelId` TEXT NOT NULL, `promptVersion` TEXT NOT NULL, `tone` TEXT NOT NULL, `language` TEXT NOT NULL, `payloadJson` TEXT NOT NULL, `sourcesJson` TEXT NOT NULL, `schemaVersion` INTEGER NOT NULL, `serverId` INTEGER NOT NULL, `generatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `identityHashVersion` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`identityKey`, `modelId`, `promptVersion`, `tone`, `language`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptVersion",
+            "columnName": "promptVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tone",
+            "columnName": "tone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedAt",
+            "columnName": "generatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHashVersion",
+            "columnName": "identityHashVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identityKey",
+            "modelId",
+            "promptVersion",
+            "tone",
+            "language"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_insights_syncedAt",
+            "unique": false,
+            "columnNames": [
+              "syncedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_syncedAt` ON `${TABLE_NAME}` (`syncedAt`)"
+          },
+          {
+            "name": "index_book_insights_metadataId",
+            "unique": false,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_book_insights_contentHash",
+            "unique": false,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_book_insights_cursor",
+            "unique": false,
+            "columnNames": [
+              "generatedAt",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_cursor` ON `${TABLE_NAME}` (`generatedAt`, `serverId`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '40c4987051d2f31f8f5aeb107d62d857')"
+    ]
+  }
+}

--- a/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local
 
+import io.theficos.ereader.core.model.CURRENT_IDENTITY_HASH_VERSION
 import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.core.model.DocumentIdentity
 import io.theficos.ereader.data.local.db.DocumentDao
@@ -80,6 +81,7 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt: Long,
         seriesName: String? = null,
         seriesIndex: Double? = null,
+        identityHashVersion: Int = CURRENT_IDENTITY_HASH_VERSION,
     ): Long = dao.insert(DocumentEntity(
         metadataId = identity.metadataId,
         contentHash = requireNotNull(identity.contentHash) {
@@ -93,11 +95,16 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt = downloadedAt,
         seriesName = seriesName?.takeIf { it.isNotBlank() },
         seriesIndex = seriesIndex,
+        identityHashVersion = identityHashVersion,
     ))
 
     private fun DocumentEntity.toDomain(): Document = Document(
         id = id,
-        identity = DocumentIdentity(metadataId = metadataId, contentHash = contentHash),
+        identity = DocumentIdentity(
+            metadataId = metadataId,
+            contentHash = contentHash,
+            identityHashVersion = identityHashVersion,
+        ),
         title = title,
         author = author,
         downloadUrl = downloadUrl,
@@ -106,6 +113,7 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt = downloadedAt,
         seriesName = seriesName,
         seriesIndex = seriesIndex,
+        identityHashVersion = identityHashVersion,
     )
 
     companion object {

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -37,4 +38,14 @@ data class DocumentEntity(
      * presence marker; we never compare it against server timestamps.
      */
     val librarySyncedAt: Long? = null,
+    /**
+     * Phase-0 / F-2: schema version of the client-side hash function that
+     * produced [contentHash]. `INTEGER NOT NULL DEFAULT 1` on disk so the
+     * 8→9 migration can backfill pre-existing rows in a single ALTER TABLE.
+     * Today every row is v1; the field exists so a future hash-function
+     * change can be detected via
+     * `io.theficos.ereader.core.model.isStaleHashVersion`.
+     */
+    @ColumnInfo(defaultValue = "1")
+    val identityHashVersion: Int = 1,
 )

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
@@ -14,7 +14,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         SyncStateEntity::class,
         InsightEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
 )
 abstract class EReaderDatabase : RoomDatabase() {
@@ -143,6 +143,33 @@ abstract class EReaderDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Phase-0 / F-2: stamps every identity-hash-carrying row with the
+         * schema version of the hash function that produced it. Backfills
+         * existing rows to `1` (the current MD5-sampled hash in
+         * `core/identity/ContentHash.kt`). Paired with
+         * `core.model.CURRENT_IDENTITY_HASH_VERSION` and
+         * `core.model.isStaleHashVersion`. Server-side change is handled by
+         * the sibling F-1 task.
+         *
+         * Two ALTER TABLEs: `documents` (the primary owner — also drives
+         * re-upload via `LibraryUploader` when stale) and `book_insights`
+         * (metadata only; this DAO cannot re-key its rows, so a future v2
+         * bump will be handled by re-syncing the cache from the server).
+         */
+        internal val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE documents ADD COLUMN identityHashVersion " +
+                        "INTEGER NOT NULL DEFAULT 1"
+                )
+                db.execSQL(
+                    "ALTER TABLE book_insights ADD COLUMN identityHashVersion " +
+                        "INTEGER NOT NULL DEFAULT 1"
+                )
+            }
+        }
+
         fun build(context: Context): EReaderDatabase =
             Room.databaseBuilder(context, EReaderDatabase::class.java, "ereader.db")
                 .addMigrations(
@@ -153,6 +180,7 @@ abstract class EReaderDatabase : RoomDatabase() {
                     MIGRATION_5_6,
                     MIGRATION_6_7,
                     MIGRATION_7_8,
+                    MIGRATION_8_9,
                 )
                 .build()
     }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/InsightEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/InsightEntity.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 
@@ -41,4 +42,17 @@ data class InsightEntity(
     val generatedAt: Long,
     /** When this row was upserted locally; wall clock millis. */
     val syncedAt: Long,
+    /**
+     * Phase-0 / F-2: schema version of the client-side hash function that
+     * produced the [contentHash] / [identityKey] this row is filed under.
+     * `INTEGER NOT NULL DEFAULT 1` on disk.
+     *
+     * Stored as metadata only — this DAO cannot re-key existing rows when
+     * the hash function bumps because the `identityKey` is part of the
+     * primary key and the source EPUB is not addressable from here. A
+     * future hash-function change will be handled by re-syncing the cache
+     * (server-driven) rather than by mutating this column in place.
+     */
+    @ColumnInfo(defaultValue = "1")
+    val identityHashVersion: Int = 1,
 )

--- a/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
@@ -258,5 +258,116 @@ class MigrationTest {
         }
     }
 
+    @Test fun `migrate 8 to 9 stamps identityHashVersion=1 on documents and book_insights`() {
+        // v8 fixture: seed one row in `documents` and one in `book_insights`
+        // (both tables exist at v8). identityHashVersion does NOT exist yet.
+        helper.createDatabase(DB, 8).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (41, 'm41', 'h41', 'Pre-F2 title', NULL, 'u', 'p', NULL, 51, NULL, NULL, NULL)"
+            )
+            db.execSQL(
+                "INSERT INTO book_insights (identityKey, metadataId, contentHash, modelId, " +
+                    "promptVersion, tone, language, payloadJson, sourcesJson, schemaVersion, " +
+                    "serverId, generatedAt, syncedAt) VALUES " +
+                    "('m41', 'm41', 'h41', 'llama3.1', '4', 'neutral', 'auto', '{}', '[]', 4, " +
+                    "100, 1000, 1100)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(DB, 9, true, EReaderDatabase.MIGRATION_8_9).use { db ->
+            // Both tables gained the column.
+            for (table in listOf("documents", "book_insights")) {
+                db.query("PRAGMA table_info('$table')").use { c ->
+                    val cols = mutableSetOf<String>()
+                    while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                    assertThat(cols).contains("identityHashVersion")
+                }
+            }
+            // Existing rows backfill to 1 via the DEFAULT clause.
+            db.query("SELECT identityHashVersion FROM documents WHERE id=41").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            db.query(
+                "SELECT identityHashVersion FROM book_insights " +
+                    "WHERE identityKey='m41' AND modelId='llama3.1' AND promptVersion='4'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            // New rows round-trip a non-default value.
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt, " +
+                    "identityHashVersion) " +
+                    "VALUES (42, 'm42', 'h42', 'Post-F2 title', NULL, 'u', 'p', NULL, 52, NULL, " +
+                    "NULL, NULL, 2)"
+            )
+            db.query("SELECT identityHashVersion FROM documents WHERE id=42").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(2)
+            }
+            db.execSQL(
+                "INSERT INTO book_insights (identityKey, metadataId, contentHash, modelId, " +
+                    "promptVersion, tone, language, payloadJson, sourcesJson, schemaVersion, " +
+                    "serverId, generatedAt, syncedAt, identityHashVersion) VALUES " +
+                    "('m42', 'm42', 'h42', 'llama3.1', '4', 'neutral', 'auto', '{}', '[]', 4, " +
+                    "200, 2000, 2100, 3)"
+            )
+            db.query(
+                "SELECT identityHashVersion FROM book_insights " +
+                    "WHERE identityKey='m42' AND modelId='llama3.1' AND promptVersion='4'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(3)
+            }
+        }
+    }
+
+    @Test fun `migrate 6 to 9 chains all additive migrations`() {
+        // Long-tail upgrade path: a v6 install (pre-PR-η) jumps straight to
+        // v9 (post-F-2). Every additive migration in between must survive.
+        helper.createDatabase(DB, 6).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (51, 'm51', 'h51', 'Pre-F2 chain title', NULL, 'u', 'p', NULL, 61, NULL, NULL, NULL)"
+            )
+            db.execSQL(
+                "INSERT INTO progress (id, documentId, locator, percent, updatedAt, " +
+                    "localUpdatedAt, syncedAt, finishedAt) " +
+                    "VALUES (51, 51, 'loc', 0.8, 100, 100, 0, NULL)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(
+            DB,
+            9,
+            true,
+            EReaderDatabase.MIGRATION_6_7,
+            EReaderDatabase.MIGRATION_7_8,
+            EReaderDatabase.MIGRATION_8_9,
+        ).use { db ->
+            // F-2 column landed on both tables.
+            db.query("SELECT identityHashVersion FROM documents WHERE id=51").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            db.query("PRAGMA table_info('book_insights')").use { c ->
+                val cols = mutableSetOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("identityHashVersion")
+            }
+            // Earlier additive migrations still present.
+            db.query("PRAGMA table_info('progress')").use { c ->
+                val cols = mutableSetOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("abandonedAt")
+            }
+        }
+    }
+
     private companion object { const val DB = "migration-test.db" }
 }

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
@@ -7,6 +7,11 @@ import kotlinx.serialization.Serializable
 data class DocumentIdDto(
     @SerialName("metadata_id") val metadataId: String? = null,
     @SerialName("content_hash") val contentHash: String,
+    // Phase-0 / F-2: schema version of the client-side hash function that
+    // produced `contentHash`. Defaults to `1` so an older server that does
+    // not yet emit the field (pre-F-1) decodes safely — every existing
+    // hash on the wire is v1.
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
 
 @Serializable

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
@@ -31,6 +31,9 @@ class SyncOrchestrator(
                         contentHash = requireNotNull(doc.identity.contentHash) {
                             "downloaded document must have a contentHash"
                         },
+                        // Phase-0 / F-2: stamp every outbound progress push
+                        // with the hash version of the row it references.
+                        identityHashVersion = doc.identityHashVersion,
                     ),
                     locator = progress.locator,
                     percent = progress.percent,
@@ -65,7 +68,15 @@ class SyncOrchestrator(
     }
 
     private suspend fun applyPulled(item: ProgressItemDto) {
-        val identity = DocumentIdentity(metadataId = item.document.metadataId, contentHash = item.document.contentHash)
+        // Phase-0 / F-2: forward the server-reported identity_hash_version
+        // into the DocumentIdentity used for local lookup. We don't act on
+        // it here (progress doesn't carry a hash on disk; doc rows are
+        // looked up by metadataId/contentHash) — but the field travels.
+        val identity = DocumentIdentity(
+            metadataId = item.document.metadataId,
+            contentHash = item.document.contentHash,
+            identityHashVersion = item.document.identityHashVersion,
+        )
         val doc = documentRepo.findByIdentity(identity) ?: return
         val incomingUpdatedAt = Instant.parse(item.clientUpdatedAt).toEpochMilli()
         val incomingFinishedAt = item.finishedAt?.let { Instant.parse(it).toEpochMilli() }

--- a/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
+++ b/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
@@ -113,4 +113,23 @@ class ProgressDtosTest {
         assertThat(r.items.first().abandonedAt).isEqualTo("2026-05-20T12:00:00+00:00")
         assertThat(r.items.first().finishedAt).isNull()
     }
+
+    // ---------- Phase-0 / F-2: identity_hash_version ----------
+
+    @Test fun `DocumentIdDto carries identity_hash_version on the wire`() {
+        val encJson = Json { encodeDefaults = true }
+        val dto = DocumentIdDto(metadataId = "m1", contentHash = "h1", identityHashVersion = 2)
+        val encoded = encJson.encodeToString(DocumentIdDto.serializer(), dto)
+        assertThat(encoded).contains("\"identity_hash_version\":2")
+        val decoded = encJson.decodeFromString(DocumentIdDto.serializer(), encoded)
+        assertThat(decoded.identityHashVersion).isEqualTo(2)
+    }
+
+    @Test fun `DocumentIdDto missing identity_hash_version defaults to 1`() {
+        // Pre-F-1 server payload — the field hasn't landed server-side yet
+        // (or the deploy lags). Every hash on the wire today is v1.
+        val raw = """{"metadata_id":"m1","content_hash":"h1"}"""
+        val decoded = json.decodeFromString(DocumentIdDto.serializer(), raw)
+        assertThat(decoded.identityHashVersion).isEqualTo(1)
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
+work-testing = { module = "androidx.work:work-testing", version.ref = "work" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }
 readium-shared = { module = "org.readium.kotlin-toolkit:readium-shared", version.ref = "readium" }
 readium-streamer = { module = "org.readium.kotlin-toolkit:readium-streamer", version.ref = "readium" }


### PR DESCRIPTION
## Summary

Implements **Phase 0, task A-4** of the monetization plan: a Kotlin/`CoroutineWorker`
job that POSTs the full Android library mirror to `POST /library/v1/sync` on
**app start**, **after library changes** (sideload hook wiring deferred — see
TODO below), and via a **daily `PeriodicWorkRequest`** with `NetworkType.CONNECTED`.

This PR is **stacked on PR #48 (F-2)** and consumes the wire contract introduced
by **PR #54 (X-1)** — specifically the renamed `identity_hash` field (the legacy
`content_hash` name is rejected by the server's `extra="forbid"` Pydantic model).

The existing per-item `LibraryUploader` PUT path is unchanged. A-4 is the durable
daily mirror; the old PUT remains the fast path for "this download just landed".

## Wire contract

Each entry is **flat** (mirrors X-1's `LibrarySyncEntry`):

- `identity_hash` (required)
- `identity_hash_version` (defaults to `1`)
- `status` (`"present"` for now; `"deleted"` reserved for future tombstone flows)
- `last_seen_at` (ISO-8601 UTC, one value per worker run)
- `metadata_id`, `title`, `authors`, `series_name`, `series_index`, `isbn`,
  `language`, `subjects`, `opds_href`

A serialization contract test asserts the key set is **exactly** the X-1
shape — no `content_hash`, no nested `metadata` block.

## Trigger model

| Trigger | Method | Policy |
|---|---|---|
| App start | `enqueueOneTime(expedited = true)` | `KEEP`, `RUN_AS_NON_EXPEDITED_WORK_REQUEST` fallback |
| Library change (sideload import) | `enqueueAfterLibraryChange` | `KEEP`, non-expedited |
| Daily heartbeat | `enqueuePeriodic` | `KEEP`, daily, network-connected |

## Failure semantics

| Response | Worker outcome | Rationale |
|---|---|---|
| 2xx | continue | server accepted / no-op replay |
| **401** | `Result.failure()` | re-auth needed; the next app-start re-enqueue picks up new credentials |
| **4xx (not 401/429)** | log + **drop this chunk**, continue with remaining chunks | server explicitly rejected this payload; retrying forever is wrong, but one poison chunk shouldn't block the rest |
| **429 / 5xx / IOException** | `Result.retry()` | transient; WorkManager handles exponential backoff |
| no account configured | `Result.success()` no-op | don't spin against a missing login |
| empty library | `Result.success()` no-op | nothing to push |

## Chunking & idempotency

- Server-side `library_sync_max_items = 500` → client chunks at 500.
- Entries sorted by `identity_hash` so replays send **identical chunk boundaries**;
  the server's diff-skip (`_row_matches_payload`) turns replays into a counter bump.
- `last_seen_at` computed once per run and reused across chunks so logs and
  server-side debugging see one cursor per run.

## Files changed

- `gradle/libs.versions.toml` — add `work-testing` alias
- `data/library/build.gradle.kts` — depend on `work-runtime-ktx`, test on `work-testing` + `androidx-test-core`
- `data/library/src/main/java/io/theficos/ereader/data/library/LibrarySyncDtos.kt` — wire DTOs (FLAT, per X-1)
- `data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt` — `PATH_SYNC` constant
- `data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt` — `syncBatch(...)` method + strict `syncJson` (`encodeDefaults=true`)
- `data/library/src/main/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorker.kt` — the worker + `LibraryMirrorPushDependencies` + `CredentialsProvider`
- `data/library/src/main/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushScheduler.kt` — `enqueueOneTime` / `enqueuePeriodic` / `enqueueAfterLibraryChange`
- `data/library/src/test/.../LibraryMirrorPushWorkerTest.kt` — 12 tests
- `data/library/src/test/.../LibraryMirrorPushSchedulerTest.kt` — 4 tests
- `app/src/main/java/io/theficos/ereader/di/AppContainer.kt` — wire `LibraryMirrorPushDependencies.holder`
- `app/src/main/java/io/theficos/ereader/EReaderApp.kt` — `enqueueOneTime(expedited=true)` + `enqueuePeriodic` on app start

## Verification

```
$ scripts/dgradle :data:library:testDebugUnitTest
BUILD SUCCESSFUL   (37 tests passed)

$ scripts/dgradle :app:testDebugUnitTest
BUILD SUCCESSFUL

$ scripts/dgradle :app:assembleDebug lint
BUILD SUCCESSFUL   (352 actionable tasks)
```

The lint pass executed `:data:library:lint`, `:app:lint`, and every other
module's `lint` — no new errors / warnings introduced.

## TODO for reconciliation

**A-3 sideload hook wiring (deferred — A-3 is on a parallel branch and we cannot cross-import).**

Once A-3 merges, the `SideloadImporter.onSuccessfulImport` callback should
invoke:

```kotlin
LibraryMirrorPushScheduler.enqueueAfterLibraryChange(context)
```

This is the third trigger called out in the task spec; the scheduler entry
point is already in place and exercised by `LibraryMirrorPushSchedulerTest`
(`enqueueAfterLibraryChange shares the one-time unique name with enqueueOneTime`).

## Out of scope / future work

- **Tombstones (`status="deleted"`)** — Phase 0 has no local-deletion flow in
  the app, so every entry today is `present`. A future bulk-delete UX will
  need to track tombstones in Room before the worker can emit them.
- **Server fields we don't yet capture** — `isbn`, `language`, `subjects` are
  sent as `null`/`[]` because `DocumentEntity` doesn't store them. A future
  PR that parses these out of the OPF can drop them in without wire changes.
- **Cloud / Bearer auth** — Phase 0 is BASIC only (via the shared `OpdsHttpClient`
  OkHttp). The Bearer-on-`/library/v1/sync` path lands when A-1 + S-1 merge.

## Test plan

- [x] `scripts/dgradle :data:library:testDebugUnitTest` — passes (37 tests)
- [x] `scripts/dgradle :app:testDebugUnitTest` — passes
- [x] `scripts/dgradle :app:assembleDebug lint` — passes, no new lint issues
- [ ] Manual smoke on a real device once F-2 lands and this PR is rebased onto `main`
- [ ] Reconciliation step: wire `enqueueAfterLibraryChange` into `SideloadImporter` post-A-3 merge