### PR TITLE
:sparkles: feat(android): wire sideload import to library-mirror push

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -12,6 +12,7 @@ import io.theficos.ereader.data.library.LibraryClient
 import io.theficos.ereader.data.library.LibraryUploader
 import io.theficos.ereader.data.library.sync.CredentialsProvider
 import io.theficos.ereader.data.library.sync.LibraryMirrorPushDependencies
+import io.theficos.ereader.data.library.sync.LibraryMirrorPushScheduler
 import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.ProgressRepository
 import io.theficos.ereader.data.local.db.EReaderDatabase
@@ -157,6 +158,11 @@ class AppContainer(context: Context) {
             runCatching {
                 SyncEnqueuer.enqueue(appContext, expedited = true, replaceExisting = true)
             }
+            // Wire the freshly-imported book into the library-mirror push
+            // path right away instead of waiting for the next periodic
+            // run. The scheduler coalesces concurrent enqueues, so this
+            // is safe to call alongside the periodic worker.
+            runCatching { LibraryMirrorPushScheduler.enqueueAfterLibraryChange(appContext) }
         },
     )
 


### PR DESCRIPTION
Phase 0 cross-bundle wire-up follow-up.

A-3 (sideload pipeline, in Phase 0 bundle 3) exposed an `onSuccessfulImport` hook on `SideloadImporter`. A-4 (WorkManager library-mirror push, also in bundle 3) exposed `LibraryMirrorPushScheduler.enqueueAfterLibraryChange(context)` as the entry point for an out-of-band push. They were intentionally not connected in the bundle PR so the diff stayed close to the constituent PRs.

Now that both are on `main`, wire them: a freshly imported book triggers an expedited library-mirror push instead of waiting for the next periodic run.

## Diff
One file, six lines added.

```
+ import LibraryMirrorPushScheduler
+ runCatching { LibraryMirrorPushScheduler.enqueueAfterLibraryChange(appContext) }
```

The scheduler coalesces concurrent enqueues, so this is safe alongside the periodic worker. Existing `onSuccessfulImport` actions (sync-cursor reset + expedited sync enqueue) are preserved.

## Verification
- `scripts/dgradle :app:testDebugUnitTest :app:assembleDebug` — BUILD SUCCESSFUL.