### PR TITLE
Add deterministic /library/v1/affinity endpoint (book-scan Tier-1)

### DIFF
--- a/server/quire_server/api/affinity_schemas.py
+++ b/server/quire_server/api/affinity_schemas.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from quire_server.api.ai_schemas import DocumentIdentity, MetadataBundle
+
+
+class AffinityRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    identity: DocumentIdentity
+    bundle: MetadataBundle
+
+
+class OwnedInfo(BaseModel):
+    in_library: bool
+    reading_status: str   # finished|abandoned|in_progress|unread
+
+
+class AffinityReason(BaseModel):
+    kind: str
+    polarity: str
+    message: str
+
+
+class AffinityResponse(BaseModel):
+    affinity_version: int
+    owned: OwnedInfo | None
+    score: int | None
+    band: str
+    reasons: list[AffinityReason]
+    generated_at: str

--- a/server/quire_server/api/affinity_schemas.py
+++ b/server/quire_server/api/affinity_schemas.py
@@ -15,7 +15,7 @@ class AffinityRequest(BaseModel):
 
 class OwnedInfo(BaseModel):
     in_library: bool
-    reading_status: str   # finished|abandoned|in_progress|unread
+    reading_status: str  # finished|abandoned|in_progress|unread
 
 
 class AffinityReason(BaseModel):

--- a/server/quire_server/api/affinity_schemas.py
+++ b/server/quire_server/api/affinity_schemas.py
@@ -6,6 +6,8 @@ from quire_server.api.ai_schemas import DocumentIdentity, MetadataBundle
 
 
 class AffinityRequest(BaseModel):
+    # extra="forbid" only guards the top level; the shared nested DocumentIdentity/
+    # MetadataBundle (from ai_schemas.py) don't forbid extras and aren't changed here.
     model_config = ConfigDict(extra="forbid")
     identity: DocumentIdentity
     bundle: MetadataBundle

