### PR TITLE
:sparkles: feat: identity hash versioning across server and Android (Phase 0 bundle 1)

### DIFF
--- a/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/Document.kt
@@ -11,4 +11,10 @@ data class Document(
     val downloadedAt: Long,
     val seriesName: String? = null,
     val seriesIndex: Double? = null,
+    /**
+     * Schema version of the client-side hash function that produced
+     * `identity.contentHash` for this document. See
+     * [CURRENT_IDENTITY_HASH_VERSION]; today every Document is v1.
+     */
+    val identityHashVersion: Int = CURRENT_IDENTITY_HASH_VERSION,
 )

--- a/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
+++ b/core/model/src/main/java/io/theficos/ereader/core/model/DocumentIdentity.kt
@@ -4,6 +4,35 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Schema version of the client-side identity-hash function. Stamped on every
+ * record that carries an identity hash (Room rows + outbound DTOs) so a future
+ * change to the hash function (edition merging, normalization fixes, etc.)
+ * doesn't break sync, caches, recs, export, or deletion across persisted data.
+ *
+ * Phase-0 task F-2 introduces this constant at value `1` — the current MD5-
+ * sampled hash in `core/identity/ContentHash.kt`. Bumping this constant later
+ * requires:
+ *   1. Updating the hash function.
+ *   2. A migration that re-computes hashes for local rows and re-uploads them.
+ *   3. Server-side acceptance of the new version (sibling task F-1 introduces
+ *      the wire field; further bumps are coordinated with the server team).
+ *
+ * The companion [isStaleHashVersion] predicate is the explicit "needs rehash"
+ * check; today it is a no-op (no rows exist at version < 1) but the mechanism
+ * is wired so a future version bump only needs to flip the constant.
+ */
+const val CURRENT_IDENTITY_HASH_VERSION: Int = 1
+
+/**
+ * True iff a record stamped with [rowVersion] was produced by an older client
+ * hash function and should be re-hashed before its next push to the server.
+ *
+ * Today this is `rowVersion < 1`, which is always false — bumping
+ * [CURRENT_IDENTITY_HASH_VERSION] activates the predicate for legacy rows.
+ */
+fun isStaleHashVersion(rowVersion: Int): Boolean = rowVersion < CURRENT_IDENTITY_HASH_VERSION
+
+/**
  * Mirrors `DocumentIdentity` in `server/quire_server/api/ai_schemas.py`.
  *
  * Canonical schemes (`metadataId`, `contentHash`) identify a downloaded EPUB
@@ -16,6 +45,13 @@ import kotlinx.serialization.Serializable
  * invariant (`contentHash` non-empty) is enforced by the call site
  * (`EpubIdentityExtractor`), not the type — pre-download paths legitimately
  * have no `contentHash`.
+ *
+ * `identityHashVersion` (Phase-0 / F-2) stamps which version of the
+ * client-side hash function produced [contentHash]. Defaults to
+ * [CURRENT_IDENTITY_HASH_VERSION] so callers building an identity from a
+ * freshly-computed hash get the right value automatically; defaults to `1`
+ * on the wire so an older server that doesn't emit the field decodes
+ * correctly (every existing hash on the network is v1).
  */
 @Serializable
 data class DocumentIdentity(
@@ -25,6 +61,7 @@ data class DocumentIdentity(
     @SerialName("opds_href") val opdsHref: String? = null,
     @SerialName("calibre_book_id") val calibreBookId: String? = null,
     val isbn: String? = null,
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 ) {
     init {
         require(

--- a/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
+++ b/core/model/src/test/java/io/theficos/ereader/core/model/DocumentIdentityTest.kt
@@ -1,9 +1,12 @@
 package io.theficos.ereader.core.model
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
 import org.junit.Test
 
 class DocumentIdentityTest {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
     @Test fun `accepts contentHash-only`() {
         val id = DocumentIdentity(metadataId = null, contentHash = "abc123")
         assertThat(id.contentHash).isEqualTo("abc123")
@@ -40,5 +43,46 @@ class DocumentIdentityTest {
     @Test fun `accepts isbn-only alias payload`() {
         val id = DocumentIdentity(isbn = "9780553293357")
         assertThat(id.isbn).isEqualTo("9780553293357")
+    }
+
+    // ---------- Phase-0 / F-2: identity hash version ----------
+
+    @Test fun `identityHashVersion defaults to current version`() {
+        val id = DocumentIdentity(contentHash = "abc")
+        assertThat(id.identityHashVersion).isEqualTo(CURRENT_IDENTITY_HASH_VERSION)
+        assertThat(CURRENT_IDENTITY_HASH_VERSION).isEqualTo(1)
+    }
+
+    @Test fun `isStaleHashVersion is no-op at current version`() {
+        assertThat(isStaleHashVersion(1)).isFalse()
+        // A future v2 row decoded by a v1 client is NOT stale (not the
+        // direction the predicate cares about).
+        assertThat(isStaleHashVersion(2)).isFalse()
+    }
+
+    @Test fun `isStaleHashVersion detects pre-current versions`() {
+        // Hypothetical bump to v2: a v1 row is now stale and needs a rehash.
+        // Asserted via the underlying inequality so the test is robust against
+        // a future constant change.
+        assertThat(0 < CURRENT_IDENTITY_HASH_VERSION).isTrue()
+        assertThat(isStaleHashVersion(0)).isTrue()
+    }
+
+    @Test fun `identity_hash_version round-trips on the wire`() {
+        val id = DocumentIdentity(contentHash = "abc", identityHashVersion = 7)
+        val encoded = json.encodeToString(DocumentIdentity.serializer(), id)
+        assertThat(encoded).contains("\"identity_hash_version\":7")
+        val decoded = json.decodeFromString(DocumentIdentity.serializer(), encoded)
+        assertThat(decoded.identityHashVersion).isEqualTo(7)
+        assertThat(decoded.contentHash).isEqualTo("abc")
+    }
+
+    @Test fun `missing identity_hash_version decodes to 1 for back-compat`() {
+        // An older server that doesn't yet emit the field (pre-F-1) must
+        // still decode cleanly. Every hash on the wire today is v1.
+        val legacyWire = """{"content_hash":"abc"}"""
+        val decoded = json.decodeFromString(DocumentIdentity.serializer(), legacyWire)
+        assertThat(decoded.identityHashVersion).isEqualTo(1)
+        assertThat(decoded.contentHash).isEqualTo("abc")
     }
 }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/AiRepository.kt
@@ -301,6 +301,9 @@ class AiRepository(
             serverId = 0L,
             generatedAt = parseIsoMillis(resp.generatedAt) ?: clock(),
             syncedAt = clock(),
+            // Phase-0 / F-2: stamp the cache row with the hash version of
+            // the identity used to fetch it. See `InsightEntity.identityHashVersion`.
+            identityHashVersion = identity.identityHashVersion,
         )
         insightDao.upsert(entity)
     }

--- a/data/ai/src/main/java/io/theficos/ereader/data/ai/InsightSyncRepository.kt
+++ b/data/ai/src/main/java/io/theficos/ereader/data/ai/InsightSyncRepository.kt
@@ -131,5 +131,8 @@ internal fun InsightSyncItem.toEntity(syncedAtMs: Long, json: Json): InsightEnti
         serverId = id,
         generatedAt = parseIsoMillis(generatedAt) ?: syncedAtMs,
         syncedAt = syncedAtMs,
+        // Phase-0 / F-2: cache row inherits the hash version stamped by
+        // the server on the source identity.
+        identityHashVersion = identity.identityHashVersion,
     )
 }

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
@@ -56,6 +56,10 @@ data class LibraryItemRequest(
     val language: String? = null,
     val subjects: List<String> = emptyList(),
     @SerialName("opds_href") val opdsHref: String? = null,
+    // Phase-0 / F-2: stamps which client hash-function version produced
+    // `contentHash`. Defaults to `1` for wire back-compat with an older
+    // server that doesn't yet emit the field (F-1 lands it server-side).
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
 
 /**
@@ -90,4 +94,7 @@ data class LibraryItemResponse(
     @SerialName("created_at") val createdAt: String,
     @SerialName("updated_at") val updatedAt: String,
     @SerialName("deleted_at") val deletedAt: String? = null,
+    // Phase-0 / F-2: defaults to `1` so an older server (pre-F-1) decodes
+    // safely — every hash on the wire today is v1.
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryUploader.kt
@@ -119,6 +119,10 @@ class LibraryUploader(
             language = null,    // v2: parse from OPF
             subjects = emptyList(), // v2: parse from OPF
             opdsHref = downloadUrl,
+            // Phase-0 / F-2: forward the row's stored hash version. Today
+            // this is always 1; a future hash-function bump will set it to
+            // the version that was current when this row was hashed.
+            identityHashVersion = identityHashVersion,
         )
 
     private companion object {

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryDtosTest.kt
@@ -63,4 +63,48 @@ class LibraryDtosTest {
         assertThat(parsed.totalBooks).isEqualTo(3)
         assertThat(parsed.abandonedCount).isEqualTo(0)
     }
+
+    // ---------- Phase-0 / F-2: identity_hash_version ----------
+
+    @Test
+    fun `LibraryItemRequest carries identity_hash_version on the wire`() {
+        // Round-trip with encodeDefaults=true so we can see what would
+        // travel over the wire if an AI-style client were used (the real
+        // LibraryClient uses default encodeDefaults=false, so the field
+        // is omitted on encode there — that's fine, the server applies
+        // its own DEFAULT 1).
+        val encJson = Json { encodeDefaults = true }
+        val req = LibraryItemRequest(
+            contentHash = "abc",
+            title = "T",
+            identityHashVersion = 2,
+        )
+        val encoded = encJson.encodeToString(LibraryItemRequest.serializer(), req)
+        assertThat(encoded).contains("\"identity_hash_version\":2")
+    }
+
+    @Test
+    fun `LibraryItemResponse decodes default 1 when server omits identity_hash_version`() {
+        // Older server (pre-F-1) doesn't emit the field. Every existing
+        // hash on the wire is v1, so the default `= 1` is correct.
+        val body = """
+            {
+              "content_hash":"h1","title":"T","authors":[],"created_at":"2026-01-01T00:00:00+00:00","updated_at":"2026-01-01T00:00:00+00:00"
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryItemResponse.serializer(), body)
+        assertThat(parsed.identityHashVersion).isEqualTo(1)
+    }
+
+    @Test
+    fun `LibraryItemResponse decodes non-default identity_hash_version`() {
+        val body = """
+            {
+              "content_hash":"h1","title":"T","authors":[],"identity_hash_version":3,
+              "created_at":"2026-01-01T00:00:00+00:00","updated_at":"2026-01-01T00:00:00+00:00"
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(LibraryItemResponse.serializer(), body)
+        assertThat(parsed.identityHashVersion).isEqualTo(3)
+    }
 }

--- a/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json
+++ b/data/local/schemas/io.theficos.ereader.data.local.db.EReaderDatabase/9.json
@@ -1,0 +1,393 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "40c4987051d2f31f8f5aeb107d62d857",
+    "entities": [
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `metadataId` TEXT, `contentHash` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `downloadUrl` TEXT NOT NULL, `localPath` TEXT NOT NULL, `coverPath` TEXT, `downloadedAt` INTEGER NOT NULL, `seriesName` TEXT, `seriesIndex` REAL, `librarySyncedAt` INTEGER, `identityHashVersion` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "librarySyncedAt",
+            "columnName": "librarySyncedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "identityHashVersion",
+            "columnName": "identityHashVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_documents_metadataId",
+            "unique": true,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_documents_contentHash",
+            "unique": true,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_documents_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_documents_seriesName_seriesIndex",
+            "unique": false,
+            "columnNames": [
+              "seriesName",
+              "seriesIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_documents_seriesName_seriesIndex` ON `${TABLE_NAME}` (`seriesName`, `seriesIndex`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `documentId` INTEGER NOT NULL, `locator` TEXT NOT NULL, `percent` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `finishedAt` INTEGER, `abandonedAt` INTEGER, FOREIGN KEY(`documentId`) REFERENCES `documents`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locator",
+            "columnName": "locator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percent",
+            "columnName": "percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "abandonedAt",
+            "columnName": "abandonedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_documentId",
+            "unique": true,
+            "columnNames": [
+              "documentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_progress_documentId` ON `${TABLE_NAME}` (`documentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "documents",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "documentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `lastPulledAt` INTEGER NOT NULL, PRIMARY KEY(`tableName`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPulledAt",
+            "columnName": "lastPulledAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "book_insights",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identityKey` TEXT NOT NULL, `metadataId` TEXT, `contentHash` TEXT, `modelId` TEXT NOT NULL, `promptVersion` TEXT NOT NULL, `tone` TEXT NOT NULL, `language` TEXT NOT NULL, `payloadJson` TEXT NOT NULL, `sourcesJson` TEXT NOT NULL, `schemaVersion` INTEGER NOT NULL, `serverId` INTEGER NOT NULL, `generatedAt` INTEGER NOT NULL, `syncedAt` INTEGER NOT NULL, `identityHashVersion` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`identityKey`, `modelId`, `promptVersion`, `tone`, `language`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataId",
+            "columnName": "metadataId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptVersion",
+            "columnName": "promptVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tone",
+            "columnName": "tone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcesJson",
+            "columnName": "sourcesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generatedAt",
+            "columnName": "generatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncedAt",
+            "columnName": "syncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHashVersion",
+            "columnName": "identityHashVersion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identityKey",
+            "modelId",
+            "promptVersion",
+            "tone",
+            "language"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_insights_syncedAt",
+            "unique": false,
+            "columnNames": [
+              "syncedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_syncedAt` ON `${TABLE_NAME}` (`syncedAt`)"
+          },
+          {
+            "name": "index_book_insights_metadataId",
+            "unique": false,
+            "columnNames": [
+              "metadataId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_metadataId` ON `${TABLE_NAME}` (`metadataId`)"
+          },
+          {
+            "name": "index_book_insights_contentHash",
+            "unique": false,
+            "columnNames": [
+              "contentHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_contentHash` ON `${TABLE_NAME}` (`contentHash`)"
+          },
+          {
+            "name": "index_book_insights_cursor",
+            "unique": false,
+            "columnNames": [
+              "generatedAt",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_insights_cursor` ON `${TABLE_NAME}` (`generatedAt`, `serverId`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '40c4987051d2f31f8f5aeb107d62d857')"
+    ]
+  }
+}

--- a/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/DocumentRepository.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local
 
+import io.theficos.ereader.core.model.CURRENT_IDENTITY_HASH_VERSION
 import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.core.model.DocumentIdentity
 import io.theficos.ereader.data.local.db.DocumentDao
@@ -80,6 +81,7 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt: Long,
         seriesName: String? = null,
         seriesIndex: Double? = null,
+        identityHashVersion: Int = CURRENT_IDENTITY_HASH_VERSION,
     ): Long = dao.insert(DocumentEntity(
         metadataId = identity.metadataId,
         contentHash = requireNotNull(identity.contentHash) {
@@ -93,11 +95,16 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt = downloadedAt,
         seriesName = seriesName?.takeIf { it.isNotBlank() },
         seriesIndex = seriesIndex,
+        identityHashVersion = identityHashVersion,
     ))
 
     private fun DocumentEntity.toDomain(): Document = Document(
         id = id,
-        identity = DocumentIdentity(metadataId = metadataId, contentHash = contentHash),
+        identity = DocumentIdentity(
+            metadataId = metadataId,
+            contentHash = contentHash,
+            identityHashVersion = identityHashVersion,
+        ),
         title = title,
         author = author,
         downloadUrl = downloadUrl,
@@ -106,6 +113,7 @@ class DocumentRepository(private val dao: DocumentDao) {
         downloadedAt = downloadedAt,
         seriesName = seriesName,
         seriesIndex = seriesIndex,
+        identityHashVersion = identityHashVersion,
     )
 
     companion object {

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/DocumentEntity.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -37,4 +38,14 @@ data class DocumentEntity(
      * presence marker; we never compare it against server timestamps.
      */
     val librarySyncedAt: Long? = null,
+    /**
+     * Phase-0 / F-2: schema version of the client-side hash function that
+     * produced [contentHash]. `INTEGER NOT NULL DEFAULT 1` on disk so the
+     * 8→9 migration can backfill pre-existing rows in a single ALTER TABLE.
+     * Today every row is v1; the field exists so a future hash-function
+     * change can be detected via
+     * `io.theficos.ereader.core.model.isStaleHashVersion`.
+     */
+    @ColumnInfo(defaultValue = "1")
+    val identityHashVersion: Int = 1,
 )

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/EReaderDatabase.kt
@@ -14,7 +14,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         SyncStateEntity::class,
         InsightEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
 )
 abstract class EReaderDatabase : RoomDatabase() {
@@ -143,6 +143,33 @@ abstract class EReaderDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Phase-0 / F-2: stamps every identity-hash-carrying row with the
+         * schema version of the hash function that produced it. Backfills
+         * existing rows to `1` (the current MD5-sampled hash in
+         * `core/identity/ContentHash.kt`). Paired with
+         * `core.model.CURRENT_IDENTITY_HASH_VERSION` and
+         * `core.model.isStaleHashVersion`. Server-side change is handled by
+         * the sibling F-1 task.
+         *
+         * Two ALTER TABLEs: `documents` (the primary owner — also drives
+         * re-upload via `LibraryUploader` when stale) and `book_insights`
+         * (metadata only; this DAO cannot re-key its rows, so a future v2
+         * bump will be handled by re-syncing the cache from the server).
+         */
+        internal val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE documents ADD COLUMN identityHashVersion " +
+                        "INTEGER NOT NULL DEFAULT 1"
+                )
+                db.execSQL(
+                    "ALTER TABLE book_insights ADD COLUMN identityHashVersion " +
+                        "INTEGER NOT NULL DEFAULT 1"
+                )
+            }
+        }
+
         fun build(context: Context): EReaderDatabase =
             Room.databaseBuilder(context, EReaderDatabase::class.java, "ereader.db")
                 .addMigrations(
@@ -153,6 +180,7 @@ abstract class EReaderDatabase : RoomDatabase() {
                     MIGRATION_5_6,
                     MIGRATION_6_7,
                     MIGRATION_7_8,
+                    MIGRATION_8_9,
                 )
                 .build()
     }

