### PR TITLE
feat: optional Quire server URL override for split deployments

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -51,6 +51,15 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import io.theficos.ereader.data.local.db.ProgressDao
 
+/**
+ * URL that sync/library/AI clients should target. For [AccountCredentials.Basic]
+ * with a [AccountCredentials.Basic.quireServerUrl] override, return the
+ * override; otherwise fall back to [AccountCredentials.baseUrl]. Bearer
+ * accounts have no override in tier-1.
+ */
+private fun io.theficos.ereader.auth.AccountCredentials.quireServerOrPrimaryUrl(): String =
+    (this as? io.theficos.ereader.auth.AccountCredentials.Basic)?.quireServerUrl ?: baseUrl
+
 class AppContainer(context: Context) {
     private val appContext = context.applicationContext
 
@@ -80,7 +89,7 @@ class AppContainer(context: Context) {
     val welcomePreferencesStore = WelcomePreferencesStore(appContext)
 
     val syncClient: SyncClient = SyncClient(
-        baseUrlProvider = { credentialStore.getAccount()?.baseUrl },
+        baseUrlProvider = { credentialStore.getAccount()?.quireServerOrPrimaryUrl() },
         okHttp = opdsHttp.okHttp,
     )
     val syncOrchestrator: SyncOrchestrator = SyncOrchestrator(
@@ -92,7 +101,7 @@ class AppContainer(context: Context) {
     )
 
     val aiClient: AiClient = AiClient(
-        baseUrlProvider = { credentialStore.getAccount()?.baseUrl },
+        baseUrlProvider = { credentialStore.getAccount()?.quireServerOrPrimaryUrl() },
         http = opdsHttp.okHttp,
     )
     val insightDao = db.insightDao()
@@ -117,7 +126,7 @@ class AppContainer(context: Context) {
         credentialStore.getAccount()?.subject
 
     val libraryClient: LibraryClient = LibraryClient(
-        baseUrlProvider = { credentialStore.getAccount()?.baseUrl },
+        baseUrlProvider = { credentialStore.getAccount()?.quireServerOrPrimaryUrl() },
         http = opdsHttp.okHttp,
     )
 

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
@@ -119,6 +119,16 @@ fun SettingsScreen(
                     visualTransformation = PasswordVisualTransformation(),
                     modifier = Modifier.fillMaxWidth(),
                 )
+                OutlinedTextField(
+                    value = calibre.quireServerUrl,
+                    onValueChange = viewModel::onQuireServerUrlChange,
+                    label = { Text("Quire server URL (optional)") },
+                    placeholder = { Text("Same as calibre-web URL") },
+                    supportingText = {
+                        Text("Only set this if sync / AI run at a different address than your books.")
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
                 Button(
                     onClick = viewModel::saveCalibre,
                     enabled = calibre.baseUrl.isNotBlank() && calibre.username.isNotBlank() && calibre.password.isNotBlank(),

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
@@ -126,24 +126,33 @@ class SettingsViewModel(
     }
 
     private fun loadInitialCalibre(): CalibreUiState {
-        val creds = store.get()
+        val account = store.getAccount() as? io.theficos.ereader.auth.AccountCredentials.Basic
         return CalibreUiState(
-            baseUrl = creds?.baseUrl.orEmpty(),
-            username = creds?.username.orEmpty(),
-            password = creds?.password.orEmpty(),
-            saved = creds != null,
+            baseUrl = account?.baseUrl.orEmpty(),
+            username = account?.username.orEmpty(),
+            password = account?.password.orEmpty(),
+            quireServerUrl = account?.quireServerUrl.orEmpty(),
+            saved = account != null,
         )
     }
 
     fun onBaseUrlChange(value: String) { _calibre.value = _calibre.value.copy(baseUrl = value, saved = false) }
     fun onUsernameChange(value: String) { _calibre.value = _calibre.value.copy(username = value, saved = false) }
     fun onPasswordChange(value: String) { _calibre.value = _calibre.value.copy(password = value, saved = false) }
+    fun onQuireServerUrlChange(value: String) {
+        _calibre.value = _calibre.value.copy(quireServerUrl = value, saved = false)
+    }
 
     fun saveCalibre() {
         val s = _calibre.value
         if (s.baseUrl.isBlank() || s.username.isBlank() || s.password.isBlank()) return
         viewModelScope.launch {
-            store.put(CalibreCredentials(s.baseUrl.trim().trimEnd('/'), s.username, s.password))
+            store.saveBasicAccount(
+                baseUrl = s.baseUrl.trim().trimEnd('/'),
+                username = s.username,
+                password = s.password,
+                quireServerUrl = s.quireServerUrl.trim().trimEnd('/').takeIf { it.isNotBlank() },
+            )
             _calibre.value = s.copy(saved = true)
             _sync.value = _sync.value.copy(hasCredentials = true)
         }
@@ -242,5 +251,6 @@ data class CalibreUiState(
     val baseUrl: String,
     val username: String,
     val password: String,
+    val quireServerUrl: String,
     val saved: Boolean,
 )

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.theficos.ereader.auth.CalibreCredentialStore
-import io.theficos.ereader.auth.CalibreCredentials
 import io.theficos.ereader.data.ai.AiConfig
 import io.theficos.ereader.data.ai.AiHealthResponse
 import io.theficos.ereader.data.ai.AiPreferences

--- a/auth/src/main/java/io/theficos/ereader/auth/AccountCredentials.kt
+++ b/auth/src/main/java/io/theficos/ereader/auth/AccountCredentials.kt
@@ -28,15 +28,29 @@ sealed class AccountCredentials {
      */
     abstract val subject: String
 
+    /**
+     * Calibre-web style credentials (HTTP Basic).
+     *
+     * [quireServerUrl] optionally routes sync/library/AI calls to a different
+     * host than the OPDS catalog at [baseUrl]. Null means "use [baseUrl] for
+     * everything" (the common single-URL deployment). When set, both URLs
+     * share the same Basic credential — the operator is responsible for
+     * configuring quire-server's `QUIRE_SERVER_CWA_BASE_URL` to validate
+     * incoming Basic headers against the same calibre-web instance.
+     *
+     * See `docs/superpowers/split-server-urls.md` for the tiered scope and
+     * the deferred BEARER + separate-calibre-web case.
+     */
     data class Basic(
         override val baseUrl: String,
         val username: String,
         val password: String,
+        val quireServerUrl: String? = null,
     ) : AccountCredentials() {
         override val scheme: AuthScheme = AuthScheme.BASIC
         override val subject: String get() = username.lowercase()
         override fun toString(): String =
-            "AccountCredentials.Basic(baseUrl=$baseUrl, username=$username, password=***)"
+            "AccountCredentials.Basic(baseUrl=$baseUrl, username=$username, password=***, quireServerUrl=$quireServerUrl)"
     }
 
     data class Bearer(

--- a/auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt
+++ b/auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt
@@ -91,8 +91,18 @@ class CalibreCredentialStore(context: Context) {
      * Save a calibre-web style account (HTTP Basic). Replaces any
      * previously-stored account regardless of scheme. Blank values are
      * rejected at the API boundary.
+     *
+     * [quireServerUrl] is an optional override that routes sync/library/AI
+     * calls to a different host than the OPDS catalog at [baseUrl]. Pass
+     * null (or blank) to use [baseUrl] for everything. Tier-1 scope; see
+     * `docs/superpowers/split-server-urls.md`.
      */
-    fun saveBasicAccount(baseUrl: String, username: String, password: String) {
+    fun saveBasicAccount(
+        baseUrl: String,
+        username: String,
+        password: String,
+        quireServerUrl: String? = null,
+    ) {
         require(baseUrl.isNotBlank()) { "baseUrl must not be blank" }
         require(username.isNotBlank()) { "username must not be blank" }
         require(password.isNotBlank()) { "password must not be blank" }
@@ -100,6 +110,7 @@ class CalibreCredentialStore(context: Context) {
             baseUrl = baseUrl.trim().trimEnd('/'),
             username = username,
             password = password,
+            quireServerUrl = quireServerUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotBlank() },
         )
         persistAccount(account)
     }
@@ -151,6 +162,11 @@ class CalibreCredentialStore(context: Context) {
                         .putString(KEY_PASS, account.password)
                         .remove(KEY_EMAIL)
                         .remove(KEY_TOKEN)
+                    if (account.quireServerUrl != null) {
+                        editor.putString(KEY_QUIRE_SERVER_URL, account.quireServerUrl)
+                    } else {
+                        editor.remove(KEY_QUIRE_SERVER_URL)
+                    }
                 }
                 is AccountCredentials.Bearer -> {
                     editor
@@ -158,6 +174,7 @@ class CalibreCredentialStore(context: Context) {
                         .putString(KEY_TOKEN, account.token)
                         .remove(KEY_USER)
                         .remove(KEY_PASS)
+                        .remove(KEY_QUIRE_SERVER_URL)
                 }
             }
             val committed = editor.commit()
@@ -204,7 +221,8 @@ class CalibreCredentialStore(context: Context) {
             AuthScheme.BASIC -> {
                 val user = prefs.getString(KEY_USER, null) ?: return null
                 val pass = prefs.getString(KEY_PASS, null) ?: return null
-                AccountCredentials.Basic(baseUrl, user, pass)
+                val quireServerUrl = prefs.getString(KEY_QUIRE_SERVER_URL, null)
+                AccountCredentials.Basic(baseUrl, user, pass, quireServerUrl)
             }
             AuthScheme.BEARER -> {
                 val email = prefs.getString(KEY_EMAIL, null) ?: return null
@@ -227,5 +245,6 @@ class CalibreCredentialStore(context: Context) {
         const val KEY_PASS = "password"
         const val KEY_EMAIL = "email"
         const val KEY_TOKEN = "token"
+        const val KEY_QUIRE_SERVER_URL = "quire_server_url"
     }
 }

--- a/auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt
+++ b/auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt
@@ -202,4 +202,85 @@ class CalibreCredentialStoreTest {
         val bearer = AccountCredentials.Bearer("https://cloud", "a@b", "tok_secret_xyz")
         assertThat(bearer.toString()).doesNotContain("tok_secret_xyz")
     }
+
+    // ---------- Tier 1: optional Quire server URL override ----------
+
+    @Test fun `saveBasicAccount persists optional quireServerUrl`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBasicAccount(
+            baseUrl = "https://lib.example",
+            username = "alice",
+            password = "s3cret",
+            quireServerUrl = "https://quire.example",
+        )
+        val basic = store.getAccount() as AccountCredentials.Basic
+        assertThat(basic.quireServerUrl).isEqualTo("https://quire.example")
+        // Survives a fresh load (round-trips through EncryptedSharedPreferences).
+        val reread = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        val rereadBasic = reread.getAccount() as AccountCredentials.Basic
+        assertThat(rereadBasic.quireServerUrl).isEqualTo("https://quire.example")
+    }
+
+    @Test fun `saveBasicAccount without quireServerUrl stores null`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBasicAccount("https://lib.example", "alice", "s3cret")
+        val basic = store.getAccount() as AccountCredentials.Basic
+        assertThat(basic.quireServerUrl).isNull()
+    }
+
+    @Test fun `saveBasicAccount canonicalizes quireServerUrl trailing slash`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBasicAccount(
+            baseUrl = "https://lib.example",
+            username = "alice",
+            password = "s3cret",
+            quireServerUrl = "  https://quire.example/  ",
+        )
+        val basic = store.getAccount() as AccountCredentials.Basic
+        assertThat(basic.quireServerUrl).isEqualTo("https://quire.example")
+    }
+
+    @Test fun `blank quireServerUrl persists as null`() {
+        // Settings will pass "" when the user clears the field; treat that
+        // as "no override" rather than persisting an empty string.
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBasicAccount(
+            baseUrl = "https://lib.example",
+            username = "alice",
+            password = "s3cret",
+            quireServerUrl = "   ",
+        )
+        val basic = store.getAccount() as AccountCredentials.Basic
+        assertThat(basic.quireServerUrl).isNull()
+    }
+
+    @Test fun `switch to bearer removes quireServerUrl key`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBasicAccount("https://lib.example", "alice", "s3cret", "https://quire.example")
+        store.saveBearerAccount("https://cloud.quire.app", "alice@example.com", "tok_abc")
+        // Re-read from a fresh store. The override key must be gone — a future
+        // switch back to BASIC without an override must NOT resurrect it.
+        val reread = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        assertThat(reread.getAccount()).isInstanceOf(AccountCredentials.Bearer::class.java)
+        reread.saveBasicAccount("https://lib.example", "alice", "new-pw")
+        val basic = reread.getAccount() as AccountCredentials.Basic
+        assertThat(basic.quireServerUrl).isNull()
+    }
+
+    @Test fun `pre-tier-1 record without quireServerUrl key loads as null`() {
+        // Seed a BASIC account via the older 3-arg API (no override key written).
+        val seed = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        seed.clear()
+        seed.saveBasicAccount("https://lib.example", "alice", "s3cret")
+        // Fresh store load — quireServerUrl must surface as null, not as an
+        // empty string or a default-baseUrl fallback.
+        val reread = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        val basic = reread.getAccount() as AccountCredentials.Basic
+        assertThat(basic.quireServerUrl).isNull()
+    }
 }

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/AccountAuthInterceptor.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/AccountAuthInterceptor.kt
@@ -45,7 +45,7 @@ class AccountAuthInterceptor(
             return chain.proceed(request)
         }
         val account = accountProvider() ?: return chain.proceed(request)
-        if (!sameOrigin(account.baseUrl, request.url)) {
+        if (!isAllowedOrigin(account, request.url)) {
             return chain.proceed(request)
         }
         val headerValue = when (account) {
@@ -55,6 +55,21 @@ class AccountAuthInterceptor(
         return chain.proceed(
             request.newBuilder().header(HEADER_AUTHORIZATION, headerValue).build()
         )
+    }
+
+    /**
+     * Returns true when [requestUrl] targets either the primary [baseUrl] OR,
+     * for a [AccountCredentials.Basic] with an override, its [quireServerUrl].
+     * Bearer accounts have no override in tier-1; their check stays
+     * single-URL.
+     */
+    private fun isAllowedOrigin(
+        account: AccountCredentials,
+        requestUrl: HttpUrl,
+    ): Boolean {
+        if (sameOrigin(account.baseUrl, requestUrl)) return true
+        val override = (account as? AccountCredentials.Basic)?.quireServerUrl
+        return override != null && sameOrigin(override, requestUrl)
     }
 
     private fun basicHeader(account: AccountCredentials.Basic): String {

--- a/data/opds/src/test/java/io/theficos/ereader/data/opds/AccountAuthInterceptorTest.kt
+++ b/data/opds/src/test/java/io/theficos/ereader/data/opds/AccountAuthInterceptorTest.kt
@@ -162,4 +162,83 @@ class AccountAuthInterceptorTest {
             bearerServer.shutdown()
         }
     }
+
+    @Test fun `attaches basic header to override quireServerUrl host`() {
+        val quire = MockWebServer().apply { start() }
+        try {
+            quire.enqueue(MockResponse().setBody("ok"))
+            val provider = {
+                AccountCredentials.Basic(
+                    baseUrl = server.url("/").toString(),
+                    username = "alice",
+                    password = "s3cret",
+                    quireServerUrl = quire.url("/").toString(),
+                )
+            }
+            val client = OkHttpClient.Builder()
+                .addInterceptor(AccountAuthInterceptor(provider))
+                .build()
+            client.newCall(Request.Builder().url(quire.url("/ai/v1/config")).build())
+                .execute().close()
+
+            val recorded = quire.takeRequest()
+            val expected = "Basic " + Base64.getEncoder().encodeToString("alice:s3cret".toByteArray())
+            assertThat(recorded.getHeader("Authorization")).isEqualTo(expected)
+        } finally {
+            quire.shutdown()
+        }
+    }
+
+    @Test fun `still attaches header to primary baseUrl host when override set`() {
+        val quire = MockWebServer().apply { start() }
+        try {
+            server.enqueue(MockResponse().setBody("ok"))
+            val provider = {
+                AccountCredentials.Basic(
+                    baseUrl = server.url("/").toString(),
+                    username = "alice",
+                    password = "s3cret",
+                    quireServerUrl = quire.url("/").toString(),
+                )
+            }
+            val client = OkHttpClient.Builder()
+                .addInterceptor(AccountAuthInterceptor(provider))
+                .build()
+            client.newCall(Request.Builder().url(server.url("/opds")).build())
+                .execute().close()
+
+            val recorded = server.takeRequest()
+            val expected = "Basic " + Base64.getEncoder().encodeToString("alice:s3cret".toByteArray())
+            assertThat(recorded.getHeader("Authorization")).isEqualTo(expected)
+        } finally {
+            quire.shutdown()
+        }
+    }
+
+    @Test fun `does not attach to third foreign host even when override set`() {
+        val quire = MockWebServer().apply { start() }
+        val foreign = MockWebServer().apply { start() }
+        try {
+            foreign.enqueue(MockResponse().setBody("ok"))
+            val provider = {
+                AccountCredentials.Basic(
+                    baseUrl = server.url("/").toString(),
+                    username = "alice",
+                    password = "s3cret",
+                    quireServerUrl = quire.url("/").toString(),
+                )
+            }
+            val client = OkHttpClient.Builder()
+                .addInterceptor(AccountAuthInterceptor(provider))
+                .build()
+            client.newCall(Request.Builder().url(foreign.url("/cover.jpg")).build())
+                .execute().close()
+
+            val recorded = foreign.takeRequest()
+            assertThat(recorded.getHeader("Authorization")).isNull()
+        } finally {
+            quire.shutdown()
+            foreign.shutdown()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds an optional **Quire server URL** field to the Settings → calibre-web card. When set, sync / library / AI calls (`/sync/v1/*`, `/library/v1/*`, `/ai/v1/*`) route to that URL instead of the calibre-web URL. OPDS catalog browsing and EPUB downloads continue to use the calibre-web URL.

Covers the deployment where calibre-web and quire-server live at different addresses. The two services share a single calibre-web Basic credential (the operator is responsible for pointing quire-server's `QUIRE_SERVER_CWA_BASE_URL` at the same calibre-web instance). Onboarding (`ConnectServerScreen`) is unchanged — users with split deploys configure the override post-onboarding in Settings.

Scope notes (incl. deferred BEARER + separate-calibre-web case) are in `docs/superpowers/split-server-urls.md` (gitignored, local-only).

### What changed

- `AccountCredentials.Basic` gains nullable `quireServerUrl`. `Bearer` untouched.
- `CalibreCredentialStore` persists the override under key `quire_server_url`; missing key loads as `null` (back-compat preserved). BASIC → BEARER scheme switches remove the key.
- `AccountAuthInterceptor.isAllowedOrigin` now accepts requests targeting either the primary `baseUrl` or, for BASIC accounts, the override `quireServerUrl`. Foreign-host requests still receive no auth header.
- `AppContainer` routes `SyncClient` / `AiClient` / `LibraryClient` through a new `quireServerOrPrimaryUrl()` helper; `OpdsClient`, `BookDownloader`, and the catalog-insight stash watcher continue to use the primary `baseUrl`.
- Settings UI exposes the field with placeholder "Same as calibre-web URL" and helper text; the Save button does not gate on it.

## Test plan

- [x] `scripts/dgradle :auth:testDebugUnitTest` — persistence, canonicalization, blank-as-null, BASIC↔BEARER key cleanup, pre-tier-1 back-compat (6 new tests)
- [x] `scripts/dgradle :data:opds:testDebugUnitTest` — interceptor origin allowlist for override host + still-attaches for primary + foreign-host no-attach (3 new tests)
- [x] `scripts/dgradle :app:testDebugUnitTest`
- [x] `scripts/dgradle :app:assembleDebug`
- [ ] Manual smoke on device: configure split URLs in Settings; confirm OPDS browse still hits calibre-web and Sync/AI hit quire-server
- [ ] Manual: clear the override field, save, confirm sync/AI revert to the calibre-web URL