--- a/server/quire_server/api/library.py
+++ b/server/quire_server/api/library.py
@@ -35,6 +35,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import and_, case, func, literal_column, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from quire_server.api.affinity_schemas import (
+    AffinityReason,
+    AffinityRequest,
+    AffinityResponse,
+    OwnedInfo,
+)
 from quire_server.api.library_schemas import (
     LIBRARY_STATS_THEMES_CAVEAT,
     LibraryItemDeleteBody,
@@ -51,7 +57,9 @@ from quire_server.api.library_schemas import (
     TopTheme,
 )
 from quire_server.config import Settings, get_settings
+from quire_server.core.affinity import score_affinity
 from quire_server.core.auth import current_user_id
+from quire_server.core.isbn import to_isbn13
 from quire_server.db.models import (
     BookInsight,
     BookTheme,
@@ -863,4 +871,80 @@ async def get_stats(
         top_authors=top_authors,
         top_themes=top_themes,
         themes_caveat=LIBRARY_STATS_THEMES_CAVEAT,
+    )
+
+
+@router.post("/affinity", response_model=AffinityResponse)
+async def affinity(
+    body: AffinityRequest,
+    user_id: Annotated[str, Depends(current_user_id)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> AffinityResponse:
+    # Alive library + reading state. Progress is keyed by documents.pk (no
+    # content_hash/user_id), so bridge via Document (user_id + content_hash);
+    # BOTH joins OUTER so tracked-but-not-downloaded / unread items count.
+    rows = (
+        await session.execute(
+            select(LibraryItem, Progress)
+            .join(
+                Document,
+                and_(
+                    Document.user_id == LibraryItem.user_id,
+                    Document.content_hash == LibraryItem.content_hash,
+                ),
+                isouter=True,
+            )
+            .join(Progress, Progress.document_pk == Document.pk, isouter=True)
+            .where(LibraryItem.user_id == user_id, LibraryItem.deleted_at.is_(None))
+        )
+    ).all()
+
+    def _status(p) -> str:
+        if p is None:
+            return "unread"
+        if p.finished_at is not None:
+            return "finished"
+        if p.abandoned_at is not None:
+            return "abandoned"
+        if p.percent and p.percent > 0:
+            return "in_progress"
+        return "unread"
+
+    library = [
+        {
+            "authors": list(li.authors or []),
+            "subjects": list(li.subjects or []),
+            "series_name": li.series_name,
+            "language": (li.language or "").lower()[:2] or None,
+            "status": _status(p),
+            "isbn13": to_isbn13(li.isbn),
+        }
+        for (li, p) in rows
+    ]
+
+    scanned_isbn13 = to_isbn13(body.identity.isbn or body.bundle.isbn)
+    owned = None
+    if scanned_isbn13:
+        match = next((b for b in library if b["isbn13"] == scanned_isbn13), None)
+        if match:
+            owned = OwnedInfo(in_library=True, reading_status=match["status"])
+
+    scanned = {
+        "authors": [body.bundle.author] if body.bundle.author else [],
+        "subjects": list(body.bundle.subjects or []),
+        "series_name": body.bundle.series_name,
+        "language": body.bundle.language,
+    }
+    result = score_affinity(scanned=scanned, library=library)
+
+    return AffinityResponse(
+        affinity_version=result.version,
+        owned=owned,
+        score=result.score,
+        band=result.band,
+        reasons=[
+            AffinityReason(kind=r.kind, polarity=r.polarity, message=r.message)
+            for r in result.reasons
+        ],
+        generated_at=datetime.now(UTC).isoformat(),
     )

--- a/server/quire_server/core/affinity.py
+++ b/server/quire_server/core/affinity.py
@@ -117,6 +117,8 @@ def _theme_signal(scanned_subjects, library):
     top = best[:3]
     avg = sum(t[0] for t in top) / len(top)
     pts = round(avg * 30) if avg >= 0 else round(avg * 25)
+    if pts == 0:
+        return None   # a net-neutral theme is not a reason worth surfacing
     theme, fin, tot = top[0][1], top[0][2], top[0][3]
     if avg >= 0:
         return Reason(
@@ -159,9 +161,7 @@ def _language_signal(scanned_lang, library):
     return None
 
 
-def _band(score: int, families: int, has_series_pos: bool) -> str:
-    if families == 1 and not has_series_pos and score >= 75:
-        score = 74
+def _band(score: int) -> str:
     if score >= 75:
         return "strong"
     if score >= 60:
@@ -196,7 +196,11 @@ def score_affinity(*, scanned: dict, library: list[dict]) -> AffinityResult:
     score = max(0, min(100, round(raw)))
     families = len({s.kind for s in signals})
     has_series_pos = any(s.kind == "series" and s.polarity == "positive" for s in signals)
-    band = _band(score, families, has_series_pos)
+    # Confidence guard: cap the SCORE itself (not just the band) so the number
+    # and band never disagree.
+    if families == 1 and not has_series_pos and score >= 75:
+        score = 74
+    band = _band(score)
 
     ranked = sorted(signals, key=lambda s: abs(s.points), reverse=True)
     chosen, lang_used = [], False

--- a/server/quire_server/core/affinity.py
+++ b/server/quire_server/core/affinity.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from dataclasses import dataclass, field
 
 AFFINITY_VERSION = 1
 
@@ -60,3 +61,153 @@ def normalize_series(raw: str | None) -> str | None:
     if not raw:
         return None
     return _base_normalize(raw) or None
+
+
+@dataclass(frozen=True)
+class Reason:
+    kind: str
+    polarity: str
+    message: str
+    points: float = 0.0
+
+
+@dataclass(frozen=True)
+class AffinityResult:
+    version: int
+    score: int | None
+    band: str
+    reasons: list[Reason] = field(default_factory=list)
+
+
+def _status_counts(library):
+    finished = sum(1 for b in library if b["status"] == "finished")
+    abandoned = sum(1 for b in library if b["status"] == "abandoned")
+    return finished, abandoned
+
+
+def _author_signal(scanned_authors, library):
+    finished_titles = [b for b in library if b["status"] == "finished"
+                       and scanned_authors & {normalize_author(a) for a in b["authors"]}]
+    abandoned_titles = [b for b in library if b["status"] == "abandoned"
+                        and scanned_authors & {normalize_author(a) for a in b["authors"]}]
+    fm, am = len(finished_titles), len(abandoned_titles)
+    if fm > 0:
+        pts = min(25, 8 * fm)
+        return Reason("author", "positive", f"You've finished {fm} book(s) by this author.", pts)
+    if am >= 2:
+        return Reason("author", "negative", f"You've abandoned {am} books by this author.", -10)
+    return None
+
+
+def _theme_signal(scanned_subjects, library):
+    best = []
+    for theme in scanned_subjects:
+        terminal = [b for b in library if b["status"] in ("finished", "abandoned")
+                    and theme in {normalize_subject(s) for s in b["subjects"]}]
+        if not terminal:
+            continue
+        fin = sum(1 for b in terminal if b["status"] == "finished")
+        support = min(1.0, len(terminal) / 3.0)
+        rate = fin / len(terminal)
+        affinity = (rate - 0.5) * 2 * support
+        best.append((affinity, theme, fin, len(terminal)))
+    if not best:
+        return None
+    best.sort(key=lambda t: abs(t[0]), reverse=True)
+    top = best[:3]
+    avg = sum(t[0] for t in top) / len(top)
+    pts = round(avg * 30) if avg >= 0 else round(avg * 25)
+    theme, fin, tot = top[0][1], top[0][2], top[0][3]
+    if avg >= 0:
+        return Reason(
+            "theme", "positive",
+            f"Matches your high-finish theme '{theme}' ({fin} finished, {tot - fin} abandoned).",
+            pts)
+    return Reason("theme", "negative",
+                  f"You've abandoned {tot - fin} of {tot} books tagged '{theme}'.", pts)
+
+
+def _series_signal(scanned_series, library):
+    if not scanned_series:
+        return None
+    same = [b for b in library if normalize_series(b["series_name"]) == scanned_series]
+    if not same:
+        return None
+    if any(b["status"] in ("finished", "in_progress") for b in same):
+        return Reason("series", "positive", "Continues a series you're reading.", 20)
+    if all(b["status"] == "abandoned" for b in same):
+        return Reason("series", "negative", "You abandoned this series.", -10)
+    return Reason("series", "positive", "Matches a series in your library.", 12)
+
+
+def _language_signal(scanned_lang, library):
+    finished = [b for b in library if b["status"] == "finished" and b["language"]]
+    if not finished or not scanned_lang:
+        return None
+    counts: dict[str, int] = {}
+    for b in finished:
+        counts[b["language"]] = counts.get(b["language"], 0) + 1
+    top = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)
+    if len(top) >= 2 and top[0][1] == top[1][1]:
+        return None
+    dominant, dom_n = top[0]
+    if scanned_lang == dominant and dom_n >= 2:
+        return Reason(
+            "language", "positive", f"Language matches most of your reading: {dominant}.", 5)
+    if scanned_lang != dominant and dom_n >= 3 and scanned_lang not in counts:
+        return Reason("language", "negative", f"You mostly read in {dominant}.", -5)
+    return None
+
+
+def _band(score: int, families: int, has_series_pos: bool) -> str:
+    if families == 1 and not has_series_pos and score >= 75:
+        score = 74
+    if score >= 75:
+        return "strong"
+    if score >= 60:
+        return "moderate"
+    return "weak"
+
+
+def score_affinity(*, scanned: dict, library: list[dict]) -> AffinityResult:
+    scanned_authors = {
+        normalize_author(a) for a in scanned.get("authors", []) if normalize_author(a)}
+    scanned_subjects = {
+        normalize_subject(s) for s in scanned.get("subjects", []) if normalize_subject(s)}
+    scanned_series = normalize_series(scanned.get("series_name"))
+    scanned_lang = (scanned.get("language") or "").lower()[:2] or None
+
+    finished, abandoned = _status_counts(library)
+    no_meta = not (scanned_authors or scanned_subjects or scanned_series)
+    if (finished < 3 and (finished + abandoned) < 5) or no_meta:
+        msg = (f"Not enough reading history yet (you've finished {finished})."
+               if not no_meta else "Not enough metadata on this book to compare.")
+        return AffinityResult(
+            AFFINITY_VERSION, None, "unknown", [Reason("coldstart", "neutral", msg)])
+
+    signals = [s for s in (
+        _author_signal(scanned_authors, library),
+        _theme_signal(scanned_subjects, library),
+        _series_signal(scanned_series, library),
+        _language_signal(scanned_lang, library),
+    ) if s is not None]
+
+    raw = 50 + sum(s.points for s in signals)
+    score = max(0, min(100, round(raw)))
+    families = len({s.kind for s in signals})
+    has_series_pos = any(s.kind == "series" and s.polarity == "positive" for s in signals)
+    band = _band(score, families, has_series_pos)
+
+    ranked = sorted(signals, key=lambda s: abs(s.points), reverse=True)
+    chosen, lang_used = [], False
+    for s in ranked:
+        if s.polarity == "negative" and s.points > -8:
+            continue
+        if s.kind == "language":
+            if lang_used:
+                continue
+            lang_used = True
+        chosen.append(s)
+        if len(chosen) == 4:
+            break
+    return AffinityResult(AFFINITY_VERSION, score, band, chosen)

--- a/server/quire_server/core/affinity.py
+++ b/server/quire_server/core/affinity.py
@@ -1,0 +1,62 @@
+"""Deterministic reader-affinity scorer (no LLM).
+
+Pure functions over in-memory library rows. See
+docs/superpowers/specs/2026-05-29-book-scan-design.md for the rubric.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+
+AFFINITY_VERSION = 1
+
+_GENERIC_SUBJECTS = {
+    "fiction", "general", "literature", "novels",
+    "protected daisy", "accessible book", "large type books",
+}
+_SUBJECT_ALIASES = {
+    "detective and mystery stories": "mystery",
+    "sci-fi": "science fiction",
+    "science fiction": "science fiction",
+    "fantasy fiction": "fantasy",
+    "thrillers": "thriller",
+}
+
+
+def _strip_diacritics(s: str) -> str:
+    return "".join(c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c))
+
+
+def _base_normalize(s: str) -> str:
+    s = _strip_diacritics(s).lower()
+    s = re.sub(r"\([^)]*\)", " ", s)
+    s = re.sub(r"[^\w\s.&'-]", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def normalize_subject(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    s = _base_normalize(raw)
+    s = _SUBJECT_ALIASES.get(s, s)
+    if not s or s in _GENERIC_SUBJECTS:
+        return None
+    return s
+
+
+def normalize_author(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    s = _base_normalize(raw)
+    if "," in raw:
+        last, _, first = (p.strip() for p in raw.partition(","))   # raw, not _base_normalize(raw)
+        if first:
+            s = f"{_base_normalize(first)} {_base_normalize(last)}".strip()
+    return s or None
+
+
+def normalize_series(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    return _base_normalize(raw) or None

--- a/server/quire_server/core/affinity.py
+++ b/server/quire_server/core/affinity.py
@@ -3,6 +3,7 @@
 Pure functions over in-memory library rows. See
 docs/superpowers/specs/2026-05-29-book-scan-design.md for the rubric.
 """
+
 from __future__ import annotations
 
 import re
@@ -12,8 +13,13 @@ from dataclasses import dataclass, field
 AFFINITY_VERSION = 1
 
 _GENERIC_SUBJECTS = {
-    "fiction", "general", "literature", "novels",
-    "protected daisy", "accessible book", "large type books",
+    "fiction",
+    "general",
+    "literature",
+    "novels",
+    "protected daisy",
+    "accessible book",
+    "large type books",
 }
 _SUBJECT_ALIASES = {
     "detective and mystery stories": "mystery",
@@ -51,7 +57,7 @@ def normalize_author(raw: str | None) -> str | None:
         return None
     s = _base_normalize(raw)
     if "," in raw:
-        last, _, first = (p.strip() for p in raw.partition(","))   # raw, not _base_normalize(raw)
+        last, _, first = (p.strip() for p in raw.partition(","))  # raw, not _base_normalize(raw)
         if first:
             s = f"{_base_normalize(first)} {_base_normalize(last)}".strip()
     return s or None
@@ -86,10 +92,18 @@ def _status_counts(library):
 
 
 def _author_signal(scanned_authors, library):
-    finished_titles = [b for b in library if b["status"] == "finished"
-                       and scanned_authors & {normalize_author(a) for a in b["authors"]}]
-    abandoned_titles = [b for b in library if b["status"] == "abandoned"
-                        and scanned_authors & {normalize_author(a) for a in b["authors"]}]
+    finished_titles = [
+        b
+        for b in library
+        if b["status"] == "finished"
+        and scanned_authors & {normalize_author(a) for a in b["authors"]}
+    ]
+    abandoned_titles = [
+        b
+        for b in library
+        if b["status"] == "abandoned"
+        and scanned_authors & {normalize_author(a) for a in b["authors"]}
+    ]
     fm, am = len(finished_titles), len(abandoned_titles)
     if fm > 0:
         pts = min(25, 8 * fm)
@@ -102,8 +116,12 @@ def _author_signal(scanned_authors, library):
 def _theme_signal(scanned_subjects, library):
     best = []
     for theme in scanned_subjects:
-        terminal = [b for b in library if b["status"] in ("finished", "abandoned")
-                    and theme in {normalize_subject(s) for s in b["subjects"]}]
+        terminal = [
+            b
+            for b in library
+            if b["status"] in ("finished", "abandoned")
+            and theme in {normalize_subject(s) for s in b["subjects"]}
+        ]
         if not terminal:
             continue
         fin = sum(1 for b in terminal if b["status"] == "finished")
@@ -118,15 +136,18 @@ def _theme_signal(scanned_subjects, library):
     avg = sum(t[0] for t in top) / len(top)
     pts = round(avg * 30) if avg >= 0 else round(avg * 25)
     if pts == 0:
-        return None   # a net-neutral theme is not a reason worth surfacing
+        return None  # a net-neutral theme is not a reason worth surfacing
     theme, fin, tot = top[0][1], top[0][2], top[0][3]
     if avg >= 0:
         return Reason(
-            "theme", "positive",
+            "theme",
+            "positive",
             f"Matches your high-finish theme '{theme}' ({fin} finished, {tot - fin} abandoned).",
-            pts)
-    return Reason("theme", "negative",
-                  f"You've abandoned {tot - fin} of {tot} books tagged '{theme}'.", pts)
+            pts,
+        )
+    return Reason(
+        "theme", "negative", f"You've abandoned {tot - fin} of {tot} books tagged '{theme}'.", pts
+    )
 
 
 def _series_signal(scanned_series, library):
@@ -155,7 +176,8 @@ def _language_signal(scanned_lang, library):
     dominant, dom_n = top[0]
     if scanned_lang == dominant and dom_n >= 2:
         return Reason(
-            "language", "positive", f"Language matches most of your reading: {dominant}.", 5)
+            "language", "positive", f"Language matches most of your reading: {dominant}.", 5
+        )
     if scanned_lang != dominant and dom_n >= 3 and scanned_lang not in counts:
         return Reason("language", "negative", f"You mostly read in {dominant}.", -5)
     return None
@@ -171,26 +193,36 @@ def _band(score: int) -> str:
 
 def score_affinity(*, scanned: dict, library: list[dict]) -> AffinityResult:
     scanned_authors = {
-        normalize_author(a) for a in scanned.get("authors", []) if normalize_author(a)}
+        normalize_author(a) for a in scanned.get("authors", []) if normalize_author(a)
+    }
     scanned_subjects = {
-        normalize_subject(s) for s in scanned.get("subjects", []) if normalize_subject(s)}
+        normalize_subject(s) for s in scanned.get("subjects", []) if normalize_subject(s)
+    }
     scanned_series = normalize_series(scanned.get("series_name"))
     scanned_lang = (scanned.get("language") or "").lower()[:2] or None
 
     finished, abandoned = _status_counts(library)
     no_meta = not (scanned_authors or scanned_subjects or scanned_series)
     if (finished < 3 and (finished + abandoned) < 5) or no_meta:
-        msg = (f"Not enough reading history yet (you've finished {finished})."
-               if not no_meta else "Not enough metadata on this book to compare.")
+        msg = (
+            f"Not enough reading history yet (you've finished {finished})."
+            if not no_meta
+            else "Not enough metadata on this book to compare."
+        )
         return AffinityResult(
-            AFFINITY_VERSION, None, "unknown", [Reason("coldstart", "neutral", msg)])
+            AFFINITY_VERSION, None, "unknown", [Reason("coldstart", "neutral", msg)]
+        )
 