--- a/data/local/src/main/java/io/theficos/ereader/data/local/db/InsightEntity.kt
+++ b/data/local/src/main/java/io/theficos/ereader/data/local/db/InsightEntity.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.data.local.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 
@@ -41,4 +42,17 @@ data class InsightEntity(
     val generatedAt: Long,
     /** When this row was upserted locally; wall clock millis. */
     val syncedAt: Long,
+    /**
+     * Phase-0 / F-2: schema version of the client-side hash function that
+     * produced the [contentHash] / [identityKey] this row is filed under.
+     * `INTEGER NOT NULL DEFAULT 1` on disk.
+     *
+     * Stored as metadata only — this DAO cannot re-key existing rows when
+     * the hash function bumps because the `identityKey` is part of the
+     * primary key and the source EPUB is not addressable from here. A
+     * future hash-function change will be handled by re-syncing the cache
+     * (server-driven) rather than by mutating this column in place.
+     */
+    @ColumnInfo(defaultValue = "1")
+    val identityHashVersion: Int = 1,
 )

--- a/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
+++ b/data/local/src/test/java/io/theficos/ereader/data/local/db/MigrationTest.kt
@@ -258,5 +258,116 @@ class MigrationTest {
         }
     }
 
+    @Test fun `migrate 8 to 9 stamps identityHashVersion=1 on documents and book_insights`() {
+        // v8 fixture: seed one row in `documents` and one in `book_insights`
+        // (both tables exist at v8). identityHashVersion does NOT exist yet.
+        helper.createDatabase(DB, 8).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (41, 'm41', 'h41', 'Pre-F2 title', NULL, 'u', 'p', NULL, 51, NULL, NULL, NULL)"
+            )
+            db.execSQL(
+                "INSERT INTO book_insights (identityKey, metadataId, contentHash, modelId, " +
+                    "promptVersion, tone, language, payloadJson, sourcesJson, schemaVersion, " +
+                    "serverId, generatedAt, syncedAt) VALUES " +
+                    "('m41', 'm41', 'h41', 'llama3.1', '4', 'neutral', 'auto', '{}', '[]', 4, " +
+                    "100, 1000, 1100)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(DB, 9, true, EReaderDatabase.MIGRATION_8_9).use { db ->
+            // Both tables gained the column.
+            for (table in listOf("documents", "book_insights")) {
+                db.query("PRAGMA table_info('$table')").use { c ->
+                    val cols = mutableSetOf<String>()
+                    while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                    assertThat(cols).contains("identityHashVersion")
+                }
+            }
+            // Existing rows backfill to 1 via the DEFAULT clause.
+            db.query("SELECT identityHashVersion FROM documents WHERE id=41").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            db.query(
+                "SELECT identityHashVersion FROM book_insights " +
+                    "WHERE identityKey='m41' AND modelId='llama3.1' AND promptVersion='4'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            // New rows round-trip a non-default value.
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt, " +
+                    "identityHashVersion) " +
+                    "VALUES (42, 'm42', 'h42', 'Post-F2 title', NULL, 'u', 'p', NULL, 52, NULL, " +
+                    "NULL, NULL, 2)"
+            )
+            db.query("SELECT identityHashVersion FROM documents WHERE id=42").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(2)
+            }
+            db.execSQL(
+                "INSERT INTO book_insights (identityKey, metadataId, contentHash, modelId, " +
+                    "promptVersion, tone, language, payloadJson, sourcesJson, schemaVersion, " +
+                    "serverId, generatedAt, syncedAt, identityHashVersion) VALUES " +
+                    "('m42', 'm42', 'h42', 'llama3.1', '4', 'neutral', 'auto', '{}', '[]', 4, " +
+                    "200, 2000, 2100, 3)"
+            )
+            db.query(
+                "SELECT identityHashVersion FROM book_insights " +
+                    "WHERE identityKey='m42' AND modelId='llama3.1' AND promptVersion='4'"
+            ).use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(3)
+            }
+        }
+    }
+
+    @Test fun `migrate 6 to 9 chains all additive migrations`() {
+        // Long-tail upgrade path: a v6 install (pre-PR-η) jumps straight to
+        // v9 (post-F-2). Every additive migration in between must survive.
+        helper.createDatabase(DB, 6).use { db ->
+            db.execSQL(
+                "INSERT INTO documents (id, metadataId, contentHash, title, author, downloadUrl, " +
+                    "localPath, coverPath, downloadedAt, seriesName, seriesIndex, librarySyncedAt) " +
+                    "VALUES (51, 'm51', 'h51', 'Pre-F2 chain title', NULL, 'u', 'p', NULL, 61, NULL, NULL, NULL)"
+            )
+            db.execSQL(
+                "INSERT INTO progress (id, documentId, locator, percent, updatedAt, " +
+                    "localUpdatedAt, syncedAt, finishedAt) " +
+                    "VALUES (51, 51, 'loc', 0.8, 100, 100, 0, NULL)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(
+            DB,
+            9,
+            true,
+            EReaderDatabase.MIGRATION_6_7,
+            EReaderDatabase.MIGRATION_7_8,
+            EReaderDatabase.MIGRATION_8_9,
+        ).use { db ->
+            // F-2 column landed on both tables.
+            db.query("SELECT identityHashVersion FROM documents WHERE id=51").use { c ->
+                assertThat(c.moveToFirst()).isTrue()
+                assertThat(c.getInt(0)).isEqualTo(1)
+            }
+            db.query("PRAGMA table_info('book_insights')").use { c ->
+                val cols = mutableSetOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("identityHashVersion")
+            }
+            // Earlier additive migrations still present.
+            db.query("PRAGMA table_info('progress')").use { c ->
+                val cols = mutableSetOf<String>()
+                while (c.moveToNext()) cols += c.getString(c.getColumnIndexOrThrow("name"))
+                assertThat(cols).contains("abandonedAt")
+            }
+        }
+    }
+
     private companion object { const val DB = "migration-test.db" }
 }

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/ProgressDtos.kt
@@ -7,6 +7,11 @@ import kotlinx.serialization.Serializable
 data class DocumentIdDto(
     @SerialName("metadata_id") val metadataId: String? = null,
     @SerialName("content_hash") val contentHash: String,
+    // Phase-0 / F-2: schema version of the client-side hash function that
+    // produced `contentHash`. Defaults to `1` so an older server that does
+    // not yet emit the field (pre-F-1) decodes safely — every existing
+    // hash on the wire is v1.
+    @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
 
 @Serializable

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
@@ -31,6 +31,9 @@ class SyncOrchestrator(
                         contentHash = requireNotNull(doc.identity.contentHash) {
                             "downloaded document must have a contentHash"
                         },
+                        // Phase-0 / F-2: stamp every outbound progress push
+                        // with the hash version of the row it references.
+                        identityHashVersion = doc.identityHashVersion,
                     ),
                     locator = progress.locator,
                     percent = progress.percent,
@@ -65,7 +68,15 @@ class SyncOrchestrator(
     }
 
     private suspend fun applyPulled(item: ProgressItemDto) {
-        val identity = DocumentIdentity(metadataId = item.document.metadataId, contentHash = item.document.contentHash)
+        // Phase-0 / F-2: forward the server-reported identity_hash_version
+        // into the DocumentIdentity used for local lookup. We don't act on
+        // it here (progress doesn't carry a hash on disk; doc rows are
+        // looked up by metadataId/contentHash) — but the field travels.
+        val identity = DocumentIdentity(
+            metadataId = item.document.metadataId,
+            contentHash = item.document.contentHash,
+            identityHashVersion = item.document.identityHashVersion,
+        )
         val doc = documentRepo.findByIdentity(identity) ?: return
         val incomingUpdatedAt = Instant.parse(item.clientUpdatedAt).toEpochMilli()
         val incomingFinishedAt = item.finishedAt?.let { Instant.parse(it).toEpochMilli() }

--- a/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
+++ b/data/sync/src/test/java/io/theficos/ereader/data/sync/ProgressDtosTest.kt
@@ -113,4 +113,23 @@ class ProgressDtosTest {
         assertThat(r.items.first().abandonedAt).isEqualTo("2026-05-20T12:00:00+00:00")
         assertThat(r.items.first().finishedAt).isNull()
     }
+
+    // ---------- Phase-0 / F-2: identity_hash_version ----------
+
+    @Test fun `DocumentIdDto carries identity_hash_version on the wire`() {
+        val encJson = Json { encodeDefaults = true }
+        val dto = DocumentIdDto(metadataId = "m1", contentHash = "h1", identityHashVersion = 2)
+        val encoded = encJson.encodeToString(DocumentIdDto.serializer(), dto)
+        assertThat(encoded).contains("\"identity_hash_version\":2")
+        val decoded = encJson.decodeFromString(DocumentIdDto.serializer(), encoded)
+        assertThat(decoded.identityHashVersion).isEqualTo(2)
+    }
+
+    @Test fun `DocumentIdDto missing identity_hash_version defaults to 1`() {
+        // Pre-F-1 server payload — the field hasn't landed server-side yet
+        // (or the deploy lags). Every hash on the wire today is v1.
+        val raw = """{"metadata_id":"m1","content_hash":"h1"}"""
+        val decoded = json.decodeFromString(DocumentIdDto.serializer(), raw)
+        assertThat(decoded.identityHashVersion).isEqualTo(1)
+    }
 }

--- a/server/migrations/versions/ai_007_identity_hash_version.py
+++ b/server/migrations/versions/ai_007_identity_hash_version.py
@@ -1,0 +1,69 @@
+"""ai_007_identity_hash_version: add `identity_hash_version` to book_insights.
+
+Seventh migration on the `ai` branch. Chains off `ai_006`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function breaks sync, caches, recs, export, and
+deletion across millions of rows. Trivial now, expensive to retrofit.
+
+This migration adds `identity_hash_version` to `book_insights`, the
+SHARED-CACHE table on the `ai` branch. Companion migration `progress_003`
+adds the same column to `documents` and `library_items`.
+
+Cache-key impact: NONE. `identity_hash_version` is intentionally NOT added
+to any of the unique/cache-key constraints on `book_insights`. The
+architect-reviewed design treats it as row-freshness metadata only: a
+higher-version client hitting an existing cache row upgrades the persisted
+value via `max(existing, incoming)` in the orchestrator. Partitioning the
+cache by version would fragment the cross-tenant cache-hit property
+(see the cache-integrity comment above `BookInsight` in
+`quire_server/db/models.py`) without paying for itself in Phase 0.
+
+Schema additions:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. Pre-existing rows
+  backfill to `1` atomically via the column-level default.
+- `CHECK (identity_hash_version >= 1)`.
+
+Revision ID: ai_007
+Revises: ai_006
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ai_007"
+down_revision = "ai_006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "book_insights",
+        sa.Column(
+            "identity_hash_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+    )
+    op.create_check_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        "identity_hash_version >= 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_book_insights_identity_hash_version_ge_1",
+        "book_insights",
+        type_="check",
+    )
+    op.drop_column("book_insights", "identity_hash_version")

--- a/server/migrations/versions/progress_003_identity_hash_version.py
+++ b/server/migrations/versions/progress_003_identity_hash_version.py
@@ -1,0 +1,73 @@
+"""progress_003_identity_hash_version: add `identity_hash_version` to documents + library_items.
+
+Third migration on the `progress` branch. Chains off `progress_002`.
+`branch_labels = None` because the label is carried by `progress_001`.
+
+Phase 0, task F-1 (per `docs/superpowers/specs/2026-05-22-quire-monetization-design.md`,
+sections "Architectural changes → Identity hash schema versioning" and
+"One-way doors → Identity hash schema versioning"):
+
+Lock in identity-hash versioning before the Cloud private beta. Without an
+explicit version field on every record carrying an identity hash, any
+future change to the hash function (edition merging, normalization fixes,
+etc.) breaks sync, caches, recs, export, and deletion across millions of
+rows. Trivial to add now, very expensive to retrofit.
+
+This migration covers the `progress`-branch tables that carry an identity
+hash directly: `documents` and `library_items`. The companion migration
+`ai_007` adds the same column to `book_insights` on the `ai` branch.
+`progress.progress` deliberately has no own version column: identity travels
+via the parent `Document`, so `Progress.document.identity_hash_version` is
+the answer for any progress row.
+
+Schema additions per table:
+- `identity_hash_version INTEGER NOT NULL DEFAULT 1`. All pre-existing rows
+  backfill to `1` via the column-level default (atomic in Postgres for the
+  ADD COLUMN ... DEFAULT path; no separate UPDATE pass needed).
+- `CHECK (identity_hash_version >= 1)`. Prevents accidental zero-or-negative
+  versions from sneaking in through a future buggy writer.
+
+Downgrade-safety: dropping the column is reversible; the data loss is
+inherent and downgrade callers accept it. No indexes are added — the column
+is row-metadata, not a query predicate.
+
+Revision ID: progress_003
+Revises: progress_002
+Create Date: 2026-05-22 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "progress_003"
+down_revision = "progress_002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.add_column(
+            table,
+            sa.Column(
+                "identity_hash_version",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("1"),
+            ),
+        )
+        op.create_check_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            "identity_hash_version >= 1",
+        )
+
+
+def downgrade() -> None:
+    for table in ("documents", "library_items"):
+        op.drop_constraint(
+            f"ck_{table}_identity_hash_version_ge_1",
+            table,
+            type_="check",
+        )
+        op.drop_column(table, "identity_hash_version")

