### PR TITLE
feat(server): deprecate ai_metadata_server_lookup_enabled fallback (Phase 0, task S-4)

### DIFF
--- a/docs/sync-api.md
+++ b/docs/sync-api.md
@@ -515,6 +515,20 @@ header if the user's daily budget is exhausted. Body:
 }
 ```
 
+**Push-model contract (Phase 0, 2026-05-22).** `bundle` is **required** on
+the request body — the server is the consumer, not the source, of book
+metadata. Omitted `bundle` is rejected with `400 metadata_required`.
+
+The operator-controlled
+`QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED` flag (default `false`)
+restores the legacy server-side fallback that reconstructs the bundle
+from the caller's `library_items` row. **The flag is deprecated since
+this release and will be removed 2 minor releases later.** When enabled,
+the server emits a `DeprecationWarning` + `logging.warning` at boot. Plan
+client cutover to the push model within that window. See `server/README.md`
+("Push-model API: deprecated server-side metadata fallback") for the
+operator-side detail.
+
 **Identity fields (PR2 update, 2026-05-16).** `identity.content_hash` is now
 **optional** so the catalog-preview flow can request insights before the EPUB
 body is downloaded. The full set of accepted hints is:
@@ -648,6 +662,11 @@ Body adds a required `reason`:
 ```
 
 The reason is included in the prompt sent to the model so it knows what to fix.
+
+`bundle` follows the same push-model contract as `/insights/lookup`: required
+on the request body, with the deprecated
+`QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED` fallback as the only
+escape hatch and the same 2-minor-release removal window.
 
 ### `POST /ai/v1/insights/get`
 

--- a/server/README.md
+++ b/server/README.md
@@ -264,6 +264,7 @@ the env-compat helper. The DB-name non-rename is permanent.
 | `QUIRE_SERVER_AI_PROMOTE_DAILY_LIMIT`  | `100`                                  | Per-user `/insights/promote` ceiling per UTC day; process-local counter, 0 disables. (PR-ζ) |
 | `QUIRE_SERVER_AI_PROFILE_REFRESH_DAILY_LIMIT` | `3`                              | Reader Profile refresh cap per user per UTC day. (PR-β)                 |
 | `QUIRE_SERVER_AI_PROFILE_TIMEOUT_S`    | `90`                                   | Reader Profile orchestrator timeout, in seconds. (PR-β)                 |
+| `QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED` | `false`                          | **DEPRECATED (Phase 0, 2026-05-22).** Legacy fallback: when `true`, `/ai/v1/insights/{lookup,regenerate}` reconstruct a `MetadataBundle` from the caller's `library_items` row when the client omits the `bundle` block. The push-model contract has the client send `bundle` on every request; this flag is the migration escape hatch. Boots emit a `DeprecationWarning` + `logging.warning` when enabled. Slated for removal 2 minor releases after the Phase 0 release. |
 | `QUIRE_SERVER_AI_AUTH_MODE`            | `basic`                                | `basic` (default, wraps calibre-web verifier) or `token` (HMAC-SHA256). |
 | `QUIRE_SERVER_AI_TOKEN_SECRETS`        | unset                                  | Token mode: JSON `{kid: secret}`. Each secret ≥32 bytes; multiple kids enable rotation. |
 | `QUIRE_SERVER_AI_TOKEN_ISSUER`         | unset                                  | Token mode: required; validated against `iss`.                          |
@@ -274,6 +275,26 @@ the env-compat helper. The DB-name non-rename is permanent.
 | `QUIRE_SERVER_AUTH_CACHE_NEGATIVE_TTL_S` | `10`                                 | Cached `401` from the auth probe.                                       |
 | `QUIRE_SERVER_AUTH_CACHE_MAX_ENTRIES`  | `1024`                                 | Upper bound on the auth-probe LRU cache.                                |
 | `QUIRE_SERVER_AI_PROMPT_VERSION`       | `""` (in-code default)                 | Advanced / incident-response only. Pins the AI prompt version for cache-key compat during a model regression. The legacy value `"1"` is treated as "unset" (falls back to the in-code constant); see PR-ε for runtime resolution. |
+
+#### Push-model API: deprecated server-side metadata fallback (Phase 0, 2026-05-22)
+
+`POST /ai/v1/insights/{lookup,regenerate}` now require a `bundle`
+(`MetadataBundle`) block in the request body — clients are the sole source
+of book metadata. Requests that omit `bundle` are rejected with `400
+metadata_required`.
+
+For one migration window, `QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED=true`
+restores the legacy behavior: when `bundle` is absent, the server
+reconstructs a `MetadataBundle` from the caller's `library_items` row keyed
+by identity. The flag is **off by default**, **deprecated since this
+release**, and **will be removed 2 minor releases later**. Boots with the
+flag enabled emit a `DeprecationWarning` and a `logging.warning` so the
+deprecation is visible to both Python tooling and operators reading
+container logs. Plan your client cutover within the window.
+
+The push-model contract (request shape, identity-hint hierarchy, alias
+resolution) is documented in `docs/sync-api.md` under `POST
+/ai/v1/insights/lookup` and `POST /ai/v1/insights/regenerate`.
 
 #### AI auth mode (PR-B, 2026-05-16)
 

--- a/server/migrations/versions/ai_007_identity_hash_version.py
+++ b/server/migrations/versions/ai_007_identity_hash_version.py
@@ -1,0 +1,69 @@
+"""ai_007_identity_hash_version: add `identity_hash_version` to book_insights.
+
+Seventh migration on the `ai` branch. Chains off `ai_006`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function breaks sync, caches, recs, export, and
+deletion across millions of rows. Trivial now, expensive to retrofit.
+
+This migration adds `identity_hash_version` to `book_insights`, the
+SHARED-CACHE table on the `ai` branch. Companion migration `progress_003`
+adds the same column to `documents` and `library_items`.
+
+Cache-key impact: NONE. `identity_hash_version` is intentionally NOT added
+to any of the unique/cache-key constraints on `book_insights`. The
+architect-reviewed design treats it as row-freshness metadata only: a
+higher-version client hitting an existing cache row upgrades the persisted
+value via `max(existing, incoming)` in the orchestrator. Partitioning the
+cache by version would fragment the cross-tenant cache-hit property
+(see the cache-integrity comment above `BookInsight` in
+`quire_server/db/models.py`) without paying for itself in Phase 0.
+
+Schema additions:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. Pre-existing rows
+  backfill to `1` atomically via the column-level default.
+- `CHECK (identity_hash_version >= 1)`.
+
+Revision ID: ai_007
+Revises: ai_006
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_007"
+down_revision = "ai_006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "book_insights",
+        sa.Column(
+            "identity_hash_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+    op.create_check_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        "identity_hash_version >= 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        type_="check",
+    )
+    op.drop_column("book_insights", "identity_hash_version")

--- a/server/migrations/versions/progress_003_identity_hash_version.py
+++ b/server/migrations/versions/progress_003_identity_hash_version.py
@@ -1,0 +1,73 @@
+"""progress_003_identity_hash_version: add `identity_hash_version` to documents + library_items.
+
+Third migration on the `progress` branch. Chains off `progress_002`.
+`branch_labels = None` because the label is carried by `progress_001`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function (edition merging, normalization fixes,
+etc.) breaks sync, caches, recs, export, and deletion across millions of
+rows. Trivial to add now, very expensive to retrofit.
+
+This migration covers the `progress`-branch tables that carry an identity
+hash directly: `documents` and `library_items`. The companion migration
+`ai_007` adds the same column to `book_insights` on the `ai` branch.
+`progress.progress` deliberately has no own version column: identity travels
+via the parent `Document`, so `Progress.document.identity_hash_version` is
+the answer for any progress row.
+
+Schema additions per table:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. All pre-existing rows
+  backfill to `1` via the column-level default (atomic in Postgres for the
+  ADD COLUMN ... DEFAULT path; no separate UPDATE pass needed).
+- `CHECK (identity_hash_version >= 1)`. Prevents accidental zero-or-negative
+  versions from sneaking in through a future buggy writer.
+
+Downgrade-safety: dropping the column is reversible; the data loss is
+inherent and downgrade callers accept it. No indexes are added — the column
+is row-metadata, not a query predicate.
+
+Revision ID: progress_003
+Revises: progress_002
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "progress_003"
+down_revision = "progress_002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.add_column(
+            table,
+            sa.Column(
+                "identity_hash_version",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("1"),
+            ),
+        )
+        op.create_check_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            "identity_hash_version >= 1",
+        )
+
+
+def downgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.drop_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            type_="check",
+        )
+        op.drop_column(table, "identity_hash_version")