-    signals = [s for s in (
-        _author_signal(scanned_authors, library),
-        _theme_signal(scanned_subjects, library),
-        _series_signal(scanned_series, library),
-        _language_signal(scanned_lang, library),
-    ) if s is not None]
+    signals = [
+        s
+        for s in (
+            _author_signal(scanned_authors, library),
+            _theme_signal(scanned_subjects, library),
+            _series_signal(scanned_series, library),
+            _language_signal(scanned_lang, library),
+        )
+        if s is not None
+    ]
 
     raw = 50 + sum(s.points for s in signals)
     score = max(0, min(100, round(raw)))

--- a/server/quire_server/core/isbn.py
+++ b/server/quire_server/core/isbn.py
@@ -3,6 +3,7 @@
 A single source of truth so scanned/typed ISBNs are compared and keyed
 consistently (owned-detection, identity.metadata_id="isbn:<isbn13>").
 """
+
 from __future__ import annotations
 
 

--- a/server/quire_server/core/isbn.py
+++ b/server/quire_server/core/isbn.py
@@ -1,0 +1,50 @@
+"""ISBN normalization: validate ISBN-10/13 and canonicalize to ISBN-13.
+
+A single source of truth so scanned/typed ISBNs are compared and keyed
+consistently (owned-detection, identity.metadata_id="isbn:<isbn13>").
+"""
+from __future__ import annotations
+
+
+def _clean(raw: str) -> str:
+    return raw.strip().replace("-", "").replace(" ", "").upper()
+
+
+def _isbn10_valid(s: str) -> bool:
+    if len(s) != 10:
+        return False
+    total = 0
+    for i, ch in enumerate(s):
+        if ch == "X" and i == 9:
+            val = 10
+        elif ch.isdigit():
+            val = int(ch)
+        else:
+            return False
+        total += (10 - i) * val
+    return total % 11 == 0
+
+
+def _isbn13_valid(s: str) -> bool:
+    if len(s) != 13 or not s.isdigit():
+        return False
+    total = sum((1 if i % 2 == 0 else 3) * int(c) for i, c in enumerate(s))
+    return total % 10 == 0
+
+
+def _isbn10_to_13(s: str) -> str:
+    core = "978" + s[:9]
+    check = (10 - sum((1 if i % 2 == 0 else 3) * int(c) for i, c in enumerate(core)) % 10) % 10
+    return core + str(check)
+
+
+def to_isbn13(raw: str | None) -> str | None:
+    """Return the canonical ISBN-13 for a valid ISBN-10/13, else None."""
+    if not raw:
+        return None
+    s = _clean(raw)
+    if _isbn13_valid(s):
+        return s
+    if _isbn10_valid(s):
+        return _isbn10_to_13(s)
+    return None

--- a/server/tests/integration/test_affinity_endpoint.py
+++ b/server/tests/integration/test_affinity_endpoint.py
@@ -1,0 +1,226 @@
+"""End-to-end integration tests for `POST /library/v1/affinity` (task A6).
+
+The endpoint derives a deterministic reader-affinity score from the user's
+library: it joins `LibraryItem -> Document (user_id+content_hash) -> Progress`
+(both outer joins, `deleted_at IS NULL`), maps terminal state to a reading
+status, does owned-detection by ISBN-13 match, and calls the pure
+`score_affinity` scorer.
+
+These tests authenticate as user ``"alice"`` via the default stubbed Basic
+auth installed by ``client_factory`` (the fake maps the Basic username to the
+``user_id``), and seed library state directly through the ``session`` fixture.
+
+Spec reference:
+`docs/superpowers/specs/2026-05-29-book-scan-design.md`.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from quire_server.db.models import Document, LibraryItem, Progress
+
+pytestmark = pytest.mark.requires_progress
+
+# A valid ISBN-13 for "The Hobbit" used across the cold-start / owned tests.
+HOBBIT_ISBN13 = "9780261103573"
+
+
+def _basic_header(user: str, password: str = "p") -> dict[str, str]:
+    token = base64.b64encode(f"{user}:{password}".encode()).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+async def _seed_book(
+    session: AsyncSession,
+    *,
+    user_id: str,
+    content_hash: str,
+    title: str,
+    authors: list[str] | None = None,
+    subjects: list[str] | None = None,
+    series_name: str | None = None,
+    language: str | None = None,
+    isbn: str | None = None,
+    state: str = "unread",
+) -> None:
+    """Insert one alive library book for ``user_id`` plus its progress.
+
+    Creates a ``LibraryItem`` (alive), a matching ``Document`` (same
+    ``user_id`` + ``content_hash`` — the bridge the endpoint joins on), and,
+    unless ``state == "unread"``, a ``Progress`` row keyed by the document's
+    pk. The endpoint maps progress to a reading status:
+
+    * ``finished``   — ``finished_at`` set (``abandoned_at`` must be NULL per
+      the ``ck_progress_abandoned_xor_finished`` constraint).
+    * ``abandoned``  — ``abandoned_at`` set, ``finished_at`` NULL.
+    * ``in_progress``— neither terminal timestamp, ``percent > 0``.
+    * ``unread``     — no progress row at all.
+    """
+    now = datetime.now(UTC)
+    li = LibraryItem(
+        user_id=user_id,
+        content_hash=content_hash,
+        title=title,
+        authors=list(authors or []),
+        subjects=list(subjects or []),
+        series_name=series_name,
+        language=language,
+        isbn=isbn,
+        created_at=now,
+        updated_at=now,
+        deleted_at=None,
+    )
+    session.add(li)
+
+    doc = Document(user_id=user_id, content_hash=content_hash)
+    session.add(doc)
+    await session.flush()  # assign doc.pk
+
+    if state != "unread":
+        prog = Progress(
+            document_pk=doc.pk,
+            locator="epubcfi(/6/2)",
+            percent=1.0 if state == "finished" else 0.5,
+            finished_at=now if state == "finished" else None,
+            abandoned_at=now if state == "abandoned" else None,
+            client_updated_at=now,
+        )
+        session.add(prog)
+
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Cold-start
+# ---------------------------------------------------------------------------
+
+
+async def test_affinity_unknown_when_cold(client_factory, session):
+    """A fresh user (empty library) cannot be profiled → band 'unknown'."""
+    async with client_factory(progress_enabled=True) as client:
+        r = await client.post(
+            "/library/v1/affinity",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"isbn": HOBBIT_ISBN13},
+                "bundle": {
+                    "title": "The Hobbit",
+                    "author": "J.R.R. Tolkien",
+                    "isbn": HOBBIT_ISBN13,
+                    "subjects": ["fantasy"],
+                },
+            },
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["band"] == "unknown"
+    assert body["score"] is None
+    assert body["affinity_version"] >= 1
+    kinds = {reason["kind"] for reason in body["reasons"]}
+    assert "coldstart" in kinds, body["reasons"]
+
+
+# ---------------------------------------------------------------------------
+# Owned detection
+# ---------------------------------------------------------------------------
+
+
+async def test_affinity_owned_detection(client_factory, session):
+    """A scanned ISBN already in the library is flagged owned, with status."""
+    await _seed_book(
+        session,
+        user_id="alice",
+        content_hash="ch-hobbit",
+        title="The Hobbit",
+        authors=["J.R.R. Tolkien"],
+        subjects=["fantasy"],
+        isbn=HOBBIT_ISBN13,
+        state="finished",
+    )
+
+    async with client_factory(progress_enabled=True) as client:
+        r = await client.post(
+            "/library/v1/affinity",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"isbn": HOBBIT_ISBN13},
+                "bundle": {
+                    "title": "The Hobbit",
+                    "author": "J.R.R. Tolkien",
+                    "isbn": HOBBIT_ISBN13,
+                    "subjects": ["fantasy"],
+                },
+            },
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["owned"] is not None, body
+    assert body["owned"]["in_library"] is True
+    assert body["owned"]["reading_status"] == "finished"
+
+
+# ---------------------------------------------------------------------------
+# Strong match
+# ---------------------------------------------------------------------------
+
+
+async def test_affinity_strong_match(client_factory, session):
+    """4 finished books by one author/theme → high score + positive author."""
+    for i in range(4):
+        await _seed_book(
+            session,
+            user_id="alice",
+            content_hash=f"ch-jane-{i}",
+            title=f"Jane Mystery {i}",
+            authors=["Jane Doe"],
+            subjects=["mystery"],
+            state="finished",
+        )
+
+    async with client_factory(progress_enabled=True) as client:
+        r = await client.post(
+            "/library/v1/affinity",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"content_hash": "ch-jane-new"},
+                "bundle": {
+                    "title": "Jane's Newest Mystery",
+                    "author": "Jane Doe",
+                    "subjects": ["mystery"],
+                },
+            },
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["score"] is not None, body
+    assert body["score"] >= 60, body
+    author_reasons = [
+        reason
+        for reason in body["reasons"]
+        if reason["kind"] == "author" and reason["polarity"] == "positive"
+    ]
+    assert author_reasons, body["reasons"]
+
+
+# ---------------------------------------------------------------------------
+# Mode gating
+# ---------------------------------------------------------------------------
+
+
+async def test_affinity_absent_when_progress_disabled(client_factory, session):
+    """With progress disabled the library router isn't mounted → 404."""
+    async with client_factory(progress_enabled=False) as client:
+        r = await client.post(
+            "/library/v1/affinity",
+            headers=_basic_header("alice"),
+            json={
+                "identity": {"isbn": HOBBIT_ISBN13},
+                "bundle": {"title": "The Hobbit", "isbn": HOBBIT_ISBN13},
+            },
+        )
+    assert r.status_code == 404, r.text