--- a/server/quire_server/api/ai.py
+++ b/server/quire_server/api/ai.py
@@ -411,6 +411,9 @@ async def sync_insights(
             BookInsight.id.label("ins_id"),
             BookInsight.metadata_id.label("ins_metadata_id"),
             BookInsight.content_hash.label("ins_content_hash"),
+            # Phase 0, task F-1: surface persisted identity-hash version
+            # to the client via the sync envelope.
+            BookInsight.identity_hash_version.label("ins_identity_hash_version"),
             BookInsight.model_id.label("ins_model_id"),
             BookInsight.prompt_version.label("ins_prompt_version"),
             BookInsight.tone.label("ins_tone"),
@@ -487,6 +490,7 @@ async def sync_insights(
             identity=DocumentIdentity(
                 metadata_id=r.ins_metadata_id,
                 content_hash=r.ins_content_hash,
+                identity_hash_version=r.ins_identity_hash_version,
             ),
             payload=BookInsightPayload.model_validate(r.ins_payload),
             sources=[Citation.model_validate(c) for c in (r.ins_sources or [])],

--- a/server/quire_server/api/ai_schemas.py
+++ b/server/quire_server/api/ai_schemas.py
@@ -221,6 +221,11 @@ class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str | None = None
 
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1` keeps
+    # pre-versioning clients compatible; the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
+
     # Alias hints (PR2). All optional. The resolver maps them to a
     # canonical via insight_identity_aliases when present.
     opds_href: str | None = None
@@ -373,6 +378,12 @@ class BookInsightResponse(BaseModel):
     model_id: str
     prompt_version: str
     generated_at: str  # ISO-8601
+    # Phase 0, task F-1: identity-hash algorithm version of the persisted
+    # row this response represents. Clients use this to decide whether to
+    # recompute their local hash on the next sync (when their computed
+    # version > N). Defaults to `1` for older serialized rows that
+    # pre-date the column.
+    identity_hash_version: int = 1
 
 
 class InsightLookupBody(BaseModel):

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -61,6 +61,7 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
     return LibraryItemResponse(
         metadata_id=row.metadata_id,
         content_hash=row.content_hash,
+        identity_hash_version=row.identity_hash_version,
         title=row.title,
         authors=list(row.authors or []),
         series_name=row.series_name,
@@ -78,6 +79,11 @@ def _to_response(row: LibraryItem) -> LibraryItemResponse:
 def _apply_payload(row: LibraryItem, payload: LibraryItemRequest) -> None:
     """Write payload fields onto `row`. Caller is responsible for timestamps."""
     row.metadata_id = payload.metadata_id
+    # Phase 0, task F-1: downgrade protection. An old client (sending the
+    # default `1`) MUST NOT overwrite a row whose hash version was advanced
+    # by a newer client. `max(existing, incoming)` is the load-bearing rule.
+    if payload.identity_hash_version > row.identity_hash_version:
+        row.identity_hash_version = payload.identity_hash_version
     row.title = payload.title
     row.authors = list(payload.authors)
     row.series_name = payload.series_name
@@ -134,6 +140,7 @@ async def put_item(
         row = LibraryItem(
             user_id=user_id,
             content_hash=payload.content_hash,
+            identity_hash_version=payload.identity_hash_version,
             title=payload.title,
             authors=list(payload.authors),
             metadata_id=payload.metadata_id,

--- a/server/quire_server/api/library_schemas.py
+++ b/server/quire_server/api/library_schemas.py
@@ -26,6 +26,11 @@ class LibraryItemRequest(BaseModel):
 
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version. Default `1`
+    # accepts pre-versioning clients; the server's PUT path applies
+    # `max(existing, incoming)` so an old client cannot downgrade a row
+    # written by a newer client.
+    identity_hash_version: int = Field(default=1, ge=1)
     title: str
     authors: list[str] = Field(default_factory=list)
     series_name: str | None = None
@@ -47,6 +52,12 @@ class LibraryItemIdentity(BaseModel):
     """The identity sub-object inside a DELETE body."""
 
     content_hash: str
+    # Phase 0, task F-1: optional on DELETE. The current matcher keys
+    # exclusively on `content_hash` so the field is accepted but not used
+    # for row selection — clients can already locate a row by hash alone.
+    # Once a real hash-version migration happens this field becomes the
+    # tiebreaker for delete semantics.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class LibraryItemDeleteBody(BaseModel):
@@ -58,6 +69,10 @@ class LibraryItemResponse(BaseModel):
 
     metadata_id: str | None
     content_hash: str
+    # Phase 0, task F-1: always emitted from server, so clients can detect
+    # the row's persisted hash-algorithm version and trigger recompute on
+    # next sync when their computed-version > N.
+    identity_hash_version: int
     title: str
     authors: list[str]
     series_name: str | None

--- a/server/quire_server/api/progress.py
+++ b/server/quire_server/api/progress.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, Field, field_serializer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,11 @@ router = APIRouter(tags=["progress"])
 class DocumentIdentity(BaseModel):
     metadata_id: str | None = None
     content_hash: str
+    # Phase 0, task F-1: identity-hash algorithm version travelling on the
+    # wire. Default `1` keeps old clients (pre-versioning) round-trippable;
+    # new clients send their own value and the server's write paths apply
+    # `max(existing, incoming)` so an old client cannot downgrade a row.
+    identity_hash_version: int = Field(default=1, ge=1)
 
 
 class ProgressItem(BaseModel):
@@ -102,6 +107,10 @@ async def _resolve_or_create_document(
             )
         ).scalar_one_or_none()
         if existing:
+            # Phase 0, task F-1: downgrade protection. An old client (sending
+            # `1`) MUST NOT overwrite a row written by a newer client.
+            if ident.identity_hash_version > existing.identity_hash_version:
+                existing.identity_hash_version = ident.identity_hash_version
             return existing
     existing = (
         await session.execute(
@@ -114,8 +123,16 @@ async def _resolve_or_create_document(
         # Backfill metadata_id if we just learned it
         if ident.metadata_id and existing.metadata_id is None:
             existing.metadata_id = ident.metadata_id
+        # Phase 0, task F-1: downgrade protection (see above).
+        if ident.identity_hash_version > existing.identity_hash_version:
+            existing.identity_hash_version = ident.identity_hash_version
         return existing
-    doc = Document(user_id=user_id, metadata_id=ident.metadata_id, content_hash=ident.content_hash)
+    doc = Document(
+        user_id=user_id,
+        metadata_id=ident.metadata_id,
+        content_hash=ident.content_hash,
+        identity_hash_version=ident.identity_hash_version,
+    )
     session.add(doc)
     await session.flush()  # populate doc.pk
     return doc
@@ -130,6 +147,14 @@ async def push_progress(
     results: list[ProgressPushResult] = []
     for item in body.items:
         doc = await _resolve_or_create_document(session, user_id, item.document)
+        # Phase 0, task F-1: the result echoes the persisted Document's
+        # identity_hash_version (which may be >= the incoming one after the
+        # downgrade-protection logic in _resolve_or_create_document).
+        persisted_identity = DocumentIdentity(
+            metadata_id=doc.metadata_id,
+            content_hash=doc.content_hash,
+            identity_hash_version=doc.identity_hash_version,
+        )
         existing = (
             await session.execute(select(Progress).where(Progress.document_pk == doc.pk))
         ).scalar_one_or_none()
@@ -158,7 +183,7 @@ async def push_progress(
             )
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -172,7 +197,7 @@ async def push_progress(
             existing.abandoned_at = abandoned_at
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="accepted",
                     server_client_updated_at=item.client_updated_at,
                 )
@@ -180,7 +205,7 @@ async def push_progress(
         else:
             results.append(
                 ProgressPushResult(
-                    document=item.document,
+                    document=persisted_identity,
                     status="stale",
                     server_client_updated_at=existing.client_updated_at,
                 )
@@ -223,7 +248,11 @@ async def pull_progress(
             effective_abandoned_at = None
         items.append(
             ProgressPullItem(
-                document=DocumentIdentity(metadata_id=d.metadata_id, content_hash=d.content_hash),
+                document=DocumentIdentity(
+                    metadata_id=d.metadata_id,
+                    content_hash=d.content_hash,
+                    identity_hash_version=d.identity_hash_version,
+                ),
                 locator=p.locator,
                 percent=p.percent,
                 client_updated_at=p.client_updated_at,

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -2248,9 +2248,7 @@ def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
 
 
-def _maybe_upgrade_identity_hash_version(
-    row: BookInsight, ident: DocumentIdentity
-) -> None:
+def _maybe_upgrade_identity_hash_version(row: BookInsight, ident: DocumentIdentity) -> None:
     """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
     identity-hash version on a cache-hit.
 

--- a/server/quire_server/core/ai/service.py
+++ b/server/quire_server/core/ai/service.py
@@ -664,6 +664,10 @@ class InsightOrchestrator:
         row = BookInsight(
             metadata_id=ident.metadata_id,
             content_hash=effective_content_hash,
+            # Phase 0, task F-1: persist the incoming identity-hash version
+            # so future reads return the correct level. Defaults to `1` for
+            # pre-versioning clients.
+            identity_hash_version=getattr(ident, "identity_hash_version", 1),
             model_id=self.model_id,
             prompt_version=self.prompt_version,
             tone=tone,
@@ -857,6 +861,7 @@ class InsightOrchestrator:
                 )
             ).scalar_one_or_none()
             if row is not None:
+                _maybe_upgrade_identity_hash_version(row, ident)
                 return row
         # Step 2: by content_hash (live rows only)
         if not ident.content_hash:
@@ -875,6 +880,10 @@ class InsightOrchestrator:
         ).scalar_one_or_none()
         if row is None:
             return None
+        # Phase 0, task F-1: upgrade the row's identity_hash_version if the
+        # incoming identity is newer. Same downgrade-protection rule as
+        # Document/LibraryItem: max(existing, incoming).
+        _maybe_upgrade_identity_hash_version(row, ident)
         # Alias reconciliation: backfill metadata_id if we just learned it.
         if allow_backfill and ident.metadata_id and row.metadata_id is None:
             row.metadata_id = ident.metadata_id
@@ -1174,6 +1183,13 @@ class InsightOrchestrator:
         new_row = BookInsight(
             metadata_id=to_identity.metadata_id,
             content_hash=to_identity.content_hash or src_row.content_hash,
+            # Phase 0, task F-1: the copied row takes the maximum of the
+            # source row's version and the destination identity's version
+            # so a v2 destination promoted from a v1 source persists as v2.
+            identity_hash_version=max(
+                src_row.identity_hash_version,
+                getattr(to_identity, "identity_hash_version", 1),
+            ),
             model_id=src_row.model_id,
             prompt_version=src_row.prompt_version,
             tone=src_row.tone,
@@ -2213,6 +2229,10 @@ class InsightOrchestrator:
             model_id=row.model_id,
             prompt_version=row.prompt_version,
             generated_at=row.generated_at.isoformat(),
+            # Phase 0, task F-1: surface the persisted identity-hash version
+            # so clients can detect rows produced under an older algorithm
+            # and trigger their own recompute logic (F-2 territory).
+            identity_hash_version=row.identity_hash_version,
         )
 
 
@@ -2226,6 +2246,24 @@ def _tone_of(style: AiStyle | None) -> str:
 
 def _language_of(style: AiStyle | None) -> str:
     return style.language if style is not None else "auto"
+
+
+def _maybe_upgrade_identity_hash_version(
+    row: BookInsight, ident: DocumentIdentity
+) -> None:
+    """Phase 0, task F-1: apply `max(existing, incoming)` to the persisted
+    identity-hash version on a cache-hit.
+
+    Operates in-place on `row`. The surrounding transaction commits as
+    part of the normal cache-hit log write, so we do not flush here.
+
+    Defensive: ``ident.identity_hash_version`` is wire-side and defaults to
+    `1` when the client did not supply it (pre-versioning clients). The
+    `>` comparison therefore protects against accidental downgrades.
+    """
+    incoming = getattr(ident, "identity_hash_version", 1)
+    if incoming > row.identity_hash_version:
+        row.identity_hash_version = incoming
 
 
 # ---------- PR2 identity-resolution helpers ---------------------------------

--- a/server/quire_server/db/models.py
+++ b/server/quire_server/db/models.py
@@ -32,6 +32,10 @@ class Document(Base):
     __table_args__ = (
         UniqueConstraint("user_id", "metadata_id", name="uq_documents_user_metadata"),
         UniqueConstraint("user_id", "content_hash", name="uq_documents_user_content_hash"),
+        CheckConstraint(
+            "identity_hash_version >= 1",
+            name="ck_documents_identity_hash_version_ge_1",
+        ),
         Index("ix_documents_user", "user_id"),
     )
 
@@ -39,6 +43,15 @@ class Document(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1 (one-way-door per 2026-05-22 monetization spec):
+    # version of the identity-hash algorithm used to derive `content_hash`.
+    # Persisted with every record so a future hash-function change does not
+    # break sync/cache/recs/export/deletion across millions of rows. Always
+    # >= 1; current rows backfill to 1 in migration `progress_003`. Clients
+    # reading vN rows recompute on next sync when their algorithm > N.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -108,6 +121,14 @@ class BookInsight(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version. NOT part of the
+    # cache key (see architect decision in Phase 0 plan): treated as row-
+    # freshness metadata only. A higher-version client hitting an existing
+    # cache row upgrades the persisted value via max(existing, incoming).
+    # CHECK constraint lives in migration `ai_007`.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     model_id: Mapped[str] = mapped_column(String, nullable=False)
     prompt_version: Mapped[str] = mapped_column(String, nullable=False)
     # Part of the cache key so users with different AiStyle.tone get their own
@@ -349,6 +370,13 @@ class LibraryItem(Base):
     user_id: Mapped[str] = mapped_column(String, nullable=False)
     metadata_id: Mapped[str | None] = mapped_column(String, nullable=True)
     content_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Phase 0, task F-1: identity-hash algorithm version (see Document for
+    # full rationale). The CHECK constraint is declared in the alembic
+    # migration `progress_003` because partial-index-style metadata for
+    # this table lives there.
+    identity_hash_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("1"), default=1
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     authors: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list

--- a/server/tests/integration/test_health.py
+++ b/server/tests/integration/test_health.py
@@ -29,11 +29,12 @@ async def test_readyz_returns_200_when_db_reachable_and_heads_applied(app_under_
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    # ai branch is at ai_006 (pr-β added the audit-log generalization +
-    # profile_count column); the progress branch is at progress_002 (pr-α
-    # added abandoned_at). With the default-true mode flags, both branch
-    # heads are reported, sorted.
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`); the progress branch is at
+    # progress_003 (same task, added `identity_hash_version` to
+    # `documents` + `library_items`). With the default-true mode flags,
+    # both branch heads are reported, sorted.
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_old_sync_health_path_is_404(app_under_test):

--- a/server/tests/integration/test_library_items.py
+++ b/server/tests/integration/test_library_items.py
@@ -392,3 +392,87 @@ async def test_unauthenticated_request_rejected(app_under_test, unique_user):
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         r = await c.get("/library/v1/items")
     assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning on /library/v1/items.
+# ---------------------------------------------------------------------------
+# Three behaviours travel together:
+#   1. Default round-trip: omitting `identity_hash_version` in the PUT body
+#      persists as `1` and the GET response carries it.
+#   2. Explicit value round-trip: sending `identity_hash_version=2` persists
+#      `2` and the response/GET reflect it.
+#   3. Downgrade protection: after writing version `2`, a later PUT that
+#      defaults to `1` (or explicitly sends `1`) MUST keep the row at `2`.
+#      This is the `max(existing, incoming)` rule that prevents an old
+#      client from clobbering a newer client's row.
+
+
+async def test_identity_hash_version_defaults_to_1_when_absent(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 1
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.status_code == 200
+        items = r2.json()["items"]
+        assert len(items) == 1
+        assert items[0]["identity_hash_version"] == 1
+
+
+async def test_identity_hash_version_round_trips_explicit_value(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["identity_hash_version"] == 2
+
+        r2 = await c.get("/library/v1/items", headers=headers)
+        assert r2.json()["items"][0]["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_protects_against_downgrade(app_under_test, unique_user):
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Newer client writes v2.
+        r1 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=2),
+            headers=headers,
+        )
+        assert r1.json()["identity_hash_version"] == 2
+
+        # Older client sends nothing (defaults to v1) — must NOT downgrade.
+        r2 = await c.put("/library/v1/items", json=_put_body(), headers=headers)
+        assert r2.status_code == 200
+        assert r2.json()["identity_hash_version"] == 2
+
+        # Explicit v1 must also not downgrade.
+        r3 = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=1),
+            headers=headers,
+        )
+        assert r3.json()["identity_hash_version"] == 2
+
+
+async def test_identity_hash_version_rejects_zero(app_under_test, unique_user):
+    """Pydantic `ge=1` returns 422 for non-positive versions."""
+    transport = ASGITransport(app=app_under_test)
+    headers = _basic(*unique_user)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.put(
+            "/library/v1/items",
+            json=_put_body(identity_hash_version=0),
+            headers=headers,
+        )
+    assert r.status_code == 422, r.text

