### PR TITLE
Unify /ai/v1 auth onto NativeAuth + Android session-expiry handling

### DIFF
--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -59,6 +59,19 @@ fun AppNavGraph(container: AppContainer) {
         hasAccount = container.credentialStore.getAccount() != null,
         welcomeCompleted = container.welcomePreferencesStore.isCompleted(),
     )
+    // Re-auth gating for NativeAuth (Bearer) sessions. The store raises this
+    // when the session token expires or a request comes back 401 — there's no
+    // refresh token, so the only recovery is signing in again. We probe expiry
+    // once on entry, then route to the connect screen whenever the signal
+    // flips true mid-session. A successful re-login clears the signal (the
+    // store resets it on save) and the connect screen navigates onward.
+    LaunchedEffect(Unit) { container.credentialStore.checkSessionExpiry() }
+    val needsReauth by container.credentialStore.needsReauth.collectAsState()
+    LaunchedEffect(needsReauth) {
+        if (needsReauth) {
+            nav.navigate("connect-server") { launchSingleTop = true }
+        }
+    }
     NavHost(navController = nav, startDestination = startDestination) {
         composable("welcome") {
             WelcomeScreen(

--- a/app/src/main/java/io/theficos/ereader/ui/onboarding/ConnectServerViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/onboarding/ConnectServerViewModel.kt
@@ -25,6 +25,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+import java.time.OffsetDateTime
 import java.util.Base64
 import java.util.concurrent.TimeUnit
 
@@ -112,7 +113,12 @@ class ConnectServerViewModel(
             }
             _state.value = when (result) {
                 is VerificationOutcome.OkBearer -> {
-                    credentialStore.saveBearerAccount(canonicalBaseUrl, email, result.token)
+                    credentialStore.saveBearerAccount(
+                        canonicalBaseUrl,
+                        email,
+                        result.token,
+                        result.expiresAtEpochMs,
+                    )
                     UiState.Completed
                 }
                 is VerificationOutcome.OkBasic -> error("unreachable in bearer flow")
@@ -181,13 +187,13 @@ class ConnectServerViewModel(
                 when (resp.code) {
                     200 -> {
                         val body = resp.body?.string().orEmpty()
-                        val token = parseLoginToken(body)
-                        if (token.isNullOrBlank()) {
+                        val parsed = parseLogin(body)
+                        if (parsed == null || parsed.token.isBlank()) {
                             VerificationOutcome.Failure(
                                 "Server returned 200 but the response didn't include a token.",
                             )
                         } else {
-                            VerificationOutcome.OkBearer(token)
+                            VerificationOutcome.OkBearer(parsed.token, parsed.expiresAtEpochMs)
                         }
                     }
                     401 -> VerificationOutcome.Failure("Email or password rejected by the server.")
@@ -204,9 +210,22 @@ class ConnectServerViewModel(
         }
     }
 
-    private fun parseLoginToken(body: String): String? = runCatching {
+    /** Token plus optional absolute expiry, parsed from a login response. */
+    private data class ParsedLogin(val token: String, val expiresAtEpochMs: Long?)
+
+    /**
+     * Parse `{"token": ..., "expires_at": ...}` from the login response.
+     * `expires_at` is an ISO-8601 instant (e.g. `2026-06-28T12:00:00+00:00`
+     * or `...Z`); an absent or unparseable value yields a null expiry, which
+     * the credential store treats as "expiry unknown" rather than failing the
+     * login. Returns null only when the body isn't a JSON object.
+     */
+    private fun parseLogin(body: String): ParsedLogin? = runCatching {
         val parsed = Json.parseToJsonElement(body) as? JsonObject ?: return null
-        (parsed["token"] as? JsonPrimitive)?.content
+        val token = (parsed["token"] as? JsonPrimitive)?.content ?: return null
+        val expiresAt = (parsed["expires_at"] as? JsonPrimitive)?.content
+            ?.let { raw -> runCatching { OffsetDateTime.parse(raw).toInstant().toEpochMilli() }.getOrNull() }
+        ParsedLogin(token, expiresAt)
     }.getOrNull()
 
     /** UI state. Sealed so the screen can `when`-exhaust render branches. */
@@ -221,7 +240,7 @@ class ConnectServerViewModel(
 
     private sealed class VerificationOutcome {
         object OkBasic : VerificationOutcome()
-        data class OkBearer(val token: String) : VerificationOutcome()
+        data class OkBearer(val token: String, val expiresAtEpochMs: Long?) : VerificationOutcome()
         data class Failure(val message: String) : VerificationOutcome()
     }
 

--- a/auth/src/main/java/io/theficos/ereader/auth/AccountCredentials.kt
+++ b/auth/src/main/java/io/theficos/ereader/auth/AccountCredentials.kt
@@ -53,14 +53,44 @@ sealed class AccountCredentials {
             "AccountCredentials.Basic(baseUrl=$baseUrl, username=$username, password=***, quireServerUrl=$quireServerUrl)"
     }
 
+    /**
+     * NativeAuth (`quire_server` / Quire Cloud) bearer-token credentials.
+     *
+     * [expiresAtEpochMs] is the absolute expiry of the session token, in
+     * Unix epoch milliseconds, as reported by the server's
+     * `POST /auth/v1/login` response (`expires_at`). It is **nullable** to
+     * cover two cases: legacy records persisted before expiry tracking
+     * existed, and login responses whose `expires_at` we could not parse.
+     * `null` means "expiry unknown" — callers must treat that as a
+     * still-usable token (fail-open) rather than as already-expired, since
+     * NativeAuth has no refresh endpoint and a spurious logout would be worse
+     * than letting the next request surface a real 401.
+     *
+     * NativeAuth issues opaque, non-refreshable session tokens, so when this
+     * instant passes the only recovery is a fresh interactive login. See
+     * [isExpiredAt].
+     */
     data class Bearer(
         override val baseUrl: String,
         val email: String,
         val token: String,
+        val expiresAtEpochMs: Long? = null,
     ) : AccountCredentials() {
         override val scheme: AuthScheme = AuthScheme.BEARER
         override val subject: String get() = email.lowercase()
+
+        /**
+         * True when this session's [expiresAtEpochMs] is known and is at or
+         * before [nowEpochMs]. Returns false when expiry is unknown
+         * (fail-open — see the [expiresAtEpochMs] doc).
+         */
+        fun isExpiredAt(nowEpochMs: Long): Boolean {
+            val exp = expiresAtEpochMs ?: return false
+            return nowEpochMs >= exp
+        }
+
         override fun toString(): String =
-            "AccountCredentials.Bearer(baseUrl=$baseUrl, email=$email, token=***)"
+            "AccountCredentials.Bearer(baseUrl=$baseUrl, email=$email, token=***, " +
+                "expiresAtEpochMs=$expiresAtEpochMs)"
     }
 }

--- a/auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt
+++ b/auth/src/main/java/io/theficos/ereader/auth/CalibreCredentialStore.kt
@@ -47,12 +47,36 @@ class CalibreCredentialStore(context: Context) {
 
     private val _accountFlow: MutableStateFlow<AccountCredentials?>
     private val _flow: MutableStateFlow<CalibreCredentials?>
+    private val _needsReauth: MutableStateFlow<Boolean>
 
     init {
         val initial = loadAccount()
         _accountFlow = MutableStateFlow(initial)
         _flow = MutableStateFlow(initial.asLegacyBasicOrNull())
+        // A stored Bearer session whose expiry has already passed on cold
+        // launch starts in the re-auth state, so the UI can route the user
+        // straight to sign-in instead of letting the first request 401.
+        _needsReauth = MutableStateFlow(
+            (initial as? AccountCredentials.Bearer)?.isExpiredAt(System.currentTimeMillis()) == true
+        )
     }
+
+    /**
+     * Re-auth signal for the configured Bearer (NativeAuth) account.
+     *
+     * Emits `true` when the current session can no longer authenticate and
+     * the user must sign in again — either because its `expires_at` has
+     * passed ([checkSessionExpiry]) or because a request came back `401`
+     * ([notifyUnauthorized]). NativeAuth has no refresh endpoint, so there is
+     * nothing to silently retry; the only recovery is a fresh interactive
+     * login, which the onboarding flow drives.
+     *
+     * This is a read-only *signal*: it never mutates or clears the stored
+     * credential. Saving a new account (a successful re-login) or clearing
+     * the store resets it to `false`. Basic accounts never set it — a 401
+     * there is a wrong-password condition handled by the onboarding verifier.
+     */
+    val needsReauth: StateFlow<Boolean> = _needsReauth.asStateFlow()
 
     /**
      * Scheme-aware account observable. New callers (sync, library, AI,
@@ -119,8 +143,20 @@ class CalibreCredentialStore(context: Context) {
      * Save a `quire_server` / Quire Cloud bearer-token account. The token is
      * stored as-is; callers must pass the raw token (no leading "Bearer ").
      * Blank values and tokens containing whitespace are rejected.
+     *
+     * [expiresAtEpochMs] is the session expiry from the login response's
+     * `expires_at`, in Unix epoch milliseconds; pass null when unknown (the
+     * session is then treated as non-expiring locally — see
+     * [AccountCredentials.Bearer.expiresAtEpochMs]). A successful save clears
+     * any pending [needsReauth] signal, since persisting a token is exactly
+     * what a re-login does.
      */
-    fun saveBearerAccount(baseUrl: String, email: String, token: String) {
+    fun saveBearerAccount(
+        baseUrl: String,
+        email: String,
+        token: String,
+        expiresAtEpochMs: Long? = null,
+    ) {
         require(baseUrl.isNotBlank()) { "baseUrl must not be blank" }
         require(email.isNotBlank()) { "email must not be blank" }
         require(token.isNotBlank()) { "token must not be blank" }
@@ -131,8 +167,44 @@ class CalibreCredentialStore(context: Context) {
             baseUrl = baseUrl.trim().trimEnd('/'),
             email = email,
             token = token,
+            expiresAtEpochMs = expiresAtEpochMs,
         )
         persistAccount(account)
+    }
+
+    /**
+     * Record that an authenticated request to the configured account's origin
+     * came back `401`. Flips [needsReauth] to `true` **only** when the current
+     * account is Bearer (NativeAuth) — there is no token to refresh, so the
+     * user must sign in again. Never mutates or clears the stored credential
+     * (the network layer must not silently swap or drop credentials); it only
+     * raises the signal the UI observes. No-op for Basic accounts and when no
+     * account is configured.
+     */
+    fun notifyUnauthorized() {
+        synchronized(mutationLock) {
+            if (_accountFlow.value is AccountCredentials.Bearer) {
+                _needsReauth.value = true
+            }
+        }
+    }
+
+    /**
+     * Proactively evaluate the configured Bearer session's expiry against
+     * [nowEpochMs] and raise [needsReauth] if it has lapsed. Callers (e.g. the
+     * UI on resume / cold launch) invoke this so an already-expired session
+     * routes to sign-in without first firing a doomed network request.
+     * Returns the resulting [needsReauth] value. No-op effect for non-Bearer
+     * accounts or sessions with unknown expiry.
+     */
+    fun checkSessionExpiry(nowEpochMs: Long = System.currentTimeMillis()): Boolean {
+        synchronized(mutationLock) {
+            val account = _accountFlow.value
+            if (account is AccountCredentials.Bearer && account.isExpiredAt(nowEpochMs)) {
+                _needsReauth.value = true
+            }
+            return _needsReauth.value
+        }
     }
 
     /** Clear all stored credentials. */
@@ -144,6 +216,7 @@ class CalibreCredentialStore(context: Context) {
             }
             _accountFlow.value = null
             _flow.value = null
+            _needsReauth.value = false
         }
     }
 
@@ -162,6 +235,7 @@ class CalibreCredentialStore(context: Context) {
                         .putString(KEY_PASS, account.password)
                         .remove(KEY_EMAIL)
                         .remove(KEY_TOKEN)
+                        .remove(KEY_EXPIRES_AT)
                     if (account.quireServerUrl != null) {
                         editor.putString(KEY_QUIRE_SERVER_URL, account.quireServerUrl)
                     } else {
@@ -175,6 +249,11 @@ class CalibreCredentialStore(context: Context) {
                         .remove(KEY_USER)
                         .remove(KEY_PASS)
                         .remove(KEY_QUIRE_SERVER_URL)
+                    if (account.expiresAtEpochMs != null) {
+                        editor.putLong(KEY_EXPIRES_AT, account.expiresAtEpochMs)
+                    } else {
+                        editor.remove(KEY_EXPIRES_AT)
+                    }
                 }
             }
             val committed = editor.commit()
@@ -187,6 +266,9 @@ class CalibreCredentialStore(context: Context) {
             }
             _accountFlow.value = account
             _flow.value = account.asLegacyBasicOrNull()
+            // A fresh save is a (re-)authentication: any pending re-auth
+            // signal is now satisfied.
+            _needsReauth.value = false
         }
     }
 
@@ -227,7 +309,14 @@ class CalibreCredentialStore(context: Context) {
             AuthScheme.BEARER -> {
                 val email = prefs.getString(KEY_EMAIL, null) ?: return null
                 val token = prefs.getString(KEY_TOKEN, null) ?: return null
-                AccountCredentials.Bearer(baseUrl, email, token)
+                // Absent key → unknown expiry (legacy record or unparseable
+                // login response). Stored as a plain Long when known.
+                val expiresAt = if (prefs.contains(KEY_EXPIRES_AT)) {
+                    prefs.getLong(KEY_EXPIRES_AT, 0L)
+                } else {
+                    null
+                }
+                AccountCredentials.Bearer(baseUrl, email, token, expiresAt)
             }
         }
     }
@@ -245,6 +334,7 @@ class CalibreCredentialStore(context: Context) {
         const val KEY_PASS = "password"
         const val KEY_EMAIL = "email"
         const val KEY_TOKEN = "token"
+        const val KEY_EXPIRES_AT = "expires_at_epoch_ms"
         const val KEY_QUIRE_SERVER_URL = "quire_server_url"
     }
 }

--- a/auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt
+++ b/auth/src/test/java/io/theficos/ereader/auth/CalibreCredentialStoreTest.kt
@@ -283,4 +283,116 @@ class CalibreCredentialStoreTest {
         val basic = reread.getAccount() as AccountCredentials.Basic
         assertThat(basic.quireServerUrl).isNull()
     }
+
+    // ---------- B2: Bearer session expiry + re-auth signal ----------
+
+    @Test fun `saveBearerAccount persists expiresAtEpochMs and round-trips`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        val exp = 1_900_000_000_000L
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok", expiresAtEpochMs = exp)
+        assertThat((store.getAccount() as AccountCredentials.Bearer).expiresAtEpochMs).isEqualTo(exp)
+        // Survives a fresh load through EncryptedSharedPreferences.
+        val reread = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        assertThat((reread.getAccount() as AccountCredentials.Bearer).expiresAtEpochMs).isEqualTo(exp)
+    }
+
+    @Test fun `saveBearerAccount without expiry stores null`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok")
+        assertThat((store.getAccount() as AccountCredentials.Bearer).expiresAtEpochMs).isNull()
+        val reread = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        assertThat((reread.getAccount() as AccountCredentials.Bearer).expiresAtEpochMs).isNull()
+    }
+
+    @Test fun `switching away from bearer removes the expiry key`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok", expiresAtEpochMs = 123L)
+        store.saveBasicAccount("https://lib.example", "alice", "s3cret")
+        // Switch back to a bearer with no expiry: the stale key must not resurrect.
+        val reread = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        reread.saveBearerAccount("https://cloud.quire.app", "a@b", "tok2")
+        val fresh = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        assertThat((fresh.getAccount() as AccountCredentials.Bearer).expiresAtEpochMs).isNull()
+    }
+
+    @Test fun `notifyUnauthorized raises needsReauth only for bearer`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        // No account → no-op.
+        store.notifyUnauthorized()
+        assertThat(store.needsReauth.value).isFalse()
+        // Basic → no-op (a 401 there is a wrong-password condition).
+        store.saveBasicAccount("https://lib.example", "alice", "s3cret")
+        store.notifyUnauthorized()
+        assertThat(store.needsReauth.value).isFalse()
+        // Bearer → raises the signal.
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok")
+        store.notifyUnauthorized()
+        assertThat(store.needsReauth.value).isTrue()
+        // notifyUnauthorized never mutates the stored credential.
+        assertThat(store.getAccount()).isInstanceOf(AccountCredentials.Bearer::class.java)
+    }
+
+    @Test fun `checkSessionExpiry raises needsReauth when the token has lapsed`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok", expiresAtEpochMs = 1_000L)
+        // now before expiry → no signal.
+        assertThat(store.checkSessionExpiry(nowEpochMs = 999L)).isFalse()
+        assertThat(store.needsReauth.value).isFalse()
+        // now at/after expiry → signal.
+        assertThat(store.checkSessionExpiry(nowEpochMs = 1_000L)).isTrue()
+        assertThat(store.needsReauth.value).isTrue()
+    }
+
+    @Test fun `checkSessionExpiry is a no-op when expiry is unknown`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok") // null expiry
+        assertThat(store.checkSessionExpiry(nowEpochMs = Long.MAX_VALUE)).isFalse()
+        assertThat(store.needsReauth.value).isFalse()
+    }
+
+    @Test fun `saving a new account clears a pending re-auth signal`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok")
+        store.notifyUnauthorized()
+        assertThat(store.needsReauth.value).isTrue()
+        // A successful re-login (new save) resolves the signal.
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok-fresh")
+        assertThat(store.needsReauth.value).isFalse()
+    }
+
+    @Test fun `clear resets the re-auth signal`() {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        store.saveBearerAccount("https://cloud.quire.app", "a@b", "tok")
+        store.notifyUnauthorized()
+        store.clear()
+        assertThat(store.needsReauth.value).isFalse()
+    }
+
+    @Test fun `an already-expired stored session starts in the re-auth state on cold launch`() {
+        val seed = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        seed.clear()
+        seed.saveBearerAccount("https://cloud.quire.app", "a@b", "tok", expiresAtEpochMs = 1_000L)
+        // A fresh store (process restart) whose stored expiry is already past.
+        val reread = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        // Sanity: the stored expiry is in the past relative to "now".
+        assertThat((reread.getAccount() as AccountCredentials.Bearer).isExpiredAt(System.currentTimeMillis()))
+            .isTrue()
+        assertThat(reread.needsReauth.value).isTrue()
+    }
+
+    @Test fun `isExpiredAt is fail-open when expiry is unknown`() {
+        val bearer = AccountCredentials.Bearer("https://cloud", "a@b", "tok", expiresAtEpochMs = null)
+        assertThat(bearer.isExpiredAt(Long.MAX_VALUE)).isFalse()
+        val withExp = bearer.copy(expiresAtEpochMs = 10L)
+        assertThat(withExp.isExpiredAt(9L)).isFalse()
+        assertThat(withExp.isExpiredAt(10L)).isTrue()
+    }
 }

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/AccountAuthInterceptor.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/AccountAuthInterceptor.kt
@@ -30,13 +30,19 @@ import java.util.Base64
  *   proactive header injection because (a) refresh-token rotation is
  *   deliberately deferred and (b) using an Authenticator for a static
  *   bearer would just retry the same bad token in a loop on 401.