--- a/server/tests/unit/test_affinity_scorer.py
+++ b/server/tests/unit/test_affinity_scorer.py
@@ -69,3 +69,30 @@ def test_version_present():
         scanned={"authors": [], "subjects": [], "series_name": None, "language": "en"}, library=[])
     assert res.version == AFFINITY_VERSION
     assert res.band == "unknown"
+
+
+def test_confidence_guard_caps_score_and_band_consistently():
+    # Single signal family (author only) would raw to 50+25=75 ("strong");
+    # the guard must cap BOTH score and band so they never disagree.
+    lib = [_lib(f"b{i}", ["Jane Doe"], ["cooking"], "finished") for i in range(4)]
+    res = score_affinity(
+        scanned={"authors": ["Jane Doe"], "subjects": ["astronomy"],
+                 "series_name": None, "language": None},
+        library=lib,
+    )
+    assert res.score is not None and res.score <= 74
+    assert res.band == "moderate"
+
+
+def test_zero_affinity_theme_emits_no_reason():
+    # A theme with an exact 50/50 finish/abandon split contributes 0 points
+    # and must NOT surface as a positive reason.
+    lib = ([_lib(f"m{i}", ["A"], ["mystery"], "finished") for i in range(3)]
+           + [_lib("n1", ["B"], ["noir"], "finished"),
+              _lib("n2", ["C"], ["noir"], "abandoned")])
+    res = score_affinity(
+        scanned={"authors": ["Nobody"], "subjects": ["noir"],
+                 "series_name": None, "language": None},
+        library=lib,
+    )
+    assert not any(r.kind == "theme" for r in res.reasons)