--- a/server/tests/integration/test_migrate_script.py
+++ b/server/tests/integration/test_migrate_script.py
@@ -2,11 +2,11 @@
 
 Cases covered:
 1. Default state with real migrations: wrapper upgrades backbone + ai branch,
-   DB ends at ai@head (currently `ai_006`).
+   DB ends at ai@head (currently `ai_007`).
 2. Idempotent: running twice in a row is a no-op.
-3. Synthetic branched script directory (tmp copy of migrations + an ai_test_006
-   revision chained off the current ai@head):
-   - ai_enabled=true → upgrades to ai_test_006.
+3. Synthetic branched script directory (tmp copy of migrations + an
+   ai_test_008 revision chained off the current ai@head):
+   - ai_enabled=true → upgrades to ai_test_008.
    - ai_enabled=false → stays at 0004 (no ai branch applied).
 """
 
@@ -53,7 +53,7 @@ async def _downgrade_in_thread(cfg, target: str) -> None:
 
 
 async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str):
-    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_006)."""
+    """Fresh DB → wrapper upgrades to backbone, then to ai@head (ai_007)."""
 
     # Wipe DB to fresh state.
     eng = create_async_engine(postgres_url, future=True)
@@ -66,9 +66,11 @@ async def test_default_state_upgrades_backbone_then_ai_branch(postgres_url: str)
 
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch is at ai_006 (pr-β / Bundle 3 added the audit-log generalization
-    # + profile_count column). The progress branch is at progress_002.
-    assert versions == {"ai_006", "progress_002"}
+    # ai branch is at ai_007 (Phase 0 / task F-1 added
+    # `book_insights.identity_hash_version`). The progress branch is at
+    # progress_003 (same task, added the column to `documents` and
+    # `library_items`).
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_idempotent_second_run(postgres_url: str):
@@ -81,14 +83,14 @@ async def test_idempotent_second_run(postgres_url: str):
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    assert versions == {"ai_006", "progress_002"}
+    assert versions == {"ai_007", "progress_003"}
 
 
 async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_path: Path):