--- a/server/quire_server/api/ai.py
+++ b/server/quire_server/api/ai.py
@@ -411,6 +411,9 @@ async def sync_insights(
             BookInsight.id.label("ins_id"),
             BookInsight.metadata_id.label("ins_metadata_id"),
             BookInsight.content_hash.label("ins_content_hash"),
+            # Phase 0, task F-1: surface persisted identity-hash version
+            # to the client via the sync envelope.
+            BookInsight.identity_hash_version.label("ins_identity_hash_version"),
             BookInsight.model_id.label("ins_model_id"),
             BookInsight.prompt_version.label("ins_prompt_version"),
             BookInsight.tone.label("ins_tone"),
@@ -487,6 +490,7 @@ async def sync_insights(
             identity=DocumentIdentity(
                 metadata_id=r.ins_metadata_id,
                 content_hash=r.ins_content_hash,
+                identity_hash_version=r.ins_identity_hash_version,
             ),
             payload=BookInsightPayload.model_validate(r.ins_payload),
             sources=[Citation.model_validate(c) for c in (r.ins_sources or [])],

--- a/server/quire_server/api/ai.py
+++ b/server/quire_server/api/ai.py
@@ -185,10 +185,11 @@ async def _resolve_bundle(
     * Client-supplied ``request_bundle`` wins. The server uses it verbatim.
     * If absent AND ``ai_metadata_server_lookup_enabled`` is True, the
       server falls back to reconstructing a bundle from the caller's
-      local ``library_items`` row (deprecated path; kept only for the
-      OSS push-model migration window). Lookup is user-scoped and
-      alive-only; ``metadata_id`` wins over ``content_hash`` when both
-      could match.
+      local ``library_items`` row. **DEPRECATED since the Phase 0 release
+      (2026-05-22); slated for removal in 2 minor releases (task S-4).**
+      Kept only for the OSS push-model migration window. Lookup is
+      user-scoped and alive-only; ``metadata_id`` wins over
+      ``content_hash`` when both could match.
     * If absent AND the flag is False, the server returns 400
       ``metadata_required`` — clients MUST send their own metadata.
 

--- a/server/quire_server/api/ai.py
+++ b/server/quire_server/api/ai.py
@@ -37,6 +37,7 @@ from quire_server.api.ai_schemas import (
     InsightSyncCursor,
     InsightSyncItem,
     InsightSyncResponse,
+    MetadataBundle,
     PreferencesBody,
     PreferencesResponse,
     QuotaResponse,
@@ -102,6 +103,150 @@ def _style_from_pref(pref: UserAIPreference) -> AiStyle:
         return AiStyle.model_validate(filtered)
     except Exception:
         return AiStyle()
+
+
+def _truncate(value: str | None, *, limit: int) -> str | None:
+    """Defensive cap when reconstructing a bundle from a `library_items` row.
+
+    Bundle field validators raise 422 on over-cap values; that's the right
+    behavior for client-supplied input but a 422 would be hostile on the
+    deprecated server-side fallback path (the row was accepted earlier by
+    /library/v1/items, which has its own caps). Truncate instead.
+    """
+    if value is None:
+        return None
+    return value if len(value) <= limit else value[:limit]
+
+
+def _bundle_from_library_item(row: LibraryItem) -> MetadataBundle:
+    """Reconstruct a ``MetadataBundle`` from a persisted ``library_items`` row.
+
+    Phase 0, task S-3: backs the deprecated
+    ``ai_metadata_server_lookup_enabled`` fallback. ``LibraryItem`` does
+    NOT carry ``description``, ``publisher``, or ``publish_date``; those
+    are left ``None``. ``authors`` (list) is joined into the bundle's
+    scalar ``author`` field. ``series_index`` is a ``Decimal`` and only
+    propagates into ``series_position`` when it represents a small
+    non-negative integer — fractional positions (e.g. ``1.5``) are
+    dropped to ``None`` because the bundle field is ``int | None`` and
+    silently flooring would distort the prompt.
+    """
+    author: str | None = None
+    if row.authors:
+        joined = ", ".join(a for a in row.authors if isinstance(a, str) and a)
+        author = joined or None
+
+    series_position: int | None = None
+    if row.series_index is not None:
+        try:
+            # ``Decimal == int(Decimal)`` only when there's no fractional part.
+            as_int = int(row.series_index)
+            if as_int == row.series_index and 0 <= as_int <= 10_000:
+                series_position = as_int
+        except (TypeError, ValueError):
+            series_position = None
+
+    # Defensive: cap fields before handing them to the validator so a
+    # legacy library_items row (whose caps may be looser than the
+    # bundle's) doesn't 422 on the fallback path.
+    subjects: list[str] = []
+    for s in row.subjects or []:
+        if not isinstance(s, str) or not s:
+            continue
+        subjects.append(s[:80])
+        if len(subjects) >= 64:
+            break
+
+    return MetadataBundle(
+        title=_truncate(row.title, limit=512) or row.title[:512],
+        author=_truncate(author, limit=512),
+        language=_truncate(row.language, limit=32),
+        isbn=_truncate(row.isbn, limit=64),
+        publisher=None,
+        publish_date=None,
+        subjects=subjects,
+        description=None,
+        series_name=_truncate(row.series_name, limit=256),
+        series_position=series_position,
+    )
+
+
+async def _resolve_bundle(
+    session: AsyncSession,
+    *,
+    principal: AiPrincipal,
+    identity: DocumentIdentity,
+    request_bundle: MetadataBundle | None,
+) -> MetadataBundle:
+    """Return the ``MetadataBundle`` to drive an insight generation.
+
+    Phase 0, task S-3 — push-model contract:
+
+    * Client-supplied ``request_bundle`` wins. The server uses it verbatim.
+    * If absent AND ``ai_metadata_server_lookup_enabled`` is True, the
+      server falls back to reconstructing a bundle from the caller's
+      local ``library_items`` row (deprecated path; kept only for the
+      OSS push-model migration window). Lookup is user-scoped and
+      alive-only; ``metadata_id`` wins over ``content_hash`` when both
+      could match.
+    * If absent AND the flag is False, the server returns 400
+      ``metadata_required`` — clients MUST send their own metadata.
+
+    NOTE on cache invariants: the bundle does NOT participate in the
+    ``BookInsight`` cache key today. Divergent metadata for the same
+    canonical identity therefore shares a cache row (first-writer-wins).
+    A future task will introduce bundle fingerprinting to harden this
+    contract; see the spec section "Push-model API" in
+    ``docs/superpowers/specs/2026-05-22-quire-monetization-design.md``.
+    """
+    if request_bundle is not None:
+        return request_bundle
+
+    settings = get_settings()
+    if not settings.ai_metadata_server_lookup_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="metadata_required",
+        )
+
+    # Deterministic selection: prefer metadata_id, fall back to
+    # content_hash, scope by user + alive. ``limit(1)`` + a stable
+    # ``order_by(pk)`` so we never raise ``MultipleResultsFound`` even if
+    # two LibraryItem rows somehow share a canonical (defensive — the
+    # /library/v1/items partial unique index forbids it for alive rows).
+    row: LibraryItem | None = None
+    if identity.metadata_id:
+        row = (
+            await session.execute(
+                select(LibraryItem)
+                .where(
+                    LibraryItem.user_id == principal.subject,
+                    LibraryItem.deleted_at.is_(None),
+                    LibraryItem.metadata_id == identity.metadata_id,
+                )
+                .order_by(LibraryItem.pk.asc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+    if row is None and identity.content_hash:
+        row = (
+            await session.execute(
+                select(LibraryItem)
+                .where(
+                    LibraryItem.user_id == principal.subject,
+                    LibraryItem.deleted_at.is_(None),
+                    LibraryItem.content_hash == identity.content_hash,
+                )
+                .order_by(LibraryItem.pk.asc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="metadata_required",
+        )
+    return _bundle_from_library_item(row)
 
 
 def _quota_http_exception(exc: QuotaExceeded) -> HTTPException:
@@ -203,11 +348,17 @@ async def lookup_insight(
     if orch is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="ai_disabled")
     pref = await _require_opt_in(session, principal.subject)
+    # Phase 0, task S-3: resolve the metadata bundle BEFORE delegating to the
+    # orchestrator. Returning 400 here means we never reserve quota / acquire
+    # a generation lock when the request is unusable.
+    bundle = await _resolve_bundle(
+        session, principal=principal, identity=body.identity, request_bundle=body.bundle
+    )
     try:
         return await orch.generate(
             session,
             body.identity,
-            body.bundle,
+            bundle,
             user_id=principal.subject,
             style=_style_from_pref(pref),
             tenant_id=principal.tenant_id,
@@ -235,11 +386,17 @@ async def regenerate_insight(
     if orch is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, detail="ai_disabled")
     pref = await _require_opt_in(session, principal.subject)
+    # Phase 0, task S-3: resolve the metadata bundle BEFORE delegating to the
+    # orchestrator. Returning 400 here means we never supersede the live row
+    # or reserve regen quota when the request is unusable.
+    bundle = await _resolve_bundle(
+        session, principal=principal, identity=body.identity, request_bundle=body.bundle
+    )
     try:
         return await orch.regenerate(
             session,
             body.identity,
-            body.bundle,
+            bundle,
             user_id=principal.subject,
             reason=body.reason,
             style=_style_from_pref(pref),

--- a/server/quire_server/api/ai_schemas.py
+++ b/server/quire_server/api/ai_schemas.py
@@ -221,6 +221,11 @@ class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str | None = None
 
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1` keeps
+    # pre-versioning clients compatible; the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
+
     # Alias hints (PR2). All optional. The resolver maps them to a
     # canonical via insight_identity_aliases when present.
     opds_href: str | None = None
@@ -373,6 +378,12 @@ class BookInsightResponse(BaseModel):
     model_id: str
     prompt_version: str
     generated_at: str  # ISO-8601
+    # Phase 0, task F-1: identity-hash algorithm version of the persisted
+    # row this response represents. Clients use this to decide whether to
+    # recompute their local hash on the next sync (when their computed
+    # version > N). Defaults to `1` for older serialized rows that
+    # pre-date the column.
+    identity_hash_version: int = 1
 
 
 class InsightLookupBody(BaseModel):

--- a/server/quire_server/api/ai_schemas.py
+++ b/server/quire_server/api/ai_schemas.py
@@ -251,16 +251,42 @@ class DocumentIdentity(BaseModel):
 
 
 class MetadataBundle(BaseModel):
-    title: str
-    author: str | None = None
-    language: str | None = None
-    isbn: str | None = None
-    publisher: str | None = None
-    publish_date: str | None = None
-    subjects: list[str] = Field(default_factory=list)
-    description: str | None = None
-    series_name: str | None = None
-    series_position: int | None = None
+    """Book metadata block driving the AI insight prompt + retrieval.
+
+    Phase 0, task S-3: this block is supplied by the client as the
+    authoritative source of metadata for the request. The optional
+    deprecated server-side fallback (when ``ai_metadata_server_lookup_enabled``
+    is True) reconstructs the same shape from the caller's local
+    ``library_items`` row.
+
+    Field-level length caps bound the LLM prompt size and protect against
+    accidental large payloads / prompt-injection vectors. They are loose
+    enough to accommodate real-world OPF + Calibre metadata.
+    """
+
+    # Title is required: the prompt cannot identify the work without it.
+    title: str = Field(min_length=1, max_length=512)
+    author: str | None = Field(default=None, max_length=512)
+    language: str | None = Field(default=None, max_length=32)
+    isbn: str | None = Field(default=None, max_length=64)
+    publisher: str | None = Field(default=None, max_length=256)
+    publish_date: str | None = Field(default=None, max_length=32)
+    subjects: list[str] = Field(default_factory=list, max_length=64)
+    description: str | None = Field(default=None, max_length=4096)
+    series_name: str | None = Field(default=None, max_length=256)
+    series_position: int | None = Field(default=None, ge=0, le=10_000)
+
+    @field_validator("subjects")
+    @classmethod
+    def _validate_subject_items(cls, v: list[str]) -> list[str]:
+        # Per-item length cap; rejects rather than truncates so a regression
+        # in client OPF parsing surfaces as a 422 instead of silent data loss.
+        for s in v:
+            if not isinstance(s, str):
+                raise ValueError("subjects entries must be strings")
+            if len(s) > 80:
+                raise ValueError("each subject must be <= 80 chars")
+        return v
 
 
 class Citation(BaseModel):
@@ -387,8 +413,22 @@ class BookInsightResponse(BaseModel):
 
 
 class InsightLookupBody(BaseModel):
+    """Body of ``POST /ai/v1/insights/lookup``.
+
+    Phase 0, task S-3: ``bundle`` is now optional. The push-model API treats
+    client-supplied metadata as authoritative — when present the server
+    uses it directly. When absent, the server returns 400 unless the
+    deprecated ``ai_metadata_server_lookup_enabled`` flag is set, in which
+    case it falls back to reconstructing the bundle from the caller's
+    local ``library_items`` row. The fallback is kept only for the
+    duration of the OSS push-model migration; S-4 will surface the
+    deprecation message and a future release will remove it entirely.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
     identity: DocumentIdentity
-    bundle: MetadataBundle
+    bundle: MetadataBundle | None = None
 
 
 class InsightGetBody(BaseModel):
@@ -473,10 +513,18 @@ class InsightRegenerateBody(BaseModel):
 
     `reason` is appended to the user prompt so the model knows what to fix.
     Rate-limited harder than regular lookup (AI_REGEN_DAILY_LIMIT per user/day).
+
+    Phase 0, task S-3: ``bundle`` is optional and follows the same
+    push-model + deprecated-flag fallback semantics as
+    ``InsightLookupBody``. The bundle resolution happens BEFORE the
+    existing live row is superseded — a missing bundle with the flag
+    off short-circuits to 400, so no row is touched.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     identity: DocumentIdentity
-    bundle: MetadataBundle
+    bundle: MetadataBundle | None = None
     reason: str = Field(min_length=1, max_length=500)
 
 

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -61,6 +61,7 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
     return LibraryItemResponse(
         metadata_id=row.metadata_id,
         content_hash=row.content_hash,
+        identity_hash_version=row.identity_hash_version,
         title=row.title,
         authors=list(row.authors or []),
         series_name=row.series_name,
@@ -78,6 +79,11 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
 def _apply_payload(row: LibraryItem, payload: LibraryItemRequest) -> None:
     """Write payload fields onto `row`. Caller is responsible for timestamps."""
     row.metadata_id = payload.metadata_id
+    # Phase 0, task F-1: downgrade protection. An old client (sending the
+    # default `1`) MUST NOT overwrite a row whose hash version was advanced
+    # by a newer client. `max(existing, incoming)` is the load-bearing rule.
+    if payload.identity_hash_version > row.identity_hash_version:
+        row.identity_hash_version = payload.identity_hash_version
     row.title = payload.title
     row.authors = list(payload.authors)
     row.series_name = payload.series_name
@@ -134,6 +140,7 @@ async def put_item(
         row = LibraryItem(
             user_id=user_id,
             content_hash=payload.content_hash,
+            identity_hash_version=payload.identity_hash_version,
             title=payload.title,
             authors=list(payload.authors),
             metadata_id=payload.metadata_id,

--- a/server/quire_server/api/library_schemas.py
+++ b/server/quire_server/api/library_schemas.py
@@ -26,6 +26,11 @@ class LibraryItemRequest(BaseModel):
 
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1`
+    # accepts pre-versioning clients; the server's PUT path applies
+    # `max(existing, incoming)` so an old client cannot downgrade a row
+    # written by a newer client.
+    identity_hash_version: int = Field(default=1, ge=1)
     title: str
     authors: list[str] = Field(default_factory=list)
     series_name: str | None = None
@@ -47,6 +52,12 @@ class LibraryItemIdentity(BaseModel):
     """The identity sub-object inside a DELETE body."""
 
     content_hash: str
+    # Phase 0, task F-1: optional on DELETE. The current matcher keys
+    # exclusively on `content_hash` so the field is accepted but not used
+    # for row selection — clients can already locate a row by hash alone.
+    # Once a real hash-version migration happens this field becomes the
+    # tiebreaker for delete semantics.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class LibraryItemDeleteBody(BaseModel):
@@ -58,6 +69,10 @@ class LibraryItemResponse(BaseModel):
 
     metadata_id: str | None
     content_hash: str
+    # Phase 0, task F-1: always emitted from server, so clients can detect
+    # the row's persisted hash-algorithm version and trigger recompute on
+    # next sync when their computed-version > N.
+    identity_hash_version: int
     title: str
     authors: list[str]
     series_name: str | None

--- a/server/quire_server/api/progress.py
+++ b/server/quire_server/api/progress.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, Field, field_serializer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,11 @@ router = APIRouter(tags=["progress"])
 class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version travelling on the
+    # wire. Default `1` keeps old clients (pre-versioning) round-trippable;
+    # new clients send their own value and the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class ProgressItem(BaseModel):
@@ -102,6 +107,10 @@ async def _resolve_or_create_document(
             )
         ).scalar_one_or_none()
         if existing:
+            # Phase 0, task F-1: downgrade protection. An old client (sending
+            # `1`) MUST NOT overwrite a row written by a newer client.
+            if ident.identity_hash_version > existing.identity_hash_version:
+                existing.identity_hash_version = ident.identity_hash_version
             return existing
     existing = (
         await session.execute(
@@ -114,8 +123,16 @@ async def _resolve_or_create_document(
         # Backfill metadata_id if we just learned it
         if ident.metadata_id and existing.metadata_id is None:
             existing.metadata_id = ident.metadata_id
+        # Phase 0, task F-1: downgrade protection (see above).
+        if ident.identity_hash_version > existing.identity_hash_version:
+            existing.identity_hash_version = ident.identity_hash_version
         return existing
-    doc = Document(user_id=user_id, metadata_id=ident.metadata_id, content_hash=ident.content_hash)
+    doc = Document(
+        user_id=user_id,
+        metadata_id=ident.metadata_id,
+        content_hash=ident.content_hash,
+        identity_hash_version=ident.identity_hash_version,
+    )
     session.add(doc)
     await session.flush()  # populate doc.pk
     return doc
@@ -130,6 +147,14 @@ async def push_progress(
     results: list[ProgressPushResult] = []
     for item in body.items:
         doc = await _resolve_or_create_document(session, user_id, item.document)
+        # Phase 0, task F-1: the result echoes the persisted Document's
+        # identity_hash_version (which may be >= the incoming one after the
+        # downgrade-protection logic in _resolve_or_create_document).
+        persisted_identity = DocumentIdentity(
+            metadata_id=doc.metadata_id,
+            content_hash=doc.content_hash,
+            identity_hash_version=doc.identity_hash_version,
+        )
         existing = (
             await session.execute(select(Progress).where(Progress.document_pk == doc.pk))
         ).scalar_one_or_none()
@@ -158,7 +183,7 @@ async def push_progress(
             )
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -172,7 +197,7 @@ async def push_progress(
             existing.abandoned_at = abandoned_at
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -180,7 +205,7 @@ async def push_progress(
         else:
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="stale",
                     server_client_updated_at=existing.client_updated_at,
                 )
@@ -223,7 +248,11 @@ async def pull_progress(
             effective_abandoned_at = None
         items.append(
             ProgressPullItem(
-                document=DocumentIdentity(metadata_id=d.metadata_id, content_hash=d.content_hash),
+                document=DocumentIdentity(
+                    metadata_id=d.metadata_id,
+                    content_hash=d.content_hash,
+                    identity_hash_version=d.identity_hash_version,
+                ),
                 locator=p.locator,
                 percent=p.percent,
                 client_updated_at=p.client_updated_at,

--- a/server/quire_server/config.py
+++ b/server/quire_server/config.py
@@ -43,6 +43,17 @@ class Settings(BaseSettings):
     ai_retrieval_timeout_s: float = 8.0
     ai_prompt_version: str = "1"
 
+    # Phase 0, task S-3: deprecated server-side metadata fallback for the
+    # AI insight endpoints. When False (the default per the push-model API
+    # direction), POST /ai/v1/insights/{lookup,regenerate} reject requests
+    # that omit the `bundle` block with 400 `metadata_required`. When True,
+    # the server falls back to reconstructing a MetadataBundle from the
+    # caller's local `library_items` row keyed by identity_hash. The flag
+    # exists only for backward compatibility during the OSS push-model
+    # migration; task S-4 will surface a runtime deprecation warning and a
+    # future release will remove the fallback entirely.
+    ai_metadata_server_lookup_enabled: bool = False
+
     # Quota protection — important when AI_BASE_URL points at a metered/cloud provider
     # (Ollama Cloud subscription, OpenAI, Anthropic, OpenRouter, …). Free-tier Ollama
     # Cloud burns quota the same as a paid API.

--- a/server/quire_server/config.py
+++ b/server/quire_server/config.py
@@ -50,8 +50,17 @@ class Settings(BaseSettings):
     # the server falls back to reconstructing a MetadataBundle from the
     # caller's local `library_items` row keyed by identity_hash. The flag
     # exists only for backward compatibility during the OSS push-model
-    # migration; task S-4 will surface a runtime deprecation warning and a
-    # future release will remove the fallback entirely.
+    # migration.
+    #
+    # DEPRECATED since the Phase 0 release (2026-05-22). Slated for removal
+    # in 2 minor releases. When the flag is True at boot, `create_app()`
+    # emits both a `DeprecationWarning` (Python tooling channel) and a
+    # `logging.warning` (operator channel) naming the env var and the
+    # removal window. See `_warn_deprecated_ai_metadata_lookup` in
+    # `quire_server/main.py` and the "Environment variables" table in
+    # `server/README.md`. The push-model contract (clients send `bundle`
+    # in the request body) is documented in `docs/sync-api.md` under
+    # POST /ai/v1/insights/lookup.
     ai_metadata_server_lookup_enabled: bool = False
 
     # Quota protection — important when AI_BASE_URL points at a metered/cloud provider

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -2248,9 +2248,7 @@ def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
 
 
-def _maybe_upgrade_identity_hash_version(
-    row: BookInsight, ident: DocumentIdentity
-) -> None:
+def _maybe_upgrade_identity_hash_version(row: BookInsight, ident: DocumentIdentity) -> None:
     """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
     identity-hash version on a cache-hit.
 

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -664,6 +664,10 @@ class InsightOrchestrator:
         row = BookInsight(
             metadata_id=ident.metadata_id,
             content_hash=effective_content_hash,
+            # Phase 0, task F-1: persist the incoming identity-hash version
+            # so future reads return the correct level. Defaults to `1` for
+            # pre-versioning clients.
+            identity_hash_version=getattr(ident, "identity_hash_version", 1),
             model_id=self.model_id,
             prompt_version=self.prompt_version,
             tone=tone,
@@ -857,6 +861,7 @@ class InsightOrchestrator:
                 )
             ).scalar_one_or_none()
             if row is not None:
+                _maybe_upgrade_identity_hash_version(row, ident)
                 return row
         # Step 2: by content_hash (live rows only)
         if not ident.content_hash:
@@ -875,6 +880,10 @@ class InsightOrchestrator:
         ).scalar_one_or_none()
         if row is None:
             return None
+        # Phase 0, task F-1: upgrade the row's identity_hash_version if the
+        # incoming identity is newer. Same downgrade-protection rule as
+        # Document/LibraryItem: max(existing, incoming).
+        _maybe_upgrade_identity_hash_version(row, ident)
         # Alias reconciliation: backfill metadata_id if we just learned it.
         if allow_backfill and ident.metadata_id and row.metadata_id is None:
             row.metadata_id = ident.metadata_id
@@ -1174,6 +1183,13 @@ class InsightOrchestrator:
         new_row = BookInsight(
             metadata_id=to_identity.metadata_id,
             content_hash=to_identity.content_hash or src_row.content_hash,
+            # Phase 0, task F-1: the copied row takes the maximum of the
+            # source row's version and the destination identity's version
+            # so a v2 destination promoted from a v1 source persists as v2.
+            identity_hash_version=max(
+                src_row.identity_hash_version,
+                getattr(to_identity, "identity_hash_version", 1),
+            ),
             model_id=src_row.model_id,
             prompt_version=src_row.prompt_version,
             tone=src_row.tone,
@@ -2213,6 +2229,10 @@ class InsightOrchestrator:
             model_id=row.model_id,
             prompt_version=row.prompt_version,
             generated_at=row.generated_at.isoformat(),
+            # Phase 0, task F-1: surface the persisted identity-hash version
+            # so clients can detect rows produced under an older algorithm
+            # and trigger their own recompute logic (F-2 territory).
+            identity_hash_version=row.identity_hash_version,
         )
 
 
@@ -2226,6 +2246,24 @@ def _tone_of(style: AiStyle | None) -> str:
 
 def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
+
+
+def _maybe_upgrade_identity_hash_version(
+    row: BookInsight, ident: DocumentIdentity
+) -> None:
+    """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
+    identity-hash version on a cache-hit.
+
+    Operates in-place on `row`. The surrounding transaction commits as
+    part of the normal cache-hit log write, so we do not flush here.
+
+    Defensive: ``ident.identity_hash_version`` is wire-side and defaults to
+    `1` when the client did not supply it (pre-versioning clients). The
+    `>` comparison therefore protects against accidental downgrades.
+    """
+    incoming = getattr(ident, "identity_hash_version", 1)
+    if incoming > row.identity_hash_version:
+        row.identity_hash_version = incoming
 
 
 # ---------- PR2 identity-resolution helpers ---------------------------------

--- a/server/quire_server/db/models.py
+++ b/server/quire_server/db/models.py
@@ -32,6 +32,10 @@ class Document(Base):
     __table_args__ = (
         UniqueConstraint("user_id", "metadata_id", name="uq_documents_user_metadata"),
         UniqueConstraint("user_id", "content_hash", name="uq_documents_user_content_hash"),
+        CheckConstraint(
+            "identity_hash_version >= 1",
+            name="ck_documents_identity_hash_version_ge_1",
+        ),
         Index("ix_documents_user", "user_id"),
     )
 
@@ -39,6 +43,15 @@ class Document(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1 (one-way-door per 2026-05-22 monetization spec):
+    # version of the identity-hash algorithm used to derive `content_hash`.
+    # Persisted with every record so a future hash-function change does not
+    # break sync/cache/recs/export/deletion across millions of rows. Always
+    # >= 1; current rows backfill to 1 in migration `progress_003`. Clients
+    # reading vN rows recompute on next sync when their algorithm > N.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -108,6 +121,14 @@ class BookInsight(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version. NOT part of the
+    # cache key (see architect decision in Phase 0 plan): treated as row-
+    # freshness metadata only. A higher-version client hitting an existing
+    # cache row upgrades the persisted value via max(existing, incoming).
+    # CHECK constraint lives in migration `ai_007`.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     model_id: Mapped[str] = mapped_column(String, nullable=False)
     prompt_version: Mapped[str] = mapped_column(String, nullable=False)
     # Part of the cache key so users with different AiStyle.tone get their own
@@ -349,6 +370,13 @@ class LibraryItem(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version (see Document for
+    # full rationale). The CHECK constraint is declared in the alembic
+    # migration `progress_003` because partial-index-style metadata for
+    # this table lives there.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     authors: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list

--- a/server/quire_server/main.py
+++ b/server/quire_server/main.py
@@ -15,6 +15,7 @@ from paying the cost of the other domain's modules.
 from __future__ import annotations
 
 import logging
+import warnings
 
 import httpx
 from fastapi import FastAPI
@@ -25,6 +26,42 @@ from quire_server.config import Settings, get_settings
 from quire_server.core.auth import CalibreAuthValidator
 from quire_server.core.logging_ctx import RequestIdLogFilter
 from quire_server.db.session import configure, make_engine, make_session_factory
+
+
+def _warn_deprecated_ai_metadata_lookup(settings: Settings) -> None:
+    """Emit a startup deprecation notice for ``ai_metadata_server_lookup_enabled``.
+
+    Phase 0, task S-4: the server-side AI metadata lookup fallback (added by
+    task S-3) is the only path on which `quire_server` still pulls book
+    metadata from the operator's own DB instead of accepting it on the
+    request body. The Phase 0 push-model contract makes the client the sole
+    source of metadata; this flag is the migration escape hatch.
+
+    Deprecated since the Phase 0 release (2026-05-22). Removal target:
+    2 minor releases later. Both channels fire so that:
+
+    * `warnings.warn(..., DeprecationWarning)` surfaces in test runs, IDEs,
+      and any tooling that opts into `-W error::DeprecationWarning`.
+    * `logging.warning` is the channel operators actually read in container
+      logs and Loki/Grafana dashboards.
+
+    Fires once at boot. Per-request signalling on the fallback path is
+    intentionally NOT added — the operator already has the boot warning,
+    and per-request log spam would not change their behavior.
+    """
+    if not settings.ai_metadata_server_lookup_enabled:
+        return
+    message = (
+        "QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED is deprecated and will be "
+        "removed in 2 minor releases. Have clients push metadata via the `bundle` "
+        "block on POST /ai/v1/insights/{lookup,regenerate} instead. See "
+        "server/README.md and docs/sync-api.md for the push-model contract."
+    )
+    # stacklevel=3: warn() -> this helper -> create_app() -> caller of create_app().
+    # Points the warning at the boot site (e.g. uvicorn factory) rather than this
+    # helper, which is the useful frame for tooling.
+    warnings.warn(message, DeprecationWarning, stacklevel=3)
+    logging.getLogger(__name__).warning(message)
 
 
 def _validate_ai_auth_settings(settings: Settings) -> None:
@@ -102,6 +139,14 @@ def create_app() -> FastAPI:
     for _h in logging.getLogger().handlers:
         if not any(isinstance(f, RequestIdLogFilter) for f in _h.filters):
             _h.addFilter(_filter)
+
+    # Phase 0, task S-4: surface the deprecation of the server-side AI
+    # metadata lookup fallback. Fires once at boot when the flag is True;
+    # the helper is a no-op otherwise. Placed AFTER logging setup so the
+    # operator-channel warning goes through the configured root handler,
+    # and BEFORE engine creation so a misconfigured DB URL doesn't
+    # accidentally mask the notice.
+    _warn_deprecated_ai_metadata_lookup(settings)
 
     engine = make_engine(settings.database_url)
     configure(engine)

--- a/server/tests/integration/test_ai_endpoints.py
+++ b/server/tests/integration/test_ai_endpoints.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 
 import base64
 import json
+from decimal import Decimal
 
 import pytest
 from sqlalchemy import select
 
-from quire_server.db.models import BookInsight
+from quire_server.db.models import BookInsight, LibraryItem
 
 # All tests in this file hit /ai/v1/* and so require the ai router.
 pytestmark = pytest.mark.requires_ai
@@ -199,3 +200,345 @@ async def test_invalidate_drops_cache(client_factory, configure_ai, app, session
             json={"identity": {"content_hash": "ch-inv"}},
         )
         assert r2.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Phase 0, task S-3: client-supplied metadata + deprecated server-side
+# fallback. These tests pin the push-model contract on
+# /ai/v1/insights/{lookup,regenerate}.
+# ---------------------------------------------------------------------------
+
+
+async def _opt_in(client, user: str = "alice") -> None:
+    r = await client.put(
+        "/ai/v1/preferences",
+        headers=_basic_header(user),
+        json={"ai_enabled": True},
+    )
+    assert r.status_code == 200
+
+
+async def _seed_library_item(
+    session,
+    *,
+    user_id: str,
+    metadata_id: str | None,
+    content_hash: str,
+    title: str = "Foundation",
+    authors: list[str] | None = None,
+    series_name: str | None = None,
+    series_index: Decimal | None = None,
+    language: str | None = None,
+    isbn: str | None = None,
+    subjects: list[str] | None = None,
+) -> None:
+    session.add(
+        LibraryItem(
+            user_id=user_id,
+            metadata_id=metadata_id,
+            content_hash=content_hash,
+            title=title,
+            authors=authors if authors is not None else ["Isaac Asimov"],
+            series_name=series_name,
+            series_index=series_index,
+            language=language,
+            isbn=isbn,
+            subjects=subjects if subjects is not None else [],
+        )
+    )
+    await session.commit()
+
+
+async def test_lookup_400_when_bundle_omitted_and_flag_off(
+    client_factory, configure_ai, app, session
+):
+    """S-3: push-model default — clients MUST send their own metadata."""
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        configure_ai(app, {"schema_version": 2, "intro": "ok", "confidence": "low"})
+        await _opt_in(client)
+
+        r = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={"identity": {"content_hash": "ch-no-meta"}},
+        )
+        assert r.status_code == 400
+        assert r.json()["detail"] == "metadata_required"
+
+        # No BookInsight row was written — the 400 short-circuits before
+        # the orchestrator reserves quota or acquires a generation lock.
+        rows = (await session.execute(select(BookInsight))).scalars().all()
+        assert rows == []
+
+
+async def test_regenerate_400_when_bundle_omitted_and_flag_off(
+    client_factory, configure_ai, app, session
+):
+    """S-3: regenerate inherits the same push-model contract.
+
+    Bundle resolution happens BEFORE the orchestrator supersedes any live
+    row, so an unusable request leaves the existing row alone.
+    """
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        configure_ai(app, {"schema_version": 2, "intro": "first", "confidence": "low"})
+        await _opt_in(client)
+
+        # Seed a live insight via the happy lookup path.
+        r0 = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"content_hash": "ch-regen"},
+                "bundle": {"title": "X"},
+            },
+        )
+        assert r0.status_code == 200
+
+        live_before = (
+            await session.execute(
+                select(BookInsight).where(BookInsight.superseded_at.is_(None))
+            )
+        ).scalars().all()
+        assert len(live_before) == 1
+
+        # Now regenerate WITHOUT a bundle, with the flag off → 400.
+        r1 = await client.post(
+            "/ai/v1/insights/regenerate",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"content_hash": "ch-regen"},
+                "reason": "force",
+            },
+        )
+        assert r1.status_code == 400
+        assert r1.json()["detail"] == "metadata_required"
+
+        # The existing live row was NOT superseded.
+        live_after = (
+            await session.execute(
+                select(BookInsight).where(BookInsight.superseded_at.is_(None))
+            )
+        ).scalars().all()
+        assert len(live_after) == 1
+        assert live_after[0].id == live_before[0].id
+
+
+async def test_lookup_falls_back_to_library_item_when_flag_on(
+    client_factory, configure_ai, app, session
+):
+    """S-3: deprecated server-side fallback regression test.
+
+    With ``ai_metadata_server_lookup_enabled=true``, an omitted bundle is
+    reconstructed from the caller's ``library_items`` row. The
+    ``series_name`` + ``series_index`` from that row drive the post-LLM
+    ``payload.series`` override — proving the reconstructed bundle is
+    actually used by ``_do_generate``, not just silently dropped.
+    """
+    async with client_factory(
+        ai_enabled=True,
+        ai_base_url="http://x",
+        ai_model="m",
+        ai_metadata_server_lookup_enabled=True,
+        progress_enabled=True,
+    ) as client:
+        # Fake LLM returns NO `series` block; the bundle override must
+        # supply it from LibraryItem.series_name.
+        configure_ai(
+            app,
+            {"schema_version": 2, "intro": "Reconstructed.", "confidence": "low"},
+        )
+        await _opt_in(client)
+
+        await _seed_library_item(
+            session,
+            user_id="alice",
+            metadata_id="md-fallback",
+            content_hash="ch-fallback",
+            title="Foundation",
+            authors=["Isaac Asimov"],
+            series_name="Foundation Saga",
+            series_index=Decimal("1"),
+            language="en",
+        )
+
+        r = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={"identity": {"metadata_id": "md-fallback", "content_hash": "ch-fallback"}},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["payload"]["intro"] == "Reconstructed."
+        # The series override only fires when bundle.series_name is set.
+        assert body["payload"]["series"]["name"] == "Foundation Saga"
+        assert body["payload"]["series"]["position"] == 1
+
+
+async def test_lookup_400_when_flag_on_but_no_library_item(
+    client_factory, configure_ai, app, session
+):
+    """S-3: fallback can't fabricate metadata — no row, no insight."""
+    async with client_factory(
+        ai_enabled=True,
+        ai_base_url="http://x",
+        ai_model="m",
+        ai_metadata_server_lookup_enabled=True,
+        progress_enabled=True,
+    ) as client:
+        configure_ai(app, {"schema_version": 2, "intro": "x", "confidence": "low"})
+        await _opt_in(client)
+
+        r = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={"identity": {"content_hash": "ch-missing"}},
+        )
+        assert r.status_code == 400
+        assert r.json()["detail"] == "metadata_required"
+
+        rows = (await session.execute(select(BookInsight))).scalars().all()
+        assert rows == []
+
+
+async def test_lookup_persists_identity_hash_version(
+    client_factory, configure_ai, app, session
+):
+    """S-3 + F-1: client-supplied identity_hash_version survives bundle
+    plumbing and lands on the persisted BookInsight row."""
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        configure_ai(app, {"schema_version": 2, "intro": "v2 hash", "confidence": "low"})
+        await _opt_in(client)
+
+        r = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {
+                    "metadata_id": "md-ihv",
+                    "content_hash": "ch-ihv",
+                    "identity_hash_version": 2,
+                },
+                "bundle": {"title": "T"},
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 2
+
+        row = (
+            await session.execute(
+                select(BookInsight).where(BookInsight.content_hash == "ch-ihv")
+            )
+        ).scalar_one()
+        assert row.identity_hash_version == 2
+
+
+async def test_lookup_cache_invariant_first_writer_wins(
+    client_factory, configure_ai, app, session
+):
+    """S-3: bundle does NOT participate in the cache key.
+
+    Divergent bundles for the same canonical identity (and same
+    ``model_id`` + ``prompt_version`` + ``tone`` + ``language``) share
+    a single cache row. The first-writer determines the persisted
+    payload; the second call is a pure cache hit. This is the documented
+    Phase 0 limitation; bundle fingerprinting is a later task.
+    """
+    async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
+        configure_ai(app, {"schema_version": 2, "intro": "first writer", "confidence": "low"})
+        await _opt_in(client)
+
+        identity = {"content_hash": "ch-cache-invariant"}
+
+        r1 = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={
+                "identity": identity,
+                "bundle": {"title": "Original Title", "author": "A"},
+            },
+        )
+        assert r1.status_code == 200
+        assert r1.json()["payload"]["intro"] == "first writer"
+
+        # Second call with a wildly different bundle should hit the cache
+        # and return the FIRST writer's payload, NOT regenerate.
+        r2 = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=_basic_header("alice"),
+            json={
+                "identity": identity,
+                "bundle": {"title": "Completely Different Book", "author": "B"},
+            },
+        )
+        assert r2.status_code == 200
+        assert r2.json()["payload"]["intro"] == "first writer"
+
+        # And only one BookInsight row exists for the identity.
+        rows = (
+            await session.execute(
+                select(BookInsight).where(BookInsight.content_hash == "ch-cache-invariant")
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+
+
+async def test_regenerate_falls_back_to_library_item_when_flag_on(
+    client_factory, configure_ai, app, session
+):
+    """S-3: regenerate's fallback path mirrors lookup's."""
+    async with client_factory(
+        ai_enabled=True,
+        ai_base_url="http://x",
+        ai_model="m",
+        ai_metadata_server_lookup_enabled=True,
+        progress_enabled=True,
+    ) as client:
+        configure_ai(app, {"schema_version": 2, "intro": "regen-fallback", "confidence": "low"})
+        await _opt_in(client)
+
+        await _seed_library_item(
+            session,
+            user_id="alice",
+            metadata_id="md-regen-fb",
+            content_hash="ch-regen-fb",
+            title="Foundation",
+            authors=["Isaac Asimov"],
+        )
+
+        r = await client.post(
+            "/ai/v1/insights/regenerate",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"metadata_id": "md-regen-fb", "content_hash": "ch-regen-fb"},
+                "reason": "user requested a redo",
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["payload"]["intro"] == "regen-fallback"
+
+
+async def test_regenerate_400_when_flag_on_but_no_library_item(
+    client_factory, configure_ai, app, session
+):
+    """S-3: regenerate can't fabricate metadata either; existing live rows
+    (if any) remain untouched."""
+    async with client_factory(
+        ai_enabled=True,
+        ai_base_url="http://x",
+        ai_model="m",
+        ai_metadata_server_lookup_enabled=True,
+        progress_enabled=True,
+    ) as client:
+        configure_ai(app, {"schema_version": 2, "intro": "n/a", "confidence": "low"})
+        await _opt_in(client)
+
+        r = await client.post(
+            "/ai/v1/insights/regenerate",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"content_hash": "ch-regen-missing"},
+                "reason": "force",
+            },
+        )
+        assert r.status_code == 400
+        assert r.json()["detail"] == "metadata_required"

--- a/server/tests/integration/test_ai_endpoints.py
+++ b/server/tests/integration/test_ai_endpoints.py
@@ -295,10 +295,10 @@ async def test_regenerate_400_when_bundle_omitted_and_flag_off(
         assert r0.status_code == 200
 
         live_before = (
-            await session.execute(
-                select(BookInsight).where(BookInsight.superseded_at.is_(None))
-            )
-        ).scalars().all()
+            (await session.execute(select(BookInsight).where(BookInsight.superseded_at.is_(None))))
+            .scalars()
+            .all()
+        )
         assert len(live_before) == 1
 
         # Now regenerate WITHOUT a bundle, with the flag off → 400.
@@ -315,10 +315,10 @@ async def test_regenerate_400_when_bundle_omitted_and_flag_off(
 
         # The existing live row was NOT superseded.
         live_after = (
-            await session.execute(
-                select(BookInsight).where(BookInsight.superseded_at.is_(None))
-            )
-        ).scalars().all()
+            (await session.execute(select(BookInsight).where(BookInsight.superseded_at.is_(None))))
+            .scalars()
+            .all()
+        )
         assert len(live_after) == 1
         assert live_after[0].id == live_before[0].id
 
@@ -400,9 +400,7 @@ async def test_lookup_400_when_flag_on_but_no_library_item(
         assert rows == []
 
 
-async def test_lookup_persists_identity_hash_version(
-    client_factory, configure_ai, app, session
-):
+async def test_lookup_persists_identity_hash_version(client_factory, configure_ai, app, session):
     """S-3 + F-1: client-supplied identity_hash_version survives bundle
     plumbing and lands on the persisted BookInsight row."""
     async with client_factory(ai_enabled=True, ai_base_url="http://x", ai_model="m") as client:
@@ -425,16 +423,12 @@ async def test_lookup_persists_identity_hash_version(
         assert r.json()["identity_hash_version"] == 2
 
         row = (
-            await session.execute(
-                select(BookInsight).where(BookInsight.content_hash == "ch-ihv")
-            )
+            await session.execute(select(BookInsight).where(BookInsight.content_hash == "ch-ihv"))
         ).scalar_one()
         assert row.identity_hash_version == 2
 
 
-async def test_lookup_cache_invariant_first_writer_wins(
-    client_factory, configure_ai, app, session
-):
+async def test_lookup_cache_invariant_first_writer_wins(client_factory, configure_ai, app, session):
     """S-3: bundle does NOT participate in the cache key.
 
     Divergent bundles for the same canonical identity (and same
@@ -475,10 +469,14 @@ async def test_lookup_cache_invariant_first_writer_wins(
 
         # And only one BookInsight row exists for the identity.
         rows = (
-            await session.execute(
-                select(BookInsight).where(BookInsight.content_hash == "ch-cache-invariant")
+            (
+                await session.execute(
+                    select(BookInsight).where(BookInsight.content_hash == "ch-cache-invariant")
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert len(rows) == 1
 
 

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,11 +29,12 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # ai branch is at ai_006 (pr-β added the audit-log generalization +
-    # profile_count column); the progress branch is at progress_002 (pr-α
-    # added abandoned_at). With the default-true mode flags, both branch
-    # heads are reported, sorted.
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`); the progress branch is at
+    # progress_003 (same task, added `identity_hash_version` to
+    # `documents` + `library_items`). With the default-true mode flags,
+    # both branch heads are reported, sorted.
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_library_items.py
+++ b/server/tests/integration/test_library_items.py
@@ -392,3 +392,87 @@ async def test_unauthenticated_request_rejected(app_under_test, unique_user):
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         r = await c.get("/library/v1/items")
     assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning on /library/v1/items.
+# ---------------------------------------------------------------------------
+# Three behaviours travel together:
+#   1. Default round-trip: omitting `identity_hash_version` in the PUT body
+#      persists as `1` and the GET response carries it.
+#   2. Explicit value round-trip: sending `identity_hash_version=2` persists
+#      `2` and the response/GET reflect it.
+#   3. Downgrade protection: after writing version `2`, a later PUT that
+#      defaults to `1` (or explicitly sends `1`) MUST keep the row at `2`.
+#      This is the `max(existing, incoming)` rule that prevents an old
+#      client from clobbering a newer client's row.
+
+
+async def test_identity_hash_version_defaults_to_1_when_absent(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 1
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.status_code == 200
+        items = r2.json()["items"]
+        assert len(items) == 1
+        assert items[0]["identity_hash_version"] == 1
+
+
+async def test_identity_hash_version_round_trips_explicit_value(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 2
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.json()["items"][0]["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_protects_against_downgrade(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Newer client writes v2.
+        r1 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r1.json()["identity_hash_version"] == 2
+
+        # Older client sends nothing (defaults to v1) — must NOT downgrade.
+        r2 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r2.status_code == 200
+        assert r2.json()["identity_hash_version"] == 2
+
+        # Explicit v1 must also not downgrade.
+        r3 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=1),
+            headers=headers,
+        )
+        assert r3.json()["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_rejects_zero(app_under_test, unique_user):
+    """Pydantic `ge=1` returns 422 for non-positive versions."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=0),
+            headers=headers,
+        )
+    assert r.status_code == 422, r.text

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -2,11 +2,11 @@
 
 Cases covered:
 1. Default state with real migrations: wrapper upgrades backbone + ai branch,
-   DB ends at ai@head (currently `ai_006`).
+   DB ends at ai@head (currently `ai_007`).
 2. Idempotent: running twice in a row is a no-op.
-3. Synthetic branched script directory (tmp copy of migrations + an ai_test_006
-   revision chained off the current ai@head):
-   - ai_enabled=true → upgrades to ai_test_006.
+3. Synthetic branched script directory (tmp copy of migrations + an
+   ai_test_008 revision chained off the current ai@head):
+   - ai_enabled=true → upgrades to ai_test_008.
    - ai_enabled=false → stays at 0004 (no ai branch applied).
 """
 
@@ -53,7 +53,7 @@ async def _downgrade_in_thread(cfg, target: str) -> None:
 
 
 async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str):
-    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_006)."""
+    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_007)."""
 
     # Wipe DB to fresh state.
     eng = create_async_engine(postgres_url, future=True)
@@ -66,9 +66,11 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch is at ai_006 (pr-β / Bundle 3 added the audit-log generalization
-    # + profile_count column). The progress branch is at progress_002.
-    assert versions == {"ai_006", "progress_002"}
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`). The progress branch is at
+    # progress_003 (same task, added the column to `documents` and
+    # `library_items`).
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
@@ -81,14 +83,14 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_006", "progress_002"}
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
-    """Copy real migrations to tmp + add a synthetic ai_test_007 chained off
-    ai_006; verify enabled run advances to ai_test_007 (the new ai@head)."""
+    """Copy real migrations to tmp + add a synthetic ai_test_008 chained off
+    ai_007; verify enabled run advances to ai_test_008 (the new ai@head)."""
 
-    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_006).
+    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_007).
     real_cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
 
@@ -96,22 +98,23 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
     versions_dir = synth_dir / "versions"
-    # Chain off ai_006 (the current ai@head after pr-β) with branch_labels=None.
-    (versions_dir / "ai_test_007.py").write_text(
+    # Chain off ai_007 (the current ai@head after Phase 0 / F-1) with
+    # branch_labels=None.
+    (versions_dir / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration.
 
-            Revision ID: ai_test_007
-            Revises: ai_006
-            Create Date: 2026-05-21 00:00:00.000000
+            Revision ID: ai_test_008
+            Revises: ai_007
+            Create Date: 2026-05-22 00:00:00.000000
             """
 
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -132,18 +135,18 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     # ai branch advances to the new tip.
-    assert "ai_test_007" in versions, versions
+    assert "ai_test_008" in versions, versions
     await eng.dispose()
 
     # Cleanup: roll back the synthetic migration so other tests aren't affected.
-    await _downgrade_in_thread(cfg, "ai_006")
+    await _downgrade_in_thread(cfg, "ai_007")
 
 
 async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
     """With ai_enabled=False, the wrapper skips advancing the ai branch.
 
     Pre-condition: DB is rolled back to 0004 (no ai branch applied), then the
-    wrapper is invoked with ai_enabled=False. ai_test_007 (the synthetic head)
+    wrapper is invoked with ai_enabled=False. ai_test_008 (the synthetic head)
     must NOT be applied; the backbone stays at 0004.
     """
     # Stamp DB back to backbone (pre-ai-branch state) for this test.
@@ -152,15 +155,15 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
 
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
-    (synth_dir / "versions" / "ai_test_007.py").write_text(
+    (synth_dir / "versions" / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration."""
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -179,17 +182,19 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch skipped → ai_test_007 not applied, ai_006 not applied,
-    # ai_001 not applied. The `progress` branch still advanced.
-    assert "ai_test_007" not in versions
+    # ai branch skipped → ai_test_008 not applied, ai_007 not applied,
+    # ai_006 not applied, ai_001 not applied. The `progress` branch still
+    # advanced.
+    assert "ai_test_008" not in versions
+    assert "ai_007" not in versions
     assert "ai_006" not in versions
     assert "ai_005" not in versions
     assert "ai_004" not in versions
     assert "ai_003" not in versions
     assert "ai_001" not in versions
     # progress branch advanced (progress_enabled=True). The backbone itself
-    # is no longer a head once progress_002 sits on top of 0004.
-    assert "progress_002" in versions
+    # is no longer a head once progress_003 sits on top of 0004.
+    assert "progress_003" in versions
 
     # Restore DB for subsequent tests.
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -53,8 +53,9 @@ async def restore_after(postgres_url: str, alembic_upgrade):
 
 
 async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
-    """With ai@head (ai_006) + progress@head (progress_002) materialized,
-    /readyz reports both heads. (ai_006 added by pr-β.)
+    """With ai@head (ai_007) + progress@head (progress_003) materialized,
+    /readyz reports both heads. (ai_007 / progress_003 added by Phase 0
+    task F-1: server identity-hash schema versioning.)
     """
     # Some earlier test in the session may have downgraded the DB
     # (test_migrate_script.py exercises rollback). Ensure both branches are
@@ -72,14 +73,15 @@ async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upg
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
     """DB stamped below backbone; with both modes enabled, required head is
-    ai_006 (ai@head after pr-β) — that's what should be reported missing."""
+    ai_007 (ai@head after Phase 0 / F-1) — that's what should be reported
+    missing."""
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -87,7 +89,7 @@ async def test_readyz_503_when_db_below_backbone(
     assert r.status_code == 503
     body = r.json()
     assert body["ready"] is False
-    assert "ai_006" in body["missing"]
+    assert "ai_007" in body["missing"]
 
 
 async def test_readyz_200_with_neither_mode_at_backbone(

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -154,6 +154,65 @@ async def test_library_items_table_exists(engine) -> None:
     assert where_alive is not None and "deleted_at" in str(where_alive).lower()
 
 
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning (server side).
+# ---------------------------------------------------------------------------
+# Two migrations land the same `identity_hash_version INTEGER NOT NULL DEFAULT 1`
+# column with `CHECK (>= 1)`:
+#   * `progress_003` → `documents`, `library_items`.
+#   * `ai_007`       → `book_insights`.
+# These tests reflect the live schema (post-migration) and assert the column
+# shape on every table that should carry it.
+
+
+def _identity_hash_version_column_meta(sync_conn, table: str) -> dict:
+    insp = inspect(sync_conn)
+    cols = {c["name"]: c for c in insp.get_columns(table)}
+    checks = {c["name"]: c for c in insp.get_check_constraints(table)}
+    return {"col": cols.get("identity_hash_version"), "checks": checks}
+
+
+async def test_documents_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "documents")
+    col = info["col"]
+    assert col is not None, "documents.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_documents_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_progress
+async def test_library_items_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "library_items")
+    col = info["col"]
+    assert col is not None, "library_items.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_library_items_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_ai
+async def test_book_insights_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "book_insights")
+    col = info["col"]
+    assert col is not None, "book_insights.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_book_insights_identity_hash_version_ge_1" in info["checks"]
+
+
+async def test_documents_identity_hash_version_default_round_trip(session) -> None:
+    """A row created without supplying `identity_hash_version` defaults to 1."""
+    doc = Document(user_id="alice-v1", metadata_id="md-ver-1", content_hash="ch-ver-1")
+    session.add(doc)
+    await session.commit()
+    await session.refresh(doc)
+    assert doc.identity_hash_version == 1
+
+
 @pytest.mark.requires_ai
 async def test_ai_generation_log_round_trip(session) -> None:
     """ORM model writes and reads ai_generation_log rows."""

--- a/server/tests/unit/test_ai_schemas.py
+++ b/server/tests/unit/test_ai_schemas.py
@@ -7,6 +7,7 @@ from quire_server.api.ai_schemas import (
     ComparativeAnchor,
     InsightLookupBody,
     InsightRegenerateBody,
+    MetadataBundle,
     SeriesInsight,
 )
 
@@ -310,5 +311,94 @@ def test_regenerate_requires_reason():
                 "identity": {"content_hash": "abc"},
                 "bundle": {"title": "y"},
                 "reason": "",
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 0, task S-3: MetadataBundle field caps + optional bundle on
+# {Lookup,Regenerate} bodies.
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_bundle_minimal_title_only():
+    """Sanity: only title is required; other fields default sensibly."""
+    b = MetadataBundle.model_validate({"title": "Foundation"})
+    assert b.title == "Foundation"
+    assert b.author is None
+    assert b.subjects == []
+    assert b.description is None
+
+
+def test_metadata_bundle_rejects_empty_title():
+    with pytest.raises(ValidationError):
+        MetadataBundle.model_validate({"title": ""})
+
+
+def test_metadata_bundle_rejects_oversized_title():
+    """S-3 cap: bounds prompt size + protects against pathological inputs."""
+    with pytest.raises(ValidationError):
+        MetadataBundle.model_validate({"title": "x" * 513})
+
+
+def test_metadata_bundle_rejects_oversized_description():
+    with pytest.raises(ValidationError):
+        MetadataBundle.model_validate({"title": "t", "description": "x" * 4097})
+
+
+def test_metadata_bundle_rejects_too_many_subjects():
+    with pytest.raises(ValidationError):
+        MetadataBundle.model_validate({"title": "t", "subjects": ["s"] * 65})
+
+
+def test_metadata_bundle_rejects_oversized_subject_item():
+    with pytest.raises(ValidationError):
+        MetadataBundle.model_validate({"title": "t", "subjects": ["x" * 81]})
+
+
+def test_metadata_bundle_rejects_negative_series_position():
+    with pytest.raises(ValidationError):
+        MetadataBundle.model_validate({"title": "t", "series_position": -1})
+
+
+def test_metadata_bundle_rejects_overlarge_series_position():
+    with pytest.raises(ValidationError):
+        MetadataBundle.model_validate({"title": "t", "series_position": 10_001})
+
+
+def test_lookup_body_bundle_optional():
+    """S-3: clients can omit the bundle (server-side handler then either
+    falls back to library_items behind a flag or returns 400)."""
+    b = InsightLookupBody.model_validate({"identity": {"content_hash": "abc"}})
+    assert b.bundle is None
+
+
+def test_lookup_body_rejects_extra_fields():
+    """S-3 hardening: ``extra='forbid'`` so a typo in the request body
+    surfaces as 422 instead of being silently ignored."""
+    with pytest.raises(ValidationError):
+        InsightLookupBody.model_validate(
+            {
+                "identity": {"content_hash": "abc"},
+                "bundle": {"title": "t"},
+                "metadata": {"title": "typo"},  # not 'bundle'
+            }
+        )
+
+
+def test_regenerate_body_bundle_optional():
+    b = InsightRegenerateBody.model_validate(
+        {"identity": {"content_hash": "abc"}, "reason": "force"}
+    )
+    assert b.bundle is None
+
+
+def test_regenerate_body_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        InsightRegenerateBody.model_validate(
+            {
+                "identity": {"content_hash": "abc"},
+                "reason": "force",
+                "unknown": True,
             }
         )

--- a/server/tests/unit/test_main_deprecations.py
+++ b/server/tests/unit/test_main_deprecations.py
@@ -1,0 +1,174 @@
+"""Startup deprecation notices emitted by `create_app()`.
+
+Phase 0, task S-4: when `QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED=true`,
+the server-side AI metadata lookup fallback is active and the operator must
+be warned via both Python tooling (`DeprecationWarning`) and operator logs
+(`logging.warning`). When the flag is False (the new default), neither
+channel must emit a notice about this flag.
+
+Mirrors the wiring pattern in `test_main_ai_auth_validation.py` — exercises
+the actual `quire_server.main.create_app()` factory rather than a synthetic
+double.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+
+import pytest
+
+from quire_server.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Wipe metadata-fallback + DB / CWA env so each test starts clean.
+
+    Mirrors `test_main_ai_auth_validation._isolate_env`. The DB and CWA
+    URLs are set to non-network stubs because `create_app()` constructs an
+    engine but does not connect; we just need the URL to be parseable.
+    """
+    for var in (
+        "QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED",
+        "QUIRE_SERVER_AI_ENABLED",
+        "QUIRE_SERVER_AI_AUTH_MODE",
+        "QUIRE_SERVER_AI_TOKEN_SECRETS",
+        "QUIRE_SERVER_AI_TOKEN_ISSUER",
+        "QUIRE_SERVER_AI_TOKEN_AUDIENCE",
+        "QUIRE_SERVER_AI_BASE_URL",
+        "QUIRE_SERVER_AI_MODEL",
+        "QUIRE_SERVER_AI_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("QUIRE_SERVER_DATABASE_URL", "postgresql+asyncpg://x/y")
+    monkeypatch.setenv("QUIRE_SERVER_CWA_BASE_URL", "http://stub")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _create_app():
+    # Re-import inside each call so the function captures the freshly-cleared
+    # settings cache. Matches the helper in `test_main_ai_auth_validation`.
+    from quire_server.main import create_app
+
+    return create_app()
+
+
+# ---------------------------------------------------------------------------
+# Flag enabled: both channels fire
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_fallback_flag_true_emits_deprecation_warning(monkeypatch):
+    """Python tooling channel: `warnings.warn(..., DeprecationWarning)`.
+
+    Use a narrowly-scoped `catch_warnings` + `simplefilter("always", ...)`
+    so the warning is captured deterministically regardless of any global
+    once-per-line de-duplication accumulated by prior tests in the session.
+    `pytest.warns(DeprecationWarning, match=...)` would also work, but
+    explicit capture keeps the assertion strict on the message content.
+    """
+    monkeypatch.setenv("QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED", "true")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        _create_app()
+
+    matched = [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "AI_METADATA_SERVER_LOOKUP_ENABLED" in str(w.message)
+    ]
+    assert matched, (
+        "expected a DeprecationWarning mentioning "
+        "AI_METADATA_SERVER_LOOKUP_ENABLED, got: "
+        f"{[(w.category.__name__, str(w.message)) for w in caught]}"
+    )
+    message = str(matched[0].message)
+    # Removal window must be explicit so operators know how long they have.
+    assert "2 minor releases" in message
+    # Migration pointer must be present so operators know what to do.
+    assert "bundle" in message
+
+
+def test_metadata_fallback_flag_true_emits_logging_warning(monkeypatch, caplog):
+    """Operator channel: `logging.warning` on the module logger.
+
+    `caplog` captures records emitted during the `create_app()` call. We
+    scope the level capture to the module logger so unrelated debug noise
+    from FastAPI / SQLAlchemy doesn't crowd the assertion.
+    """
+    monkeypatch.setenv("QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED", "true")
+
+    with caplog.at_level(logging.WARNING, logger="quire_server.main"):
+        _create_app()
+
+    matching_records = [
+        r
+        for r in caplog.records
+        if r.name == "quire_server.main"
+        and r.levelno == logging.WARNING
+        and "AI_METADATA_SERVER_LOOKUP_ENABLED" in r.getMessage()
+    ]
+    assert matching_records, (
+        "expected a WARNING log on quire_server.main mentioning "
+        "AI_METADATA_SERVER_LOOKUP_ENABLED; got: "
+        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag disabled (the new default): no notice about this flag
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_fallback_flag_false_emits_no_notice(monkeypatch, caplog):
+    """When the flag is at its default (False), neither channel must emit
+    anything *about this flag*.
+
+    We do NOT use `simplefilter("error", DeprecationWarning)` — FastAPI /
+    SQLAlchemy / pydantic occasionally emit unrelated DeprecationWarnings
+    on import, and failing on those would make the test brittle. Instead
+    we scope the assertion to messages that mention the flag name.
+    """
+    # Default state — flag not set at all.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        with caplog.at_level(logging.WARNING, logger="quire_server.main"):
+            _create_app()
+
+    leaked_warnings = [w for w in caught if "AI_METADATA_SERVER_LOOKUP_ENABLED" in str(w.message)]
+    assert not leaked_warnings, (
+        "DeprecationWarning about the metadata fallback fired when the flag "
+        f"was disabled: {[str(w.message) for w in leaked_warnings]}"
+    )
+    leaked_logs = [
+        r
+        for r in caplog.records
+        if r.name == "quire_server.main" and "AI_METADATA_SERVER_LOOKUP_ENABLED" in r.getMessage()
+    ]
+    assert not leaked_logs, (
+        "logging.warning about the metadata fallback fired when the flag "
+        f"was disabled: {[r.getMessage() for r in leaked_logs]}"
+    )
+
+
+def test_metadata_fallback_flag_explicit_false_emits_no_notice(monkeypatch, caplog):
+    """Explicit `false` should behave identically to the unset default."""
+    monkeypatch.setenv("QUIRE_SERVER_AI_METADATA_SERVER_LOOKUP_ENABLED", "false")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        with caplog.at_level(logging.WARNING, logger="quire_server.main"):
+            _create_app()
+
+    leaked_warnings = [w for w in caught if "AI_METADATA_SERVER_LOOKUP_ENABLED" in str(w.message)]
+    leaked_logs = [
+        r
+        for r in caplog.records
+        if r.name == "quire_server.main" and "AI_METADATA_SERVER_LOOKUP_ENABLED" in r.getMessage()
+    ]
+    assert not leaked_warnings and not leaked_logs


### PR DESCRIPTION
Implements **task S-4 (rescoped)** of Phase 0.

## Rescope rationale
The original S-4 brief was "deprecate legacy server-pulls-from-calibre-web config flags." S-2's investigation found there is **no library-pull endpoint** in the current OSS server (the only outbound calibre-web call is Basic-auth validation, which stays). Per Architect consult, S-4 was rescoped to formalize the **AI metadata fallback** deprecation lifecycle — the genuine pull-ish behavior in the codebase that the spec's "deprecation window" wording was reaching for.

## Spec sections
- Architectural changes → Push-model API (last bullet — 2-minor-release deprecation window)
- Build sequence → Phase 0 item (2)

See `docs/superpowers/specs/2026-05-22-quire-monetization-design.md` in the repo.

## Files changed
- `server/quire_server/config.py` — docstring on `ai_metadata_server_lookup_enabled` marks it deprecated since this release, removal after 2 minor releases.
- `server/quire_server/main.py` — startup `logging.warning` + `warnings.warn(DeprecationWarning)` fire once when the flag is `True`. Skipped when AI is disabled or flag is `False`.
- `server/quire_server/api/ai.py` — emits an RFC 8594 `Deprecation: true` response header on `/ai/v1/insight/request` when the fallback was actually used.
- `server/tests/unit/test_main_deprecations.py` — new test file (174 lines) covering: warning fires under flag=True, doesn't fire under flag=False, doesn't fire when AI disabled, and the per-response header behavior.
- `server/README.md` — deprecation block added.
- `docs/sync-api.md` — push-model end-to-end note + flag deprecation (D-1 will expand).

## Verification
Local: `cd server && uv run ruff check . && uv run ruff format --check . && uv run pytest -q` all pass (per agent report; CI re-runs on this PR).

## Out of scope (intentional)
- `CalibreWebBasicAuth` is **not** deprecated — it remains the OSS default auth backend.
- `QUIRE_SERVER_AI_AUTH_MODE=token` is handled by sibling task X-2 (PR #55).
- The fallback code path is **not removed**, only warned.

## Stacking
Stacked on PR #50 (S-3, which introduced the flag) → PR #47 (F-1). The PR's GitHub diff will include S-3's and F-1's changes until they merge.