--- a/server/tests/unit/test_affinity_scorer.py
+++ b/server/tests/unit/test_affinity_scorer.py
@@ -25,15 +25,23 @@ def test_normalize_series():
 
 
 def _lib(title, authors, subjects, status, series=None, language="en"):
-    return {"authors": authors, "subjects": subjects, "series_name": series,
-            "language": language, "status": status}
+    return {
+        "authors": authors,
+        "subjects": subjects,
+        "series_name": series,
+        "language": language,
+        "status": status,
+    }
 
 
 def test_cold_start_returns_unknown():
     res = score_affinity(
         scanned={
-            "authors": ["Jane Doe"], "subjects": ["mystery"],
-            "series_name": None, "language": "en"},
+            "authors": ["Jane Doe"],
+            "subjects": ["mystery"],
+            "series_name": None,
+            "language": "en",
+        },
         library=[_lib("A", ["Jane Doe"], ["mystery"], "finished")],
     )
     assert res.band == "unknown"
@@ -45,8 +53,11 @@ def test_strong_author_and_theme_match():
     lib = [_lib(f"b{i}", ["Jane Doe"], ["mystery"], "finished") for i in range(4)]
     res = score_affinity(
         scanned={
-            "authors": ["Jane Doe"], "subjects": ["mystery"],
-            "series_name": None, "language": "en"},
+            "authors": ["Jane Doe"],
+            "subjects": ["mystery"],
+            "series_name": None,
+            "language": "en",
+        },
         library=lib,
     )
     assert res.band in ("strong", "moderate")