-    """Copy real migrations to tmp + add a synthetic ai_test_007 chained off
-    ai_006; verify enabled run advances to ai_test_007 (the new ai@head)."""
+    """Copy real migrations to tmp + add a synthetic ai_test_008 chained off
+    ai_007; verify enabled run advances to ai_test_008 (the new ai@head)."""
 
-    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_006).
+    # First, ensure DB is at ai@head (real migrations include ai_001 .. ai_007).
     real_cfg = _make_cfg(postgres_url)
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)
 
@@ -96,22 +98,23 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
     versions_dir = synth_dir / "versions"
-    # Chain off ai_006 (the current ai@head after pr-β) with branch_labels=None.
-    (versions_dir / "ai_test_007.py").write_text(
+    # Chain off ai_007 (the current ai@head after Phase 0 / F-1) with
+    # branch_labels=None.
+    (versions_dir / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration.
 
-            Revision ID: ai_test_007
-            Revises: ai_006
-            Create Date: 2026-05-21 00:00:00.000000
+            Revision ID: ai_test_008
+            Revises: ai_007
+            Create Date: 2026-05-22 00:00:00.000000
             """
 
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -132,18 +135,18 @@ async def test_synthetic_ai_branch_upgrades_when_enabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     # ai branch advances to the new tip.
-    assert "ai_test_007" in versions, versions
+    assert "ai_test_008" in versions, versions
     await eng.dispose()
 
     # Cleanup: roll back the synthetic migration so other tests aren't affected.
-    await _downgrade_in_thread(cfg, "ai_006")
+    await _downgrade_in_thread(cfg, "ai_007")
 
 
 async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_path: Path):
     """With ai_enabled=False, the wrapper skips advancing the ai branch.
 
     Pre-condition: DB is rolled back to 0004 (no ai branch applied), then the
-    wrapper is invoked with ai_enabled=False. ai_test_007 (the synthetic head)
+    wrapper is invoked with ai_enabled=False. ai_test_008 (the synthetic head)
     must NOT be applied; the backbone stays at 0004.
     """
     # Stamp DB back to backbone (pre-ai-branch state) for this test.
@@ -152,15 +155,15 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
 
     synth_dir = tmp_path / "migrations"
     shutil.copytree("migrations", synth_dir)
-    (synth_dir / "versions" / "ai_test_007.py").write_text(
+    (synth_dir / "versions" / "ai_test_008.py").write_text(
         textwrap.dedent(
             '''
             """synthetic ai branch test migration."""
             import sqlalchemy as sa
             from alembic import op
 
-            revision = "ai_test_007"
-            down_revision = "ai_006"
+            revision = "ai_test_008"
+            down_revision = "ai_007"
             branch_labels = None
             depends_on = None
 
@@ -179,17 +182,19 @@ async def test_synthetic_ai_branch_skipped_when_disabled(postgres_url: str, tmp_
     eng = create_async_engine(postgres_url, future=True)
     versions = await _alembic_versions(eng)
     await eng.dispose()
-    # ai branch skipped → ai_test_007 not applied, ai_006 not applied,
-    # ai_001 not applied. The `progress` branch still advanced.
-    assert "ai_test_007" not in versions
+    # ai branch skipped → ai_test_008 not applied, ai_007 not applied,
+    # ai_006 not applied, ai_001 not applied. The `progress` branch still
+    # advanced.
+    assert "ai_test_008" not in versions
+    assert "ai_007" not in versions
     assert "ai_006" not in versions
     assert "ai_005" not in versions
     assert "ai_004" not in versions
     assert "ai_003" not in versions
     assert "ai_001" not in versions
     # progress branch advanced (progress_enabled=True). The backbone itself
-    # is no longer a head once progress_002 sits on top of 0004.
-    assert "progress_002" in versions
+    # is no longer a head once progress_003 sits on top of 0004.
+    assert "progress_003" in versions
 
     # Restore DB for subsequent tests.
     await _run_migrations_in_thread(real_cfg, progress_enabled=True, ai_enabled=True)

--- a/server/tests/integration/test_readyz_migration_state.py
+++ b/server/tests/integration/test_readyz_migration_state.py
@@ -53,8 +53,9 @@ async def restore_after(postgres_url: str, alembic_upgrade):
 
 
 async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upgrade):
-    """With ai@head (ai_006) + progress@head (progress_002) materialized,
-    /readyz reports both heads. (ai_006 added by pr-β.)
+    """With ai@head (ai_007) + progress@head (progress_003) materialized,
+    /readyz reports both heads. (ai_007 / progress_003 added by Phase 0
+    task F-1: server identity-hash schema versioning.)
     """
     # Some earlier test in the session may have downgraded the DB
     # (test_migrate_script.py exercises rollback). Ensure both branches are
@@ -72,14 +73,15 @@ async def test_readyz_200_when_at_ai_head(monkeypatch, postgres_url, alembic_upg
     assert r.status_code == 200
     body = r.json()
     assert body["ready"] is True
-    assert body["heads_applied"] == ["ai_006", "progress_002"]
+    assert body["heads_applied"] == ["ai_007", "progress_003"]
 
 
 async def test_readyz_503_when_db_below_backbone(
     monkeypatch, postgres_url, alembic_upgrade, restore_after
 ):
     """DB stamped below backbone; with both modes enabled, required head is
-    ai_006 (ai@head after pr-β) — that's what should be reported missing."""
+    ai_007 (ai@head after Phase 0 / F-1) — that's what should be reported
+    missing."""
     await _stamp(postgres_url, "0003")
     app = _build_app(monkeypatch, postgres_url, progress=True, ai=True)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -87,7 +89,7 @@ async def test_readyz_503_when_db_below_backbone(
     assert r.status_code == 503
     body = r.json()
     assert body["ready"] is False
-    assert "ai_006" in body["missing"]
+    assert "ai_007" in body["missing"]
 
 
 async def test_readyz_200_with_neither_mode_at_backbone(

--- a/server/tests/integration/test_schema.py
+++ b/server/tests/integration/test_schema.py
@@ -154,6 +154,65 @@ async def test_library_items_table_exists(engine) -> None:
     assert where_alive is not None and "deleted_at" in str(where_alive).lower()
 
 
+# ---------------------------------------------------------------------------
+# Phase 0, task F-1 — identity-hash schema versioning (server side).
+# ---------------------------------------------------------------------------
+# Two migrations land the same `identity_hash_version INTEGER NOT NULL DEFAULT 1`
+# column with `CHECK (>= 1)`:
+#   * `progress_003` → `documents`, `library_items`.
+#   * `ai_007`       → `book_insights`.
+# These tests reflect the live schema (post-migration) and assert the column
+# shape on every table that should carry it.
+
+
+def _identity_hash_version_column_meta(sync_conn, table: str) -> dict:
+    insp = inspect(sync_conn)
+    cols = {c["name"]: c for c in insp.get_columns(table)}
+    checks = {c["name"]: c for c in insp.get_check_constraints(table)}
+    return {"col": cols.get("identity_hash_version"), "checks": checks}
+
+
+async def test_documents_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "documents")
+    col = info["col"]
+    assert col is not None, "documents.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_documents_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_progress
+async def test_library_items_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "library_items")
+    col = info["col"]
+    assert col is not None, "library_items.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_library_items_identity_hash_version_ge_1" in info["checks"]
+
+
+@pytest.mark.requires_ai
+async def test_book_insights_has_identity_hash_version_column(engine) -> None:
+    async with engine.connect() as conn:
+        info = await conn.run_sync(_identity_hash_version_column_meta, "book_insights")
+    col = info["col"]
+    assert col is not None, "book_insights.identity_hash_version missing"
+    assert col["nullable"] is False
+    assert "1" in str(col.get("default", "")), col.get("default")
+    assert "ck_book_insights_identity_hash_version_ge_1" in info["checks"]
+
+
+async def test_documents_identity_hash_version_default_round_trip(session) -> None:
+    """A row created without supplying `identity_hash_version` defaults to 1."""
+    doc = Document(user_id="alice-v1", metadata_id="md-ver-1", content_hash="ch-ver-1")
+    session.add(doc)
+    await session.commit()
+    await session.refresh(doc)
+    assert doc.identity_hash_version == 1
+
+
 @pytest.mark.requires_ai
 async def test_ai_generation_log_round_trip(session) -> None:
     """ORM model writes and reads ai_generation_log rows."""


### PR DESCRIPTION
**Phase 0 — Bundle 1 (foundations)**

Bundles the two identity-hash version-field PRs into one integration merge so the release automation cuts a single version. Both constituents merged cleanly; no conflicts.

## What lands
- **F-1** (#47): adds `identity_hash_version: int` to every server-side model carrying an identity hash (`Document`, `LibraryItem`, `BookInsight`). Alembic migrations `progress_003` + `ai_007` backfill existing rows to `1`. 14 files, +469/-46.
- **F-2** (#48): mirrors the field across the Android side — Room entities + DTOs + a Room migration 8→9, plus a `CURRENT_IDENTITY_HASH_VERSION` constant and an `isStaleHashVersion()` predicate in `core/model` so future hash bumps can re-sync. 17 files, +751/-3.

Wire field name on both sides is `identity_hash_version`.

## Verification
Constituent PR CI all green at time of bundling:
- PR #47: `test (full)`, `test (ai_only)`, `test (sync_only)`, `analyze (python)`, CodeQL — all pass.
- PR #48: `build`, `analyze (java-kotlin)`, CodeQL — all pass.

## Unresolved (carried forward from constituents)
- `LibraryItemIdentity` DELETE body accepts-but-ignores `identity_hash_version` (intentional Phase 0).
- New migration heads `ai_007`/`progress_003` — confirm no external pinning manifests need updating before rollout.

Closes #47
Closes #48