- * - On a 401 from a bearer endpoint, callers should surface the failure to
- *   the user (re-auth) rather than mutate the store from inside an
- *   interceptor — silent token swaps from the network layer have caused
- *   "wrong credentials sent to wrong host" incidents in the past.
+ * - On a 401 to a bearer endpoint we surface the failure to the user (via
+ *   the optional [onBearerUnauthorized] callback) rather than mutate the
+ *   store from inside the interceptor — silent token swaps from the network
+ *   layer have caused "wrong credentials sent to wrong host" incidents in
+ *   the past. The callback is a read-only *signal*: it does NOT retry the
+ *   request, swap the token, or clear the credential. It fires only when we
+ *   ourselves attached a Bearer header to a same-origin request and that
+ *   request came back 401 — never for Basic accounts, third-party hosts, or
+ *   requests that arrived with a caller-supplied Authorization header.
  */
 class AccountAuthInterceptor(
     private val accountProvider: () -> AccountCredentials?,
+    private val onBearerUnauthorized: () -> Unit = {},
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -52,9 +58,16 @@ class AccountAuthInterceptor(
             is AccountCredentials.Basic -> basicHeader(account)
             is AccountCredentials.Bearer -> "Bearer ${account.token}"
         }
-        return chain.proceed(
+        val response = chain.proceed(
             request.newBuilder().header(HEADER_AUTHORIZATION, headerValue).build()
         )
+        // We only signal re-auth for the case we can attribute with
+        // certainty: a Bearer token we just attached to a same-origin request
+        // was rejected. The response is returned unchanged — no retry.
+        if (account is AccountCredentials.Bearer && response.code == HTTP_UNAUTHORIZED) {
+            onBearerUnauthorized()
+        }
+        return response
     }
 
     /**
@@ -100,5 +113,6 @@ class AccountAuthInterceptor(
 
     private companion object {
         const val HEADER_AUTHORIZATION = "Authorization"
+        const val HTTP_UNAUTHORIZED = 401
     }
 }

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsHttpClient.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/OpdsHttpClient.kt
@@ -12,6 +12,14 @@ class OpdsHttpClient(credentialStore: CalibreCredentialStore) {
         // credentials and `Bearer ...` for `quire_server` / Cloud accounts.
         // The interceptor origin-guards against attaching credentials to
         // requests that target hosts other than the configured baseUrl.
-        .addInterceptor(AccountAuthInterceptor { credentialStore.getAccount() })
+        // A 401 to a same-origin Bearer request raises the store's re-auth
+        // signal (NativeAuth tokens can't be refreshed — the user must sign
+        // in again); the interceptor never retries or mutates credentials.
+        .addInterceptor(
+            AccountAuthInterceptor(
+                accountProvider = { credentialStore.getAccount() },
+                onBearerUnauthorized = { credentialStore.notifyUnauthorized() },
+            )
+        )
         .build()
 }

--- a/data/opds/src/test/java/io/theficos/ereader/data/opds/AccountAuthInterceptorTest.kt
+++ b/data/opds/src/test/java/io/theficos/ereader/data/opds/AccountAuthInterceptorTest.kt
@@ -53,7 +53,7 @@ class AccountAuthInterceptorTest {
     @Test fun `omits header when no account configured`() {
         server.enqueue(MockResponse().setBody("ok"))
         val client = OkHttpClient.Builder()
-            .addInterceptor(AccountAuthInterceptor { null })
+            .addInterceptor(AccountAuthInterceptor(accountProvider = { null }))
             .build()
         client.newCall(Request.Builder().url(server.url("/feed")).build()).execute().close()
 
@@ -113,14 +113,14 @@ class AccountAuthInterceptorTest {
                 bearerServer.enqueue(MockResponse().setBody("ok"))
             }
             val basicClient = OkHttpClient.Builder()
-                .addInterceptor(AccountAuthInterceptor {
+                .addInterceptor(AccountAuthInterceptor(accountProvider = {
                     AccountCredentials.Basic(basicServer.url("/").toString(), "alice", "s3cret")
-                })
+                }))
                 .build()
             val bearerClient = OkHttpClient.Builder()
-                .addInterceptor(AccountAuthInterceptor {
+                .addInterceptor(AccountAuthInterceptor(accountProvider = {
                     AccountCredentials.Bearer(bearerServer.url("/").toString(), "bob@example.com", "tok_zzz")
-                })
+                }))
                 .build()
 
             val pool = Executors.newFixedThreadPool(8)
@@ -212,6 +212,72 @@ class AccountAuthInterceptorTest {
             assertThat(recorded.getHeader("Authorization")).isEqualTo(expected)
         } finally {
             quire.shutdown()
+        }
+    }
+
+    // ---------- B2: 401 re-auth signal for bearer sessions ----------
+
+    @Test fun `401 on a same-origin bearer request fires the re-auth callback`() {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("unauthorized"))
+        val calls = AtomicInteger(0)
+        val provider = {
+            AccountCredentials.Bearer(server.url("/").toString(), "alice@example.com", "stale_tok")
+        }
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AccountAuthInterceptor(provider, onBearerUnauthorized = { calls.incrementAndGet() }))
+            .build()
+        val resp = client.newCall(Request.Builder().url(server.url("/ai/v1/config")).build()).execute()
+        // Response is returned unchanged (no retry, no mutation).
+        assertThat(resp.code).isEqualTo(401)
+        resp.close()
+        assertThat(calls.get()).isEqualTo(1)
+        // The interceptor still attached our bearer header to the (rejected) request.
+        assertThat(server.takeRequest().getHeader("Authorization")).isEqualTo("Bearer stale_tok")
+    }
+
+    @Test fun `non-401 bearer response does not fire the re-auth callback`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+        val calls = AtomicInteger(0)
+        val provider = {
+            AccountCredentials.Bearer(server.url("/").toString(), "alice@example.com", "tok")
+        }
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AccountAuthInterceptor(provider, onBearerUnauthorized = { calls.incrementAndGet() }))
+            .build()
+        client.newCall(Request.Builder().url(server.url("/sync/v1/progress")).build()).execute().close()
+        assertThat(calls.get()).isEqualTo(0)
+    }
+
+    @Test fun `401 on a basic account does not fire the bearer re-auth callback`() {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("unauthorized"))
+        val calls = AtomicInteger(0)
+        val provider = {
+            AccountCredentials.Basic(server.url("/").toString(), "alice", "wrong-pw")
+        }
+        val client = OkHttpClient.Builder()
+            .addInterceptor(AccountAuthInterceptor(provider, onBearerUnauthorized = { calls.incrementAndGet() }))
+            .build()
+        client.newCall(Request.Builder().url(server.url("/opds")).build()).execute().close()
+        assertThat(calls.get()).isEqualTo(0)
+    }
+
+    @Test fun `401 from a foreign host does not fire the re-auth callback`() {
+        // We never attach the bearer to a foreign host, so a 401 there is not
+        // attributable to our session and must not trigger re-auth.
+        val foreign = MockWebServer().apply { start() }
+        try {
+            foreign.enqueue(MockResponse().setResponseCode(401))
+            val calls = AtomicInteger(0)
+            val provider = {
+                AccountCredentials.Bearer(server.url("/").toString(), "alice@example.com", "tok")
+            }
+            val client = OkHttpClient.Builder()
+                .addInterceptor(AccountAuthInterceptor(provider, onBearerUnauthorized = { calls.incrementAndGet() }))
+                .build()
+            client.newCall(Request.Builder().url(foreign.url("/cover.jpg")).build()).execute().close()
+            assertThat(calls.get()).isEqualTo(0)
+        } finally {
+            foreign.shutdown()
         }
     }
 

--- a/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
+++ b/data/opds/src/test/java/io/theficos/ereader/data/opds/OpdsClientTest.kt
@@ -25,7 +25,7 @@ class OpdsClientTest {
         server = MockWebServer().apply { start() }
         val creds = AccountCredentials.Basic(server.url("/").toString().trimEnd('/'), "u", "p")
         val okHttp = OkHttpClient.Builder()
-            .addInterceptor(AccountAuthInterceptor { creds })
+            .addInterceptor(AccountAuthInterceptor(accountProvider = { creds }))
             .build()
         client = OpdsClient(okHttp)
         server.dispatcher = object : Dispatcher() {

--- a/server/README.md
+++ b/server/README.md
@@ -135,12 +135,12 @@ match the table in [Deploy modes](#deploy-modes).
 | AI only    | `false`                      | `true`                 | `/ai/v1/*` only — drop the `calibre-web` service from the compose for a leaner stack |
 
 Set both flags in `.env`. Sync-only deploys don't need
-`QUIRE_SERVER_AI_*`; AI-only deploys don't need calibre-web auth once
-PR-B's token mode is selected (`QUIRE_SERVER_AI_AUTH_MODE=token`).
-Token mode is **deprecated** as of Phase 0, task X-2 (removal scheduled in
-2 minor releases); new AI-only / Cloud-style deploys should adopt
-`QUIRE_SERVER_AUTH_BACKEND=native` (NativeAuth) instead. See the
-"AI auth mode" section below.
+`QUIRE_SERVER_AI_*`; AI-only / Cloud-style deploys that don't run calibre-web
+should set `QUIRE_SERVER_AUTH_BACKEND=native`, which makes `/ai/v1/*`
+authenticate against the same NativeAuth session tokens as the rest of the
+API (no separate AI token config). The older `QUIRE_SERVER_AI_AUTH_MODE=token`
+HMAC path is **deprecated** as of Phase 0, task X-2 (removal scheduled in 2
+minor releases). See the "AI auth mode" section below.
 
 ##### Mode examples
 
@@ -279,10 +279,18 @@ resolution) is documented in `docs/sync-api.md` under `POST
 #### AI auth mode (PR-B, 2026-05-16)
 
 `/ai/v1/*` routes go through a pluggable `AiAuthenticator` (sync routes are
-unaffected). Two modes:
+unaffected). The concrete authenticator is chosen from **both**
+`QUIRE_SERVER_AI_AUTH_MODE` and the primary `QUIRE_SERVER_AUTH_BACKEND`:
 
-- **`basic`** (default) — wraps the existing calibre-web Basic verifier;
-  `AiPrincipal.tenant_id` is always `"local"`. No additional config required.
+- **`basic`** (default) — follows the primary auth backend:
+  - with `AUTH_BACKEND=calibreweb` (OSS default), wraps the calibre-web Basic
+    verifier; `AiPrincipal.tenant_id` is always `"local"`. No extra config.
+  - with `AUTH_BACKEND=native`, `/ai/v1/*` delegates to the **same**
+    `NativeAuth` session tokens that govern `/auth/v1`, `/sync/v1`, and
+    `/library/v1` — one identity layer, no separate AI token issuer. The
+    principal's `subject` is the `native:<id>` user scope and `tenant_id`
+    stays `"local"`. This is the supported, non-deprecated path for
+    Cloud-style deploys, and the replacement for `token` mode below.
 - **`token`** (**deprecated** as of Phase 0, task X-2 — removal scheduled in 2
   minor releases) — HMAC-SHA256 bearer tokens. Wire format:
   `header.payload.signature` with header `{alg=HS256, kid}` and payload claims

--- a/server/quire_server/api/ai_auth.py
+++ b/server/quire_server/api/ai_auth.py
@@ -12,9 +12,19 @@ This module introduces:
                        `get_ai_principal`).
 * `BasicAuthAiAuthenticator`  – wraps `CalibreAuthValidator`. Today's default.
                                 Emits tenant_id="local", auth_mode="basic".
-* `TokenAiAuthenticator`  – HMAC-SHA256 verifier. Stub for the hosted future;
-                            never wired by default. `kid` rotation supported
-                            from day one via a JSON `{kid: secret}` map.
+* `TokenAiAuthenticator`  – HMAC-SHA256 verifier. The hosted-multitenant
+                            seam, kept for the deprecation window of
+                            `QUIRE_SERVER_AI_AUTH_MODE=token` (task X-2).
+                            `kid` rotation supported from day one via a JSON
+                            `{kid: secret}` map.
+* `BackendAiAuthenticator`  – delegates to the primary `AuthBackend`
+                              (`NativeAuth` in Cloud). This is what lets a
+                              `QUIRE_SERVER_AUTH_BACKEND=native` deployment run
+                              `/ai/v1/*` on the same session-token identity
+                              layer as `/auth/v1`, `/sync/v1`, and `/library/v1`
+                              — no separate HMAC token config, and the
+                              long-term replacement for token mode. Emits
+                              `auth_mode="native"`, `tenant_id="local"`.
 
 Sync routes (`/sync/v1/*`) keep depending on `current_user_id` directly.
 The seam only swings on `/ai/v1/*`.
@@ -54,6 +64,7 @@ from typing import Annotated, Literal, Protocol
 from fastapi import Depends, HTTPException, Request, status
 
 from quire_server.core.auth import CalibreAuthValidator
+from quire_server.core.auth_backend import AuthBackend
 from quire_server.core.logging_ctx import request_id_var
 
 logger = logging.getLogger(__name__)
@@ -94,7 +105,7 @@ class AiPrincipal:
     subject: str
     tenant_id: str
     scopes: tuple[str, ...]
-    auth_mode: Literal["basic", "token"]
+    auth_mode: Literal["basic", "token", "native"]
     request_id: str | None = field(default=None)
 
 
@@ -132,6 +143,47 @@ class BasicAuthAiAuthenticator:
             tenant_id="local",
             scopes=(),
             auth_mode="basic",
+            request_id=_read_request_id(),
+        )
+
+
+class BackendAiAuthenticator:
+    """Delegates AI auth to the primary :class:`AuthBackend`.
+
+    Used when ``QUIRE_SERVER_AUTH_BACKEND=native``: the ``/ai/v1/*`` routes
+    authenticate against the very same ``native_sessions`` Bearer tokens that
+    govern ``/auth/v1``, ``/sync/v1``, and ``/library/v1``. This is the
+    long-term replacement for ``TokenAiAuthenticator`` (the deprecated
+    ``AI_AUTH_MODE=token`` HMAC seam, task X-2) — a Cloud deployment no longer
+    needs to provision a second, parallel token issuer just for AI.
+
+    Mapping ``AuthUser -> AiPrincipal``:
+
+    * ``subject = auth_user.user_id`` (e.g. ``"native:42"``) — the per-user
+      storage scope, exactly as the primary routes use it.
+    * ``tenant_id = "local"`` — identical to basic mode. The OSS server is one
+      logical instance; per-user attribution already lives in ``subject``
+      (and ``ai_generation_log.user_id`` / the ``(tenant_id, subject)``
+      profile singleflight key). Cross-user aggregation is a Cloud-only,
+      separate-process concern and never reaches this code.
+    * ``auth_mode = "native"`` — distinct from ``"basic"`` so audit/log lines
+      and tests can tell session-token auth apart from CalibreWeb Basic.
+
+    The backend raises ``HTTPException(401)`` on any failure (missing,
+    malformed, unknown, revoked, or expired token); we let those propagate
+    verbatim so the wire shape matches the primary routes.
+    """
+
+    def __init__(self, backend: AuthBackend) -> None:
+        self._backend = backend
+
+    async def authenticate(self, request: Request) -> AiPrincipal:
+        auth_user = await self._backend.current_user(request)
+        return AiPrincipal(
+            subject=auth_user.user_id,
+            tenant_id="local",
+            scopes=(),
+            auth_mode="native",
             request_id=_read_request_id(),
         )
 

--- a/server/quire_server/core/auth_backend.py
+++ b/server/quire_server/core/auth_backend.py
@@ -26,12 +26,14 @@ that override that dependency continue to work unchanged. Endpoints needing
 the full :class:`AuthUser` (notably ``/auth/v1/logout``, which needs the
 session token to revoke) use ``current_auth_user``.
 
-AI-routes seam (``quire_server.api.ai_auth.AiAuthenticator``) remains
-independent: AI keeps its own auth mechanism so token-mode multi-tenant
-deployments are not entangled with primary-auth selection. The app factory
-guards against the misconfiguration ``auth_backend=native`` +
-``ai_enabled=true`` + ``ai_auth_mode=basic`` (which would silently leave
-AI on CalibreWeb Basic).
+AI-routes seam (``quire_server.api.ai_auth.AiAuthenticator``) is still a
+separate Protocol, but the two seams are no longer disjoint: under
+``auth_backend=native`` the AI seam delegates to *this* backend via
+``BackendAiAuthenticator``, so ``/ai/v1/*`` shares the NativeAuth session
+tokens used by ``/auth/v1`` / ``/sync/v1`` / ``/library/v1``. The legacy
+``ai_auth_mode=token`` HMAC verifier remains for its deprecation window
+(task X-2) but is no longer required to run AI under native auth. See
+``_build_ai_authenticator`` in :mod:`quire_server.main`.
 """
 
 from __future__ import annotations

--- a/server/quire_server/main.py
+++ b/server/quire_server/main.py
@@ -29,35 +29,6 @@ from quire_server.core.logging_ctx import RequestIdLogFilter
 from quire_server.db.session import configure, make_engine, make_session_factory
 
 
-def _validate_auth_backend_settings(settings: Settings) -> None:
-    """Phase 0, task S-1: cross-config guard for the primary AuthBackend.
-
-    The independent AI auth seam (``ai_auth_mode``) means a Cloud-style
-    deployment that flips ``auth_backend`` to ``native`` could
-    accidentally leave ``ai_auth_mode=basic``, which would route AI
-    requests through CalibreWeb Basic — a backend that doesn't exist in
-    a Cloud deployment. Fail loudly at startup.
-
-    Valid combinations:
-      * ``auth_backend=calibreweb`` + any ``ai_auth_mode`` (today's OSS).
-      * ``auth_backend=native``    + ``ai_enabled=false`` OR
-                                     ``ai_auth_mode=token``.
-    """
-    if settings.auth_backend != "native":
-        return
-    if not settings.ai_enabled:
-        return
-    if settings.ai_auth_mode != "basic":
-        return
-    raise RuntimeError(
-        "QUIRE_SERVER_AUTH_BACKEND=native is incompatible with "
-        "QUIRE_SERVER_AI_AUTH_MODE=basic when AI is enabled: AI requests "
-        "would silently route through the CalibreWeb verifier. Either "
-        "disable AI (QUIRE_SERVER_AI_ENABLED=false) or switch AI auth to "
-        "token mode (QUIRE_SERVER_AI_AUTH_MODE=token)."
-    )
-
-
 def _warn_deprecated_ai_metadata_lookup(settings: Settings) -> None:
     """Emit a startup deprecation notice for ``ai_metadata_server_lookup_enabled``.
 
@@ -169,19 +140,35 @@ def _warn_if_ai_auth_mode_deprecated(settings: Settings) -> None:
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
 
-def _build_ai_authenticator(settings: Settings, validator: CalibreAuthValidator):
-    """Construct the AiAuthenticator implied by settings.ai_auth_mode.
+def _build_ai_authenticator(settings: Settings, validator: CalibreAuthValidator, auth_backend):
+    """Construct the AiAuthenticator implied by the auth config.
+
+    The concrete authenticator is chosen from BOTH ``settings.auth_backend``
+    and ``settings.ai_auth_mode`` (the env stays a two-value ``basic|token``
+    switch — there is no third ``native`` env mode):
+
+    * ``ai_auth_mode=token`` → :class:`TokenAiAuthenticator` (the deprecated
+      HMAC seam, regardless of primary backend; kept for its removal window).
+    * ``ai_auth_mode=basic`` + ``auth_backend=native`` →
+      :class:`BackendAiAuthenticator`, delegating to the configured
+      ``NativeAuth`` so ``/ai/v1/*`` shares the primary session-token identity
+      layer. This is the long-term replacement for token mode.
+    * ``ai_auth_mode=basic`` + ``auth_backend=calibreweb`` →
+      :class:`BasicAuthAiAuthenticator` (today's OSS default, byte-exact).
 
     Imported here (rather than at module top) to keep the AI auth surface
     lazy alongside the rest of the AI imports — sync-only deploys never pay
     for the HMAC / token code.
     """
     from quire_server.api.ai_auth import (
+        BackendAiAuthenticator,
         BasicAuthAiAuthenticator,
         TokenAiAuthenticator,
     )
 
     if settings.ai_auth_mode == "basic":
+        if settings.auth_backend == "native":
+            return BackendAiAuthenticator(auth_backend)
         return BasicAuthAiAuthenticator(validator=validator)
     # token mode — validation already ran, so secrets/iss/aud are guaranteed.
     assert settings.ai_token_secrets is not None
@@ -239,9 +226,9 @@ def create_app() -> FastAPI:
 
     # Phase 0, task S-1: pick the primary AuthBackend before any router
     # mounts so /readyz and the AI-auth wiring below see a consistent
-    # picture. The cross-config guard runs first; misconfigurations
-    # crashloop here instead of silently 401-ing users.
-    _validate_auth_backend_settings(settings)
+    # picture. Under ``auth_backend=native`` the AI seam delegates to this
+    # same backend (see ``_build_ai_authenticator``), so there is no longer a
+    # forbidden ``native + ai_auth_mode=basic`` combination to guard against.
     if settings.auth_backend == "native":
         app.state.auth_backend = NativeAuth(
             session_factory=session_factory,
@@ -286,7 +273,9 @@ def create_app() -> FastAPI:
         # is known to be valid. Misconfigured token deploys still crashloop
         # via _validate_ai_auth_settings above.
         _warn_if_ai_auth_mode_deprecated(settings)
-        app.state.ai_authenticator = _build_ai_authenticator(settings, app.state.auth_validator)
+        app.state.ai_authenticator = _build_ai_authenticator(
+            settings, app.state.auth_validator, app.state.auth_backend
+        )
 
         if settings.ai_base_url and settings.ai_model:
             # Lazy imports: only pull AI modules when AI mode is on AND configured.

--- a/server/tests/integration/test_ai_auth_modes.py
+++ b/server/tests/integration/test_ai_auth_modes.py
@@ -287,3 +287,108 @@ async def test_token_auth_propagates_request_id_to_generation_log(client_factory
 
     logs = (await session.execute(select(AIGenerationLog))).scalars().all()
     assert any(log.request_id == "rid-test-pr-b" for log in logs), [log.request_id for log in logs]
+
+
+# ---------------------------------------------------------------------------
+# Native backend: /ai/v1/* delegates to the primary NativeAuth session tokens
+# (task X-2 — the long-term replacement for AI_AUTH_MODE=token).
+# ---------------------------------------------------------------------------
+
+
+async def _register_and_login(
+    app,
+    *,
+    email: str = "reader@example.com",
+    password: str = "correct-horse-battery",
+) -> str:
+    """Create a native user and return a freshly-minted session token.
+
+    Signup is intentionally not HTTP-exposed in the OSS server (Cloud's
+    control plane owns it), so we drive ``NativeAuth.register`` / ``login``
+    directly through the configured backend — exactly the building blocks the
+    future control plane will call.
+    """
+    backend = app.state.auth_backend
+    await backend.register(email=email, password=password)
+    token, _expires_at = await backend.login(email=email, password=password)
+    return token
+
+
+async def test_native_backend_ai_accepts_session_token(client_factory, app, session):
+    """``auth_backend=native`` + default ``ai_auth_mode=basic``: ``/ai/v1/*``
+    authenticates against the SAME ``native_sessions`` Bearer tokens as
+    ``/auth/v1`` / ``/sync/v1`` / ``/library/v1`` — no HMAC token config.
+    """
+    async with client_factory(
+        ai_enabled=True,
+        auth_backend="native",
+        skip_auth_overrides=True,
+    ) as client:
+        token = await _register_and_login(app)
+        r = await client.get("/ai/v1/config", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+
+
+async def test_native_backend_ai_rejects_missing_and_bad_credentials(client_factory, app, session):
+    """No header, an unknown bearer, and Basic creds must all 401 under the
+    native AI seam (it is session-token-only)."""
+    async with client_factory(
+        ai_enabled=True,
+        auth_backend="native",
+        skip_auth_overrides=True,
+    ) as client:
+        # Register a user so the table is non-empty, proving rejection is about
+        # the *presented* credential, not an empty DB.
+        await _register_and_login(app)
+
+        r0 = await client.get("/ai/v1/config")
+        assert r0.status_code == 401, r0.text
+
+        r1 = await client.get(
+            "/ai/v1/config",
+            headers={"Authorization": "Bearer not-a-real-session-token"},
+        )
+        assert r1.status_code == 401, r1.text
+
+        r2 = await client.get("/ai/v1/config", headers=_basic_header("alice"))
+        assert r2.status_code == 401, r2.text
+
+
+@pytest.mark.requires_ai
+async def test_native_auth_writes_native_subject_to_generation_log(client_factory, app, session):
+    """End-to-end: a native session's subject (``native:<id>``) flows into
+    ``ai_generation_log.subject`` and the tenant stays ``"local"`` (the OSS
+    server is one logical instance; cross-user aggregation is Cloud-only)."""
+    async with client_factory(
+        ai_enabled=True,
+        auth_backend="native",
+        ai_base_url="http://fake/v1",
+        ai_model="test-model",
+        skip_auth_overrides=True,
+    ) as client:
+        _install_fake_orchestrator(
+            app,
+            {"schema_version": 2, "intro": "From a native reader.", "confidence": "high"},
+        )
+
+        token = await _register_and_login(app)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        r = await client.put("/ai/v1/preferences", headers=headers, json={"ai_enabled": True})
+        assert r.status_code == 200, r.text
+
+        r2 = await client.post(
+            "/ai/v1/insights/lookup",
+            headers=headers,
+            json={
+                "identity": {"content_hash": "ch-native-1"},
+                "bundle": {"title": "Native Book"},
+            },
+        )
+        assert r2.status_code == 200, r2.text
+
+    logs = (await session.execute(select(AIGenerationLog))).scalars().all()
+    assert len(logs) >= 1
+    assert any(log.subject.startswith("native:") for log in logs), [log.subject for log in logs]
+    # tenant_id stays "local" under native auth — no per-user tenant explosion.
+    assert all(log.tenant_id == "local" for log in logs), [log.tenant_id for log in logs]

--- a/server/tests/unit/test_ai_auth.py
+++ b/server/tests/unit/test_ai_auth.py
@@ -23,10 +23,12 @@ from starlette.requests import Request
 
 from quire_server.api.ai_auth import (
     AiPrincipal,
+    BackendAiAuthenticator,
     BasicAuthAiAuthenticator,
     TokenAiAuthenticator,
 )
 from quire_server.core.auth import CalibreAuthValidator
+from quire_server.core.auth_backend import AuthUser
 from quire_server.core.logging_ctx import request_id_var
 
 # ---------------------------------------------------------------------------
@@ -218,6 +220,73 @@ async def test_basic_auth_request_id_none_when_unset():
     req = _make_request({"authorization": _basic_header_value("alice", "alicepass")})
     p = await auth.authenticate(req)
     assert p.request_id is None
+
+
+# ---------------------------------------------------------------------------
+# BackendAiAuthenticator — delegates to the primary AuthBackend (NativeAuth)
+# ---------------------------------------------------------------------------
+
+
+class _StubBackend:
+    """Minimal AuthBackend: returns a fixed AuthUser, or raises if configured.
+
+    Records the request it was handed so we can assert the authenticator
+    passes the inbound request straight through (Bearer header lives there).
+    """
+
+    def __init__(self, *, user: AuthUser | None = None, error: HTTPException | None = None):
+        self._user = user
+        self._error = error
+        self.seen_request: Request | None = None
+
+    async def current_user(self, request: Request) -> AuthUser:
+        self.seen_request = request
+        if self._error is not None:
+            raise self._error
+        assert self._user is not None
+        return self._user
+
+
+async def test_backend_auth_maps_authuser_to_native_principal():
+    backend = _StubBackend(
+        user=AuthUser(user_id="native:42", backend="native", session_token_hash="abc")
+    )
+    auth = BackendAiAuthenticator(backend)
+    req = _make_request({"authorization": "Bearer sometoken"})
+    p = await auth.authenticate(req)
+    assert p == AiPrincipal(
+        subject="native:42",
+        tenant_id="local",
+        scopes=(),
+        auth_mode="native",
+        request_id=None,
+    )
+    # The inbound request (carrying the Bearer header) is delegated verbatim.
+    assert backend.seen_request is req
+
+
+async def test_backend_auth_propagates_backend_401():
+    backend = _StubBackend(error=HTTPException(status_code=401, detail="invalid credentials"))
+    auth = BackendAiAuthenticator(backend)
+    req = _make_request({"authorization": "Bearer bad"})
+    with pytest.raises(HTTPException) as exc:
+        await auth.authenticate(req)
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "invalid credentials"
+
+
+async def test_backend_auth_carries_request_id_from_contextvar():
+    backend = _StubBackend(
+        user=AuthUser(user_id="native:7", backend="native", session_token_hash="h")
+    )
+    auth = BackendAiAuthenticator(backend)
+    token = request_id_var.set("rid-native-1")
+    try:
+        req = _make_request({"authorization": "Bearer t"})
+        p = await auth.authenticate(req)
+        assert p.request_id == "rid-native-1"
+    finally:
+        request_id_var.reset(token)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/unit/test_auth_backend_config.py
+++ b/server/tests/unit/test_auth_backend_config.py
@@ -84,19 +84,30 @@ def test_native_backend_mounts_auth_router(monkeypatch):
 
 
 # ----------------------------------------------------------------------------
-# Cross-config guard: native + AI-on + basic AI auth must crashloop
+# Native primary auth + AI-on + basic AI auth → AI delegates to NativeAuth
+# (the X-2 replacement for the deprecated token mode; formerly a crashloop).
 # ----------------------------------------------------------------------------
 
 
-def test_native_with_ai_basic_auth_raises(monkeypatch):
-    """Native primary auth + AI on + ``ai_auth_mode=basic`` would silently
-    route AI requests through CalibreWeb. The factory must refuse.
+def test_native_with_ai_basic_delegates_to_backend(monkeypatch):
+    """Native primary auth + AI on + ``ai_auth_mode=basic`` now routes AI
+    requests through the primary ``NativeAuth`` backend via
+    ``BackendAiAuthenticator`` — the same session-token identity layer as
+    ``/auth/v1`` / ``/sync/v1`` / ``/library/v1``. This is the long-term
+    replacement for ``AI_AUTH_MODE=token`` and used to crashloop.
     """
     monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
     monkeypatch.setenv("QUIRE_SERVER_AI_ENABLED", "true")
     # ai_auth_mode defaults to "basic"; leave unset.
-    with pytest.raises(RuntimeError, match="AI_AUTH_MODE=basic"):
-        _create_app()
+    app = _create_app()
+    from quire_server.api.ai_auth import BackendAiAuthenticator
+    from quire_server.core.auth_backend import NativeAuth
+
+    assert isinstance(app.state.ai_authenticator, BackendAiAuthenticator)
+    # The AI authenticator delegates to the SAME backend instance the primary
+    # routes use — not a second, parallel auth object.
+    assert isinstance(app.state.auth_backend, NativeAuth)
+    assert app.state.ai_authenticator._backend is app.state.auth_backend
 
 
 def test_native_with_ai_token_auth_is_ok(monkeypatch):


### PR DESCRIPTION
Two OSS-side changes that make a **NativeAuth (Quire Cloud)** deployment work end-to-end, without depending on the deprecated AI HMAC token mode. Both were independently filed Phase-1 leftovers; bundled here as one cohesive integration.

## Server — `/ai/v1/*` delegates to the primary `AuthBackend` under native auth

Previously a `QUIRE_SERVER_AUTH_BACKEND=native` deploy was *forced* onto `AI_AUTH_MODE=token` (deprecated, X-2) for AI, because the app factory crash-guarded `native + ai_auth_mode=basic`.

- Add **`BackendAiAuthenticator`** mapping the configured backend's `AuthUser` → `AiPrincipal` (`subject="native:<id>"`, `tenant_id="local"`, `auth_mode="native"`). Built when `auth_backend=native` + `ai_auth_mode=basic`.
- Remove the crash guard — that combination is now the supported native-AI path. `ai_auth_mode=token` is unchanged and stays for its deprecation window; the CalibreWeb Basic default is byte-for-byte unchanged.
- Extend `AiPrincipal.auth_mode` with `"native"`; update `server/README.md` + docstrings.

`tenant_id` stays `"local"` (per-user attribution already lives in `subject`); cross-user aggregation remains a Cloud-only, separate-process concern.

## Android — Bearer session expiry + re-auth signal

NativeAuth issues non-refreshable session tokens (no refresh endpoint), so the client **surfaces re-auth** rather than silently refreshing.

- Persist `expires_at` end-to-end: `AccountCredentials.Bearer.expiresAtEpochMs` (+ `isExpiredAt`), stored in `CalibreCredentialStore`, parsed from the login response in `ConnectServerViewModel`.
- `CalibreCredentialStore.needsReauth: StateFlow<Boolean>`, raised by `notifyUnauthorized()` (a 401 on a same-origin Bearer request, via `AccountAuthInterceptor`'s new non-mutating `onBearerUnauthorized` callback) and by a proactive `checkSessionExpiry()`; reset on save/clear; an already-expired stored session starts raised on cold launch.
- `AppNavGraph` routes to the connect screen when the signal flips.
- The interceptor stays a **non-retrying** `Interceptor` — no credential mutation from the network layer (honors the existing documented design).

Known limitation: backing out of the re-auth screen leaves `needsReauth` raised until the signal next toggles (next 401 / expiry check) — a blocking re-auth gate is a follow-up.

## Testing

- **Server:** full suite green; added unit + integration coverage for the native AI seam (native session → `/ai/v1/config` 200, 401/Basic rejection, `subject="native:<id>"` into `ai_generation_log`). `ruff` clean.
- **Android:** `:auth` + `:data:opds` unit tests and `assembleDebug` green via the project's dockerized Gradle.