@@ -55,8 +66,9 @@ def test_strong_author_and_theme_match():
 
 
 def test_abandoned_theme_is_negative():
-    lib = [_lib(f"b{i}", ["X"], ["horror"], "abandoned") for i in range(3)] + \
-          [_lib(f"f{i}", ["Y"], ["mystery"], "finished") for i in range(3)]
+    lib = [_lib(f"b{i}", ["X"], ["horror"], "abandoned") for i in range(3)] + [
+        _lib(f"f{i}", ["Y"], ["mystery"], "finished") for i in range(3)
+    ]
     res = score_affinity(
         scanned={"authors": ["Z"], "subjects": ["horror"], "series_name": None, "language": "en"},
         library=lib,
@@ -66,7 +78,8 @@ def test_abandoned_theme_is_negative():
 
 def test_version_present():
     res = score_affinity(
-        scanned={"authors": [], "subjects": [], "series_name": None, "language": "en"}, library=[])
+        scanned={"authors": [], "subjects": [], "series_name": None, "language": "en"}, library=[]
+    )
     assert res.version == AFFINITY_VERSION
     assert res.band == "unknown"
 
@@ -76,8 +89,12 @@ def test_confidence_guard_caps_score_and_band_consistently():
     # the guard must cap BOTH score and band so they never disagree.
     lib = [_lib(f"b{i}", ["Jane Doe"], ["cooking"], "finished") for i in range(4)]
     res = score_affinity(
-        scanned={"authors": ["Jane Doe"], "subjects": ["astronomy"],
-                 "series_name": None, "language": None},
+        scanned={
+            "authors": ["Jane Doe"],
+            "subjects": ["astronomy"],
+            "series_name": None,
+            "language": None,
+        },
         library=lib,
     )
     assert res.score is not None and res.score <= 74
@@ -87,12 +104,17 @@ def test_confidence_guard_caps_score_and_band_consistently():
 def test_zero_affinity_theme_emits_no_reason():
     # A theme with an exact 50/50 finish/abandon split contributes 0 points
     # and must NOT surface as a positive reason.
-    lib = ([_lib(f"m{i}", ["A"], ["mystery"], "finished") for i in range(3)]
-           + [_lib("n1", ["B"], ["noir"], "finished"),
-              _lib("n2", ["C"], ["noir"], "abandoned")])
+    lib = [_lib(f"m{i}", ["A"], ["mystery"], "finished") for i in range(3)] + [
+        _lib("n1", ["B"], ["noir"], "finished"),
+        _lib("n2", ["C"], ["noir"], "abandoned"),
+    ]
     res = score_affinity(
-        scanned={"authors": ["Nobody"], "subjects": ["noir"],
-                 "series_name": None, "language": None},
+        scanned={
+            "authors": ["Nobody"],
+            "subjects": ["noir"],
+            "series_name": None,
+            "language": None,
+        },
         library=lib,
     )
     assert not any(r.kind == "theme" for r in res.reasons)

--- a/server/tests/unit/test_affinity_scorer.py
+++ b/server/tests/unit/test_affinity_scorer.py
@@ -1,4 +1,10 @@
-from quire_server.core.affinity import normalize_author, normalize_series, normalize_subject
+from quire_server.core.affinity import (
+    AFFINITY_VERSION,
+    normalize_author,
+    normalize_series,
+    normalize_subject,
+    score_affinity,
+)
 
 
 def test_normalize_subject_drops_generic_and_aliases():
@@ -16,3 +22,50 @@ def test_normalize_author_handles_last_first_and_diacritics():
 
 def test_normalize_series():
     assert normalize_series("The Expanse ") == "the expanse"
+
+
+def _lib(title, authors, subjects, status, series=None, language="en"):
+    return {"authors": authors, "subjects": subjects, "series_name": series,
+            "language": language, "status": status}
+
+
+def test_cold_start_returns_unknown():
+    res = score_affinity(
+        scanned={
+            "authors": ["Jane Doe"], "subjects": ["mystery"],
+            "series_name": None, "language": "en"},
+        library=[_lib("A", ["Jane Doe"], ["mystery"], "finished")],
+    )
+    assert res.band == "unknown"
+    assert res.score is None
+    assert any(r.kind == "coldstart" for r in res.reasons)
+
+
+def test_strong_author_and_theme_match():
+    lib = [_lib(f"b{i}", ["Jane Doe"], ["mystery"], "finished") for i in range(4)]
+    res = score_affinity(
+        scanned={
+            "authors": ["Jane Doe"], "subjects": ["mystery"],
+            "series_name": None, "language": "en"},
+        library=lib,
+    )
+    assert res.band in ("strong", "moderate")
+    assert res.score is not None and res.score >= 60
+    assert any(r.kind == "author" and r.polarity == "positive" for r in res.reasons)
+
+
+def test_abandoned_theme_is_negative():
+    lib = [_lib(f"b{i}", ["X"], ["horror"], "abandoned") for i in range(3)] + \
+          [_lib(f"f{i}", ["Y"], ["mystery"], "finished") for i in range(3)]
+    res = score_affinity(
+        scanned={"authors": ["Z"], "subjects": ["horror"], "series_name": None, "language": "en"},
+        library=lib,
+    )
+    assert any(r.kind == "theme" and r.polarity == "negative" for r in res.reasons)
+
+
+def test_version_present():
+    res = score_affinity(
+        scanned={"authors": [], "subjects": [], "series_name": None, "language": "en"}, library=[])
+    assert res.version == AFFINITY_VERSION
+    assert res.band == "unknown"

--- a/server/tests/unit/test_affinity_scorer.py
+++ b/server/tests/unit/test_affinity_scorer.py
@@ -1,0 +1,18 @@
+from quire_server.core.affinity import normalize_author, normalize_series, normalize_subject
+
+
+def test_normalize_subject_drops_generic_and_aliases():
+    assert normalize_subject("Fiction") is None
+    assert normalize_subject("Science Fiction") == "science fiction"
+    assert normalize_subject("Sci-Fi") == "science fiction"
+    assert normalize_subject("Detective and mystery stories") == "mystery"
+    assert normalize_subject("  Historical Fiction (Genre) ") == "historical fiction"
+
+
+def test_normalize_author_handles_last_first_and_diacritics():
+    assert normalize_author("Le Guin, Ursula K.") == "ursula k. le guin"
+    assert normalize_author("Gabriel García Márquez") == "gabriel garcia marquez"
+
+
+def test_normalize_series():
+    assert normalize_series("The Expanse ") == "the expanse"

--- a/server/tests/unit/test_isbn.py
+++ b/server/tests/unit/test_isbn.py
@@ -1,0 +1,29 @@
+from quire_server.core.isbn import to_isbn13
+
+
+def test_isbn13_passthrough():
+    assert to_isbn13("9780261103573") == "9780261103573"
+
+
+def test_isbn13_strips_hyphens_and_spaces():
+    assert to_isbn13("978-0-261-10357-3") == "9780261103573"
+    assert to_isbn13("  9780261103573 ") == "9780261103573"
+
+
+def test_isbn10_converts_to_isbn13():
+    assert to_isbn13("0261103571") == "9780261103573"
+
+
+def test_isbn10_with_x_check_digit():
+    assert to_isbn13("080442957X") == "9780804429573"
+
+
+def test_invalid_checksum_returns_none():
+    assert to_isbn13("9780261103574") is None
+    assert to_isbn13("0261103572") is None
+
+
+def test_garbage_returns_none():
+    assert to_isbn13("") is None
+    assert to_isbn13("hello") is None
+    assert to_isbn13("12345") is None


### PR DESCRIPTION
Tier-1 of the **book-scan** feature: a deterministic, **no-LLM** reader-affinity endpoint that scores how well a (scanned) book fits the user's reading taste, with explainable reasons. Inert until the Android client calls it (Track B, separate).

Design spec: `docs/superpowers/specs/2026-05-29-book-scan-design.md` (uncommitted, per repo convention).

## What's here
- **`core/isbn.py`** — `to_isbn13()`: validate ISBN-10/13, canonicalize to ISBN-13 (used for owned-detection + identity keying).
- **`core/affinity.py`** — subject/author/series normalization + `score_affinity()`. Weighted signals (author / theme-with-sample-size-shrinkage / series / language) over a neutral 50 baseline → 0–100 score + band (strong/moderate/weak/unknown). Cold-start → `unknown`. Reason selection with count-backed phrasing. Deterministic; no LLM, no new tables.
- **`api/affinity_schemas.py`** — request/response models (`extra="forbid"`).
- **`api/library.py`** — `POST /library/v1/affinity`: loads the user's alive library (`LibraryItem → Document → Progress`, the same bridge as `get_stats`), derives reading status, ISBN-13 owned-detection, calls the scorer. Mounted under `/library/v1` (gated by `progress_enabled` → `404` when off); primary `current_user_id` auth — **deliberately not** AI-gated (no `ai_enabled` / opt-in), since it's deterministic and library-derived.

## Why under `/library/v1` (not `/ai/v1`)
Affinity is deterministic library analysis with no LLM, so coupling it to `ai_enabled`/AI opt-in would be wrong. It lives with the library data it reads.

## Testing
17 new tests (ISBN canonicalization, scorer signal-mixes/cold-start/confidence-guard/neutral-theme, endpoint integration: owned / cold-start / strong-match / 404-when-progress-disabled). Full server suite **546 passed**, ruff clean. Reviewed (incl. GPT design review of the scoring rubric); fixed a score/band-consistency bug and a net-neutral-theme reason found in review.

Note: affinity weights are a tunable starting point (`AFFINITY_VERSION` is in the response so changes are observable).