### PR TITLE
Restore in-progress books

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -6,7 +6,6 @@ import io.theficos.ereader.core.identity.extractIdentity
 import io.theficos.ereader.core.metadata.readOpfBundle
 import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.core.model.DocumentIdentity
-import io.theficos.ereader.domain.restore.RestoreInProgressUseCase
 import io.theficos.ereader.data.ai.AiClient
 import io.theficos.ereader.data.ai.AiRepository
 import io.theficos.ereader.data.ai.CatalogInsightStash
@@ -19,6 +18,7 @@ import io.theficos.ereader.data.library.sync.LibraryMirrorPushScheduler
 import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.ProgressRepository
 import io.theficos.ereader.data.local.db.EReaderDatabase
+import io.theficos.ereader.data.local.db.ProgressDao
 import io.theficos.ereader.data.opds.BookDownloader
 import io.theficos.ereader.data.opds.OpdsClient
 import io.theficos.ereader.data.opds.OpdsHttpClient
@@ -26,6 +26,7 @@ import io.theficos.ereader.data.sync.SyncClient
 import io.theficos.ereader.data.sync.SyncDependencies
 import io.theficos.ereader.data.sync.SyncEnqueuer
 import io.theficos.ereader.data.sync.SyncOrchestrator
+import io.theficos.ereader.domain.restore.RestoreInProgressUseCase
 import io.theficos.ereader.reader.ReaderPreferencesStore
 import io.theficos.ereader.reader.ReadiumFactory
 import io.theficos.ereader.sideload.SideloadImporter
@@ -52,7 +53,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import io.theficos.ereader.data.local.db.ProgressDao
 
 /**
  * URL that sync/library/AI clients should target. For [AccountCredentials.Basic]
@@ -294,9 +294,9 @@ class AppContainer(context: Context) {
         downloadAndInsert = { c ->
             val fileName = "${java.util.UUID.randomUUID()}.epub"
             val file = bookDownloader.download(c.opdsHref, fileName) { _, _ -> }
-            val coverFile = runCatching {
-                bookDownloader.downloadCover(c.opdsHref, fileName.removeSuffix(".epub") + ".cover")
-            }.getOrNull()
+            // Library mirror carries no cover URL; skip cover download (matches CatalogViewModel's
+            // pub.coverUrl?.let { ... } returning null). Restored books fall back to the default cover.
+            val coverFile: java.io.File? = null
             val identity = extractIdentity(file)
             if (documentRepository.findByIdentity(identity) != null) {
                 file.delete()

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -294,26 +294,33 @@ class AppContainer(context: Context) {
         downloadAndInsert = { c ->
             val fileName = "${java.util.UUID.randomUUID()}.epub"
             val file = bookDownloader.download(c.opdsHref, fileName) { _, _ -> }
-            // Library mirror carries no cover URL; skip cover download (matches CatalogViewModel's
-            // pub.coverUrl?.let { ... } returning null). Restored books fall back to the default cover.
             val coverFile: java.io.File? = null
-            val identity = extractIdentity(file)
-            if (documentRepository.findByIdentity(identity) != null) {
+            // If identity extraction / OPF read / insert throws after the bytes
+            // landed, delete the temp file before rethrowing so a re-run (this
+            // feature is explicitly re-runnable) doesn't accumulate orphans.
+            try {
+                val identity = extractIdentity(file)
+                if (documentRepository.findByIdentity(identity) != null) {
+                    file.delete()
+                    coverFile?.delete()
+                } else {
+                    val opf = readOpfBundle(file, fallbackTitle = c.title)
+                    documentRepository.insert(
+                        identity = identity,
+                        title = c.title,
+                        author = c.authors.firstOrNull(),
+                        downloadUrl = c.opdsHref,
+                        localPath = file.absolutePath,
+                        coverPath = coverFile?.absolutePath,
+                        downloadedAt = System.currentTimeMillis(),
+                        seriesName = opf.seriesName,
+                        seriesIndex = opf.seriesPosition?.toDouble(),
+                    )
+                }
+            } catch (t: Throwable) {
                 file.delete()
                 coverFile?.delete()
-            } else {
-                val opf = readOpfBundle(file, fallbackTitle = c.title)
-                documentRepository.insert(
-                    identity = identity,
-                    title = c.title,
-                    author = c.authors.firstOrNull(),
-                    downloadUrl = c.opdsHref,
-                    localPath = file.absolutePath,
-                    coverPath = coverFile?.absolutePath,
-                    downloadedAt = System.currentTimeMillis(),
-                    seriesName = opf.seriesName,
-                    seriesIndex = opf.seriesPosition?.toDouble(),
-                )
+                throw t
             }
         },
         applyPositions = { items -> syncOrchestrator.applyProgressItems(items) },

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -2,8 +2,11 @@ package io.theficos.ereader.di
 
 import android.content.Context
 import io.theficos.ereader.auth.CalibreCredentialStore
+import io.theficos.ereader.core.identity.extractIdentity
+import io.theficos.ereader.core.metadata.readOpfBundle
 import io.theficos.ereader.core.model.Document
 import io.theficos.ereader.core.model.DocumentIdentity
+import io.theficos.ereader.domain.restore.RestoreInProgressUseCase
 import io.theficos.ereader.data.ai.AiClient
 import io.theficos.ereader.data.ai.AiRepository
 import io.theficos.ereader.data.ai.CatalogInsightStash
@@ -263,6 +266,58 @@ class AppContainer(context: Context) {
                 }
             },
         )
+
+    /**
+     * Restore-after-reinstall use case (Tasks 1–4). Assembles
+     * [RestoreInProgressUseCase] with the real OPDS/sync/library/Room
+     * collaborators. Unlike the catalog download path this deliberately
+     * does NOT re-upload to /library/v1/items: the server mirror already
+     * holds the row we joined on, so a re-upload would be redundant.
+     *
+     * Best-effort throughout: a missing mirror, an offline/401 progress
+     * pull, or a single failed download must not abort the whole run.
+     * Callers (Tasks 5/6) own when this fires.
+     */
+    fun restoreInProgressUseCase(): RestoreInProgressUseCase = RestoreInProgressUseCase(
+        fetchLibraryItems = {
+            libraryClient.listAllItems(
+                onTruncated = { n -> android.util.Log.w("Restore", "library mirror truncated at $n items") },
+            )
+        },
+        fetchInProgress = {
+            when (val res = syncClient.pullProgress(java.time.Instant.EPOCH.toString())) {
+                is io.theficos.ereader.data.sync.SyncResult.Success -> res.value.items
+                else -> emptyList() // best-effort: offline / 401 -> nothing to restore
+            }
+        },
+        isPresent = { identity -> documentRepository.findByIdentity(identity) != null },
+        downloadAndInsert = { c ->
+            val fileName = "${java.util.UUID.randomUUID()}.epub"
+            val file = bookDownloader.download(c.opdsHref, fileName) { _, _ -> }
+            val coverFile = runCatching {
+                bookDownloader.downloadCover(c.opdsHref, fileName.removeSuffix(".epub") + ".cover")
+            }.getOrNull()
+            val identity = extractIdentity(file)
+            if (documentRepository.findByIdentity(identity) != null) {
+                file.delete()
+                coverFile?.delete()
+            } else {
+                val opf = readOpfBundle(file, fallbackTitle = c.title)
+                documentRepository.insert(
+                    identity = identity,
+                    title = c.title,
+                    author = c.authors.firstOrNull(),
+                    downloadUrl = c.opdsHref,
+                    localPath = file.absolutePath,
+                    coverPath = coverFile?.absolutePath,
+                    downloadedAt = System.currentTimeMillis(),
+                    seriesName = opf.seriesName,
+                    seriesIndex = opf.seriesPosition?.toDouble(),
+                )
+            }
+        },
+        applyPositions = { items -> syncOrchestrator.applyProgressItems(items) },
+    )
 
     private suspend fun readOpfBytes(doc: Document): ByteArray? = withContext(Dispatchers.IO) {
         runCatching {

--- a/app/src/main/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCase.kt
+++ b/app/src/main/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCase.kt
@@ -1,0 +1,95 @@
+package io.theficos.ereader.domain.restore
+
+import io.theficos.ereader.core.model.DocumentIdentity
+import io.theficos.ereader.data.library.LibraryItemResponse
+import io.theficos.ereader.data.sync.ProgressItemDto
+
+/** Outcome counters for one restore run, rendered as a snackbar summary. */
+data class RestoreSummary(
+    val requested: Int,
+    val downloaded: Int,
+    val skippedExisting: Int,
+    val skippedUnfetchable: Int,
+    val failed: Int,
+)
+
+/** One book selected for restore: an in-progress position joined to its mirror row. */
+data class RestoreCandidate(
+    val progress: ProgressItemDto,
+    val opdsHref: String,
+    val title: String,
+    val authors: List<String>,
+) {
+    val identity: DocumentIdentity
+        get() = DocumentIdentity(
+            metadataId = progress.document.metadataId,
+            contentHash = progress.document.contentHash,
+            identityHashVersion = progress.document.identityHashVersion,
+        )
+}
+
+/**
+ * Best-effort restore of in-progress books after a fresh install / data wipe.
+ *
+ * Collaborators are injected as suspend lambdas so the join/filter logic is
+ * unit-testable without OkHttp/Room. Real wiring lives in [AppContainer].
+ *
+ * Flow: pull mirror -> pull progress -> keep in-progress (not finished, not
+ * abandoned, percent > [minPercentExclusive]) -> join on content_hash for the
+ * download href -> per book: skip if unfetchable or already present, else
+ * download+insert -> finally apply the pulled positions so restored books open
+ * where the user left off.
+ */
+class RestoreInProgressUseCase(
+    private val fetchLibraryItems: suspend () -> List<LibraryItemResponse>,
+    private val fetchInProgress: suspend () -> List<ProgressItemDto>,
+    private val isPresent: suspend (DocumentIdentity) -> Boolean,
+    private val downloadAndInsert: suspend (RestoreCandidate) -> Unit,
+    private val applyPositions: suspend (List<ProgressItemDto>) -> Unit,
+    private val minPercentExclusive: Double = 0.0,
+) {
+    suspend fun run(): RestoreSummary {
+        val mirrorByHash = fetchLibraryItems().associateBy { it.contentHash }
+        val inProgress = fetchInProgress().filter {
+            it.finishedAt == null && it.abandonedAt == null && it.percent > minPercentExclusive
+        }
+        val candidates = inProgress.mapNotNull { p ->
+            val item = mirrorByHash[p.document.contentHash] ?: return@mapNotNull null
+            val href = item.opdsHref ?: return@mapNotNull null
+            RestoreCandidate(progress = p, opdsHref = href, title = item.title, authors = item.authors)
+        }
+
+        var downloaded = 0
+        var skippedExisting = 0
+        var skippedUnfetchable = 0
+        var failed = 0
+        for (c in candidates) {
+            when {
+                !isHttp(c.opdsHref) -> skippedUnfetchable++
+                isPresent(c.identity) -> skippedExisting++
+                else -> try {
+                    downloadAndInsert(c)
+                    downloaded++
+                } catch (t: Throwable) {
+                    failed++
+                }
+            }
+        }
+
+        // Restore positions for every in-progress item; items whose document
+        // isn't present are silently skipped inside applyPositions. Best-effort:
+        // a failure here must not flip an otherwise-successful restore.
+        runCatching { applyPositions(inProgress) }
+
+        return RestoreSummary(
+            requested = candidates.size,
+            downloaded = downloaded,
+            skippedExisting = skippedExisting,
+            skippedUnfetchable = skippedUnfetchable,
+            failed = failed,
+        )
+    }
+
+    private fun isHttp(href: String): Boolean =
+        href.startsWith("http://") || href.startsWith("https://")
+}

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -111,6 +111,8 @@ fun AppNavGraph(container: AppContainer) {
                     syncOrchestrator = container.syncOrchestrator,
                     booksDir = container.booksDir,
                     libraryPreferencesStore = container.libraryPreferencesStore,
+                    credentialStore = container.credentialStore,
+                    restoreInProgress = { container.restoreInProgressUseCase().run() },
                 )
             }
             val catVm = remember {

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -140,6 +140,7 @@ fun AppNavGraph(container: AppContainer) {
                     aiRepository = container.aiRepository,
                     insightSyncRepository = container.insightSyncRepository,
                     insightDao = container.insightDao,
+                    restoreInProgress = { container.restoreInProgressUseCase().run() },
                 )
             }
             val aiConfig by container.aiRepository.config.collectAsState()

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -64,6 +66,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.theficos.ereader.core.model.Document
@@ -122,13 +125,21 @@ fun LibraryScreen(
     val scope = rememberCoroutineScope()
     var searchActive by rememberSaveable { mutableStateOf(false) }
     val query by viewModel.query.collectAsState()
+    val canRestore by viewModel.canRestore.collectAsState()
+    val restoreRunning by viewModel.restoreRunning.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
-            when (event) {
-                LibraryEvent.RestartFailed ->
-                    snackbarHostState.showSnackbar("Couldn't sync restart — will retry.")
+            val msg = when (event) {
+                LibraryEvent.RestartFailed -> "Couldn't sync restart — will retry."
+                is LibraryEvent.RestoreFinished -> {
+                    val s = event.summary
+                    "Restored ${s.downloaded} of ${s.requested}" +
+                        if (s.failed > 0) " · ${s.failed} failed" else ""
+                }
+                is LibraryEvent.RestoreFailed -> "Restore failed: ${event.message}"
             }
+            snackbarHostState.showSnackbar(msg)
         }
     }
 
@@ -165,7 +176,11 @@ fun LibraryScreen(
         EmptyState(
             modifier = Modifier.padding(contentPadding),
             onImport = launchPicker,
+            canRestore = canRestore,
+            restoreRunning = restoreRunning,
+            onRestore = { viewModel.restoreInProgressBooks() },
         )
+        SnackbarHost(hostState = snackbarHostState)
         return
     }
 
@@ -536,7 +551,13 @@ fun LibraryScreen(
 }
 
 @Composable
-private fun EmptyState(modifier: Modifier = Modifier, onImport: (() -> Unit)? = null) {
+private fun EmptyState(
+    modifier: Modifier = Modifier,
+    onImport: (() -> Unit)? = null,
+    canRestore: Boolean = false,
+    restoreRunning: Boolean = false,
+    onRestore: () -> Unit = {},
+) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
@@ -568,6 +589,22 @@ private fun EmptyState(modifier: Modifier = Modifier, onImport: (() -> Unit)? = 
                     Icon(Icons.Filled.Add, contentDescription = null)
                     Text(text = "Import EPUB", modifier = Modifier.padding(start = 8.dp))
                 }
+            }
+            // Task 6: empty-state restore prompt — only when an account is
+            // connected and the library is empty (reconnected on a new device).
+            if (canRestore) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    "Reconnected on a new device? Bring back the books you were reading.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    onClick = onRestore,
+                    enabled = !restoreRunning,
+                ) { Text(if (restoreRunning) "Restoring…" else "Restore in-progress books") }
             }
         }
     }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
@@ -173,14 +173,19 @@ fun LibraryScreen(
     }
 
     if (items.isEmpty() && !searchActive && query.isBlank()) {
-        EmptyState(
-            modifier = Modifier.padding(contentPadding),
-            onImport = launchPicker,
-            canRestore = canRestore,
-            restoreRunning = restoreRunning,
-            onRestore = { viewModel.restoreInProgressBooks() },
-        )
-        SnackbarHost(hostState = snackbarHostState)
+        Box(modifier = Modifier.fillMaxSize()) {
+            EmptyState(
+                modifier = Modifier.padding(contentPadding),
+                onImport = launchPicker,
+                canRestore = canRestore,
+                restoreRunning = restoreRunning,
+                onRestore = { viewModel.restoreInProgressBooks() },
+            )
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+        }
         return
     }
 

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
@@ -26,6 +26,8 @@ import java.io.File
 
 sealed interface LibraryEvent {
     data object RestartFailed : LibraryEvent
+    data class RestoreFinished(val summary: io.theficos.ereader.domain.restore.RestoreSummary) : LibraryEvent
+    data class RestoreFailed(val message: String) : LibraryEvent
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -37,6 +39,8 @@ class LibraryViewModel(
     private val libraryPreferencesStore: LibraryPreferencesStore,
     private val nowMillis: () -> Long = System::currentTimeMillis,
     private val syncEnqueuer: (Context) -> Unit = { SyncEnqueuer.enqueue(it, expedited = true, replaceExisting = true) },
+    private val credentialStore: io.theficos.ereader.auth.CalibreCredentialStore? = null,
+    private val restoreInProgress: (suspend () -> io.theficos.ereader.domain.restore.RestoreSummary)? = null,
 ) : ViewModel() {
 
     val sort: StateFlow<LibrarySort> = libraryPreferencesStore.flow
@@ -118,6 +122,37 @@ class LibraryViewModel(
 
     private val _events = MutableSharedFlow<LibraryEvent>(extraBufferCapacity = 4)
     val events: SharedFlow<LibraryEvent> = _events.asSharedFlow()
+
+    private val connected: StateFlow<Boolean> =
+        (credentialStore?.accountFlow?.map { it != null } ?: flowOf(false))
+            .stateIn(viewModelScope, SharingStarted.Eagerly, credentialStore?.accountFlow?.value != null)
+
+    /**
+     * True only when the library is empty AND an account is connected — the
+     * one situation where the empty-state "Restore in-progress books" prompt
+     * is worth surfacing (reconnected on a new/wiped device).
+     */
+    val canRestore: StateFlow<Boolean> =
+        combine(rows, connected) { r, conn -> conn && r.isEmpty() }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    private val _restoreRunning = kotlinx.coroutines.flow.MutableStateFlow(false)
+    val restoreRunning: StateFlow<Boolean> = _restoreRunning.asStateFlow()
+
+    fun restoreInProgressBooks() {
+        val restore = restoreInProgress ?: return
+        if (_restoreRunning.value) return
+        _restoreRunning.value = true
+        viewModelScope.launch {
+            try {
+                _events.tryEmit(LibraryEvent.RestoreFinished(restore()))
+            } catch (t: Throwable) {
+                _events.tryEmit(LibraryEvent.RestoreFailed(t.message ?: t.javaClass.simpleName))
+            } finally {
+                _restoreRunning.value = false
+            }
+        }
+    }
 
     fun delete(document: Document) {
         viewModelScope.launch { docs.delete(document) }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
@@ -134,7 +134,7 @@ class LibraryViewModel(
      */
     val canRestore: StateFlow<Boolean> =
         combine(rows, connected) { r, conn -> conn && r.isEmpty() }
-            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     private val _restoreRunning = kotlinx.coroutines.flow.MutableStateFlow(false)
     val restoreRunning: StateFlow<Boolean> = _restoreRunning.asStateFlow()

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
@@ -74,6 +74,8 @@ fun SettingsScreen(
     val reader by viewModel.readerPreferences.collectAsState()
     val aiState by viewModel.ai.collectAsState()
     val deleteInFlight by viewModel.deleteProfileInFlight.collectAsState()
+    val isConnected by viewModel.isConnected.collectAsState()
+    val restoreRunning by viewModel.restoreRunning.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
@@ -82,6 +84,12 @@ fun SettingsScreen(
                 SettingsEvent.ProfileDeleted -> "Reader profile deleted."
                 is SettingsEvent.ProfileDeleteFailed ->
                     "Couldn't delete reader profile: ${event.message}"
+                is SettingsEvent.RestoreFinished -> {
+                    val s = event.summary
+                    val failTail = if (s.failed > 0) " · ${s.failed} failed" else ""
+                    "Restored ${s.downloaded} of ${s.requested}$failTail"
+                }
+                is SettingsEvent.RestoreFailed -> "Restore failed: ${event.message}"
             }
             snackbarHostState.showSnackbar(msg)
         }
@@ -245,6 +253,20 @@ fun SettingsScreen(
                         onClick = { pendingRemoveAll = true },
                         colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
                     ) { Text("Remove all downloaded books") }
+                }
+                if (isConnected) {
+                    Column {
+                        Text("Restore in-progress books", style = MaterialTheme.typography.titleMedium)
+                        Text(
+                            "Re-download the books you'd started reading and restore where you left off. Useful after a reinstall.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        TextButton(
+                            onClick = { viewModel.restoreInProgressBooks() },
+                            enabled = !restoreRunning,
+                        ) { Text(if (restoreRunning) "Restoring…" else "Restore in-progress books") }
+                    }
                 }
             }
 

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
@@ -269,8 +269,8 @@ class SettingsViewModel(
     fun restoreInProgressBooks() {
         val restore = restoreInProgress ?: return
         if (_restoreRunning.value) return
+        _restoreRunning.value = true
         viewModelScope.launch {
-            _restoreRunning.value = true
             try {
                 _events.tryEmit(SettingsEvent.RestoreFinished(restore()))
             } catch (t: Throwable) {

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.db.InsightDao
 import io.theficos.ereader.data.local.db.SyncStateDao
 import io.theficos.ereader.data.sync.SyncEnqueuer
+import io.theficos.ereader.domain.restore.RestoreSummary
 import java.io.File
 import io.theficos.ereader.reader.ReaderFontFamily
 import io.theficos.ereader.reader.ReaderPreferences
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -58,6 +60,8 @@ sealed interface InsightSyncStatus {
 sealed interface SettingsEvent {
     data object ProfileDeleted : SettingsEvent
     data class ProfileDeleteFailed(val message: String) : SettingsEvent
+    data class RestoreFinished(val summary: RestoreSummary) : SettingsEvent
+    data class RestoreFailed(val message: String) : SettingsEvent
 }
 
 class SettingsViewModel(
@@ -70,6 +74,7 @@ class SettingsViewModel(
     private val insightSyncRepository: InsightSyncRepository? = null,
     private val insightDao: InsightDao? = null,
     private val syncEnqueuer: (Context) -> Unit = { SyncEnqueuer.enqueue(it, expedited = true, replaceExisting = true) },
+    private val restoreInProgress: (suspend () -> RestoreSummary)? = null,
 ) : ViewModel() {
     private val _calibre = MutableStateFlow(loadInitialCalibre())
     val calibre: StateFlow<CalibreUiState> = _calibre.asStateFlow()
@@ -88,6 +93,15 @@ class SettingsViewModel(
 
     private val _events = MutableSharedFlow<SettingsEvent>(extraBufferCapacity = 4)
     val events: SharedFlow<SettingsEvent> = _events.asSharedFlow()
+
+    /** True whenever an account is configured (any scheme), gating the restore action. */
+    val isConnected: StateFlow<Boolean> =
+        store.accountFlow
+            .map { it != null }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, store.accountFlow.value != null)
+
+    private val _restoreRunning = MutableStateFlow(false)
+    val restoreRunning: StateFlow<Boolean> = _restoreRunning.asStateFlow()
 
     val ai: StateFlow<AiState> = combine(
         combine(aiRepository.config, aiRepository.preferences, _aiHealth) { c, p, h ->
@@ -242,6 +256,28 @@ class SettingsViewModel(
                     InsightSyncStatus.Error(result.error.message ?: "Sync failed")
             }
             _lastInsightSync.value = insightDao?.latestSyncedAt() ?: _lastInsightSync.value
+        }
+    }
+
+    /**
+     * Task 5: user-initiated "Restore in-progress books" trigger from the
+     * Storage & sync section. Runs [RestoreInProgressUseCase] and emits a
+     * one-shot [SettingsEvent.RestoreFinished] (or [SettingsEvent.RestoreFailed])
+     * for the UI to render as a snackbar. Re-entrancy is guarded so a button
+     * mash can't fire two concurrent restores.
+     */
+    fun restoreInProgressBooks() {
+        val restore = restoreInProgress ?: return
+        if (_restoreRunning.value) return
+        viewModelScope.launch {
+            _restoreRunning.value = true
+            try {
+                _events.tryEmit(SettingsEvent.RestoreFinished(restore()))
+            } catch (t: Throwable) {
+                _events.tryEmit(SettingsEvent.RestoreFailed(t.message ?: t.javaClass.simpleName))
+            } finally {
+                _restoreRunning.value = false
+            }
         }
     }
 }

--- a/app/src/test/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCaseTest.kt
+++ b/app/src/test/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCaseTest.kt
@@ -92,14 +92,17 @@ class RestoreInProgressUseCaseTest {
         assertThat(downloaded).containsExactly("https://s/2.epub")
     }
 
-    @Test fun `applies positions for all in-progress items`() = runTest {
+    @Test fun `applies positions for all in-progress items including those not in the mirror`() = runTest {
         val applied = mutableListOf<ProgressItemDto>()
         useCase(
+            // h1 is in the mirror; h2 is in progress but has NO mirror row,
+            // so it's absent from `candidates` but must still get its position
+            // applied (proves applyPositions receives `inProgress`, not `candidates`).
             mirror = listOf(item("h1", "https://s/1.epub")),
-            prog = listOf(progress("h1")),
+            prog = listOf(progress("h1"), progress("h2")),
             present = setOf("h1"),
             applied = applied,
         ).run()
-        assertThat(applied.map { it.document.contentHash }).containsExactly("h1")
+        assertThat(applied.map { it.document.contentHash }).containsExactly("h1", "h2")
     }
 }

--- a/app/src/test/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCaseTest.kt
+++ b/app/src/test/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCaseTest.kt
@@ -1,0 +1,105 @@
+package io.theficos.ereader.domain.restore
+
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.data.library.LibraryItemResponse
+import io.theficos.ereader.data.sync.DocumentIdDto
+import io.theficos.ereader.data.sync.ProgressItemDto
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RestoreInProgressUseCaseTest {
+
+    private fun item(hash: String, href: String?) = LibraryItemResponse(
+        contentHash = hash, title = "T-$hash", authors = listOf("A"),
+        opdsHref = href, createdAt = "1970-01-01T00:00:00+00:00",
+        updatedAt = "1970-01-01T00:00:00+00:00",
+    )
+
+    private fun progress(
+        hash: String, percent: Double = 0.5,
+        finishedAt: String? = null, abandonedAt: String? = null,
+    ) = ProgressItemDto(
+        document = DocumentIdDto(metadataId = "m-$hash", contentHash = hash),
+        locator = "loc-$hash", percent = percent,
+        clientUpdatedAt = "1970-01-01T00:00:00.500Z",
+        finishedAt = finishedAt, abandonedAt = abandonedAt,
+    )
+
+    private fun useCase(
+        mirror: List<LibraryItemResponse>,
+        prog: List<ProgressItemDto>,
+        present: Set<String> = emptySet(),
+        onDownload: suspend (RestoreCandidate) -> Unit = {},
+        applied: MutableList<ProgressItemDto>? = null,
+    ) = RestoreInProgressUseCase(
+        fetchLibraryItems = { mirror },
+        fetchInProgress = { prog },
+        isPresent = { id -> id.contentHash in present },
+        downloadAndInsert = onDownload,
+        applyPositions = { items -> applied?.addAll(items) },
+    )
+
+    @Test fun `downloads in-progress books joined to the mirror`() = runTest {
+        val downloaded = mutableListOf<String>()
+        val summary = useCase(
+            mirror = listOf(item("h1", "https://s/1.epub")),
+            prog = listOf(progress("h1")),
+            onDownload = { downloaded += it.opdsHref },
+        ).run()
+        assertThat(downloaded).containsExactly("https://s/1.epub")
+        assertThat(summary.downloaded).isEqualTo(1)
+        assertThat(summary.requested).isEqualTo(1)
+    }
+
+    @Test fun `excludes finished, abandoned and zero-percent rows`() = runTest {
+        val downloaded = mutableListOf<String>()
+        val summary = useCase(
+            mirror = listOf(item("h1", "https://s/1.epub"), item("h2", "https://s/2.epub"), item("h3", "https://s/3.epub")),
+            prog = listOf(
+                progress("h1", finishedAt = "1970-01-01T00:00:00.500Z"),
+                progress("h2", abandonedAt = "1970-01-01T00:00:00.500Z"),
+                progress("h3", percent = 0.0),
+            ),
+            onDownload = { downloaded += it.opdsHref },
+        ).run()
+        assertThat(downloaded).isEmpty()
+        assertThat(summary.requested).isEqualTo(0)
+    }
+
+    @Test fun `skips already-present and unfetchable books`() = runTest {
+        val downloaded = mutableListOf<String>()
+        val summary = useCase(
+            mirror = listOf(item("h1", "https://s/1.epub"), item("h2", "sideload://v1/h2"), item("h3", "https://s/3.epub")),
+            prog = listOf(progress("h1"), progress("h2"), progress("h3")),
+            present = setOf("h1"),
+            onDownload = { downloaded += it.opdsHref },
+        ).run()
+        assertThat(downloaded).containsExactly("https://s/3.epub")
+        assertThat(summary.skippedExisting).isEqualTo(1)
+        assertThat(summary.skippedUnfetchable).isEqualTo(1)
+        assertThat(summary.downloaded).isEqualTo(1)
+    }
+
+    @Test fun `a per-book failure is counted and does not abort the batch`() = runTest {
+        val downloaded = mutableListOf<String>()
+        val summary = useCase(
+            mirror = listOf(item("h1", "https://s/1.epub"), item("h2", "https://s/2.epub")),
+            prog = listOf(progress("h1"), progress("h2")),
+            onDownload = { c -> if (c.progress.document.contentHash == "h1") error("boom") else downloaded += c.opdsHref },
+        ).run()
+        assertThat(summary.failed).isEqualTo(1)
+        assertThat(summary.downloaded).isEqualTo(1)
+        assertThat(downloaded).containsExactly("https://s/2.epub")
+    }
+
+    @Test fun `applies positions for all in-progress items`() = runTest {
+        val applied = mutableListOf<ProgressItemDto>()
+        useCase(
+            mirror = listOf(item("h1", "https://s/1.epub")),
+            prog = listOf(progress("h1")),
+            present = setOf("h1"),
+            applied = applied,
+        ).run()
+        assertThat(applied.map { it.document.contentHash }).containsExactly("h1")
+    }
+}

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
@@ -10,12 +10,16 @@ import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.ProgressRepository
 import io.theficos.ereader.data.local.db.DocumentEntity
 import io.theficos.ereader.data.local.db.EReaderDatabase
+import io.theficos.ereader.auth.CalibreCredentialStore
 import io.theficos.ereader.data.sync.SyncClient
 import io.theficos.ereader.data.sync.SyncOrchestrator
+import io.theficos.ereader.domain.restore.RestoreSummary
+import io.theficos.ereader.ui.catalog.FakeAndroidKeyStore
 import io.theficos.ereader.core.model.Progress as DomainProgress
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -42,6 +46,7 @@ class LibraryViewModelTest {
     private lateinit var vm: LibraryViewModel
 
     @Before fun setUp() {
+        FakeAndroidKeyStore.setup()
         Dispatchers.setMain(UnconfinedTestDispatcher())
         server = MockWebServer().also { it.start() }
         db = Room.inMemoryDatabaseBuilder(
@@ -280,6 +285,60 @@ class LibraryViewModelTest {
             assertThat(emission.map { it.id }).containsExactly(candidateId)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    private fun vmWith(store: CalibreCredentialStore): LibraryViewModel = LibraryViewModel(
+        docs = docs,
+        progress = progress,
+        syncOrchestrator = orchestrator,
+        booksDir = File("/dev/null"),
+        libraryPreferencesStore = LibraryPreferencesStore(ApplicationProvider.getApplicationContext()),
+        nowMillis = { 999L },
+        credentialStore = store,
+        restoreInProgress = { RestoreSummary(0, 0, 0, 0, 0) },
+    )
+
+    @Test fun `canRestore is true when connected and library empty`() = runTest {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.saveBasicAccount("http://host", "u", "p")
+        val restoreVm = vmWith(store)
+        // Collecting keeps the WhileSubscribed `rows` flow hot so canRestore reflects the DB.
+        restoreVm.canRestore.test {
+            var v = awaitItem()
+            while (!v) v = awaitItem()
+            assertThat(v).isTrue()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `canRestore is false when disconnected even if library empty`() = runTest {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.clear()
+        val restoreVm = vmWith(store)
+        restoreVm.canRestore.test {
+            // Disconnected: canRestore can never become true regardless of rows.
+            assertThat(awaitItem()).isFalse()
+            advanceUntilIdle()
+            assertThat(restoreVm.canRestore.value).isFalse()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `canRestore is false when connected but library non-empty`() = runTest {
+        val store = CalibreCredentialStore(ApplicationProvider.getApplicationContext())
+        store.saveBasicAccount("http://host", "u", "p")
+        seed("h1", "Alpha", null)
+        val restoreVm = vmWith(store)
+        // Drive `items` until the seeded row is visible so the shared `rows`
+        // flow has definitely propagated the non-empty library, then assert
+        // canRestore is false even though the account is connected.
+        restoreVm.items.test {
+            var list = awaitItem()
+            while (list.isEmpty()) list = awaitItem()
+            assertThat(list).hasSize(1)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertThat(restoreVm.canRestore.value).isFalse()
     }
 
     @Test fun `seriesContinuationCandidates re-emits when a candidate is marked finished`() = runTest {

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
@@ -329,16 +329,27 @@ class LibraryViewModelTest {
         store.saveBasicAccount("http://host", "u", "p")
         seed("h1", "Alpha", null)
         val restoreVm = vmWith(store)
-        // Drive `items` until the seeded row is visible so the shared `rows`
-        // flow has definitely propagated the non-empty library, then assert
-        // canRestore is false even though the account is connected.
-        restoreVm.items.test {
-            var list = awaitItem()
-            while (list.isEmpty()) list = awaitItem()
-            assertThat(list).hasSize(1)
+        // Subscribe to canRestore (keeps the WhileSubscribed `rows` upstream hot).
+        // Transient emission sequence with UnconfinedTestDispatcher + connected account:
+        //   1. stateIn initial → false
+        //   2. rows emits [] before Room delivers the seeded row → combine may emit true
+        //   3. rows emits [Alpha] → combine settles to false
+        // We warm `rows` by also subscribing to `items` and waiting until the seeded
+        // row arrives, then use expectMostRecentItem() to discard transients and assert
+        // the settled emission is false.
+        restoreVm.canRestore.test {
+            restoreVm.items.test {
+                var list = awaitItem()
+                while (list.isEmpty()) list = awaitItem()
+                assertThat(list).hasSize(1)
+                cancelAndIgnoreRemainingEvents()
+            }
+            advanceUntilIdle()
+            // expectMostRecentItem() returns the latest buffered item, discarding any
+            // earlier transient true — after rows has settled to non-empty, this must be false.
+            assertThat(expectMostRecentItem()).isFalse()
             cancelAndIgnoreRemainingEvents()
         }
-        assertThat(restoreVm.canRestore.value).isFalse()
     }
 
     @Test fun `seriesContinuationCandidates re-emits when a candidate is marked finished`() = runTest {

--- a/app/src/test/java/io/theficos/ereader/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,124 @@
+package io.theficos.ereader.ui.settings
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.auth.CalibreCredentialStore
+import io.theficos.ereader.data.ai.AiClient
+import io.theficos.ereader.data.ai.AiRepository
+import io.theficos.ereader.data.local.DocumentRepository
+import io.theficos.ereader.data.local.db.EReaderDatabase
+import io.theficos.ereader.domain.restore.RestoreSummary
+import io.theficos.ereader.reader.ReaderPreferencesStore
+import io.theficos.ereader.ui.catalog.FakeAndroidKeyStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class SettingsViewModelTest {
+    private lateinit var context: Context
+    private lateinit var db: EReaderDatabase
+    private lateinit var docs: DocumentRepository
+    private lateinit var booksDir: File
+    private lateinit var store: CalibreCredentialStore
+    private lateinit var aiRepository: AiRepository
+
+    @Before fun setUp() {
+        FakeAndroidKeyStore.setup()
+        Dispatchers.setMain(StandardTestDispatcher())
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, EReaderDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        docs = DocumentRepository(db.documentDao())
+        booksDir = File.createTempFile("books", "").apply { delete(); mkdirs() }
+        store = CalibreCredentialStore(context)
+        store.clear()
+        // AiClient with a null baseUrl never makes a network call; the VM's
+        // init refresh()/fetchHealth() both swallow the resulting error.
+        aiRepository = AiRepository(
+            client = AiClient(baseUrlProvider = { null }, http = OkHttpClient()),
+            insightDao = db.insightDao(),
+        )
+    }
+
+    @After fun tearDown() {
+        runCatching { db.close() }
+        runCatching { booksDir.deleteRecursively() }
+        Dispatchers.resetMain()
+    }
+
+    private fun buildVm(restoreInProgress: (suspend () -> RestoreSummary)?): SettingsViewModel =
+        SettingsViewModel(
+            store = store,
+            readerStore = ReaderPreferencesStore(context),
+            syncStateDao = db.syncStateDao(),
+            documentRepo = docs,
+            booksDir = booksDir,
+            aiRepository = aiRepository,
+            insightSyncRepository = null,
+            insightDao = db.insightDao(),
+            restoreInProgress = restoreInProgress,
+        )
+
+    @Test fun `restoreInProgressBooks emits RestoreFinished with summary`() = runTest {
+        store.saveBasicAccount(baseUrl = "https://books.example.com", username = "alice", password = "pw")
+        val summary = RestoreSummary(
+            requested = 2,
+            downloaded = 2,
+            skippedExisting = 0,
+            skippedUnfetchable = 0,
+            failed = 0,
+        )
+        val vm = buildVm(restoreInProgress = { summary })
+
+        val events = mutableListOf<SettingsEvent>()
+        val job = launch { vm.events.collect { events += it } }
+
+        vm.restoreInProgressBooks()
+        advanceUntilIdle()
+
+        assertThat(events).contains(SettingsEvent.RestoreFinished(summary))
+        assertThat(vm.restoreRunning.value).isFalse()
+        assertThat(vm.isConnected.value).isTrue()
+        job.cancel()
+    }
+
+    @Test fun `restoreInProgressBooks emits RestoreFailed when the use case throws`() = runTest {
+        store.saveBasicAccount(baseUrl = "https://books.example.com", username = "alice", password = "pw")
+        val vm = buildVm(restoreInProgress = { throw IllegalStateException("boom") })
+
+        val events = mutableListOf<SettingsEvent>()
+        val job = launch { vm.events.collect { events += it } }
+
+        vm.restoreInProgressBooks()
+        advanceUntilIdle()
+
+        assertThat(events).contains(SettingsEvent.RestoreFailed("boom"))
+        assertThat(vm.restoreRunning.value).isFalse()
+        job.cancel()
+    }
+
+    @Test fun `isConnected is false when no account configured`() = runTest {
+        val vm = buildVm(restoreInProgress = { error("should not run") })
+        advanceUntilIdle()
+        assertThat(vm.isConnected.value).isFalse()
+    }
+}

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
@@ -157,19 +157,19 @@ class LibraryClient(
         limit: Int = 200,
         maxPages: Int = 50,
         onTruncated: (collected: Int) -> Unit = {},
-    ): List<LibraryItemResponse> {
+    ): List<LibraryItemResponse> = withContext(Dispatchers.IO) {
         val all = mutableListOf<LibraryItemResponse>()
         var offset = 0
         var page = 0
         while (page < maxPages) {
             val resp = listItems(since = null, limit = limit, offset = offset)
             all += resp.items
-            if (resp.items.size < limit) return all
+            if (resp.items.size < limit) return@withContext all
             offset += limit
             page++
         }
         onTruncated(all.size)
-        return all
+        all
     }
 
     private companion object {

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
@@ -3,6 +3,7 @@ package io.theficos.ereader.data.library
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -122,6 +123,53 @@ class LibraryClient(
             if (!resp.isSuccessful) throw LibraryHttpException(resp.code, body)
             syncJson.decodeFromString(LibrarySyncSummary.serializer(), body)
         }
+    }
+
+    /**
+     * Page through `GET /library/v1/items`. `since=null` returns only live rows
+     * (no tombstones); `limit`/`offset` are server-validated (1..1000, >=0).
+     */
+    suspend fun listItems(
+        since: String?,
+        limit: Int,
+        offset: Int,
+    ): LibraryItemListResponse = withContext(Dispatchers.IO) {
+        val url = (resolveBaseUrl() + LibraryApi.PATH_ITEMS).toHttpUrl().newBuilder()
+            .apply { if (since != null) addQueryParameter("since", since) }
+            .addQueryParameter("limit", limit.toString())
+            .addQueryParameter("offset", offset.toString())
+            .build()
+        val req = Request.Builder().url(url).get().build()
+        http.newCall(req).execute().use { resp ->
+            val body = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) throw LibraryHttpException(resp.code, body)
+            json.decodeFromString(LibraryItemListResponse.serializer(), body)
+        }
+    }
+
+    /**
+     * Pull the entire live library mirror, paging until a short page. Bounded by
+     * [maxPages] so a server that keeps returning full pages can't hang the
+     * caller; on hitting the cap it invokes [onTruncated] with the count
+     * collected so far (no silent truncation) and returns what it has.
+     */
+    suspend fun listAllItems(
+        limit: Int = 200,
+        maxPages: Int = 50,
+        onTruncated: (collected: Int) -> Unit = {},
+    ): List<LibraryItemResponse> {
+        val all = mutableListOf<LibraryItemResponse>()
+        var offset = 0
+        var page = 0
+        while (page < maxPages) {
+            val resp = listItems(since = null, limit = limit, offset = offset)
+            all += resp.items
+            if (resp.items.size < limit) return all
+            offset += limit
+            page++
+        }
+        onTruncated(all.size)
+        return all
     }
 
     private companion object {

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryDtos.kt
@@ -98,3 +98,14 @@ data class LibraryItemResponse(
     // safely — every hash on the wire today is v1.
     @SerialName("identity_hash_version") val identityHashVersion: Int = 1,
 )
+
+/**
+ * Response body of `GET /library/v1/items` (paginated). `server_time` is the
+ * snapshot instant the server bounded the page to; the restore path ignores it
+ * (best-effort snapshot semantics) but it's decoded for completeness.
+ */
+@Serializable
+data class LibraryItemListResponse(
+    val items: List<LibraryItemResponse>,
+    @SerialName("server_time") val serverTime: String,
+)

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryClientTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryClientTest.kt
@@ -217,4 +217,20 @@ class LibraryClientTest {
             assertThat(e.code).isEqualTo(401)
         }
     }
+
+    @Test
+    fun `listItems wires the since query param`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"items":[],"server_time":"1970-01-01T00:00:00+00:00"}"""
+            )
+        )
+        client.listItems(since = "1970-01-01T00:00:00+00:00", limit = 50, offset = 0)
+        val req = server.takeRequest()
+        // MockWebServer URL-encodes `+` as %2B and `:` as %3A, so assert on
+        // substrings rather than an exact path match.
+        assertThat(req.path!!).contains("since=")
+        assertThat(req.path!!).contains("limit=50")
+        assertThat(req.path!!).contains("offset=0")
+    }
 }

--- a/data/library/src/test/java/io/theficos/ereader/data/library/LibraryClientTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/LibraryClientTest.kt
@@ -161,4 +161,60 @@ class LibraryClientTest {
             assertThat(e.body).contains("metadata_id_conflict")
         }
     }
+
+    // ---- listItems / listAllItems ----
+
+    @Test
+    fun `listItems hits items path with paging query and parses items`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"items":[{"content_hash":"h1","title":"Book One","authors":["A"],"opds_href":"https://srv/b1.epub","created_at":"1970-01-01T00:00:00+00:00","updated_at":"1970-01-01T00:00:00+00:00"}],"server_time":"1970-01-01T00:00:00+00:00"}"""
+            )
+        )
+        val out = client.listItems(since = null, limit = 200, offset = 0)
+        assertThat(out.items).hasSize(1)
+        assertThat(out.items[0].contentHash).isEqualTo("h1")
+        assertThat(out.items[0].opdsHref).isEqualTo("https://srv/b1.epub")
+        val req = server.takeRequest()
+        assertThat(req.method).isEqualTo("GET")
+        assertThat(req.path).isEqualTo("/library/v1/items?limit=200&offset=0")
+    }
+
+    @Test
+    fun `listAllItems pages until a short page and concatenates`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(
+            """{"items":[{"content_hash":"h1","title":"1","opds_href":"https://s/1.epub","created_at":"1970-01-01T00:00:00+00:00","updated_at":"1970-01-01T00:00:00+00:00"},{"content_hash":"h2","title":"2","opds_href":"https://s/2.epub","created_at":"1970-01-01T00:00:00+00:00","updated_at":"1970-01-01T00:00:00+00:00"}],"server_time":"1970-01-01T00:00:00+00:00"}"""
+        ))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(
+            """{"items":[{"content_hash":"h3","title":"3","opds_href":"https://s/3.epub","created_at":"1970-01-01T00:00:00+00:00","updated_at":"1970-01-01T00:00:00+00:00"}],"server_time":"1970-01-01T00:00:00+00:00"}"""
+        ))
+        val all = client.listAllItems(limit = 2, maxPages = 50)
+        assertThat(all.map { it.contentHash }).containsExactly("h1", "h2", "h3").inOrder()
+        assertThat(server.takeRequest().path).isEqualTo("/library/v1/items?limit=2&offset=0")
+        assertThat(server.takeRequest().path).isEqualTo("/library/v1/items?limit=2&offset=2")
+    }
+
+    @Test
+    fun `listAllItems stops at maxPages and reports truncation`() = runTest {
+        repeat(3) {
+            server.enqueue(MockResponse().setResponseCode(200).setBody(
+                """{"items":[{"content_hash":"h$it","title":"$it","opds_href":"https://s/$it.epub","created_at":"1970-01-01T00:00:00+00:00","updated_at":"1970-01-01T00:00:00+00:00"}],"server_time":"1970-01-01T00:00:00+00:00"}"""
+            ))
+        }
+        var truncatedAt: Int? = null
+        val all = client.listAllItems(limit = 1, maxPages = 2, onTruncated = { truncatedAt = it })
+        assertThat(all).hasSize(2)
+        assertThat(truncatedAt).isEqualTo(2)
+    }
+
+    @Test
+    fun `listItems 401 raises LibraryHttpException`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("nope"))
+        try {
+            client.listItems(since = null, limit = 200, offset = 0)
+            error("expected throw")
+        } catch (e: LibraryHttpException) {
+            assertThat(e.code).isEqualTo(401)
+        }
+    }
 }

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncOrchestrator.kt
@@ -58,13 +58,25 @@ class SyncOrchestrator(
         val pulled = client.pullProgress(sinceIso)
         return when (pulled) {
             is SyncResult.Success -> {
-                pulled.value.items.forEach { applyPulled(it) }
+                applyProgressItems(pulled.value.items)
                 val serverEpoch = Instant.parse(pulled.value.serverTime).toEpochMilli()
                 syncState.set(SyncStateEntity(SYNC_TABLE, serverEpoch))
                 SyncResult.Success(Unit)
             }
             else -> pulled.asUnit()
         }
+    }
+
+    /**
+     * Apply a caller-supplied batch of pulled progress items to local storage.
+     * Pure local effect: no network, no watermark write. Each item attaches to
+     * its local document via [DocumentRepository.findByIdentity]; items with no
+     * matching document are silently skipped (same as the pull path). The
+     * restore flow calls this directly with items it already pulled, so reading
+     * positions are restored without depending on the sync cursor.
+     */
+    suspend fun applyProgressItems(items: List<ProgressItemDto>) {
+        items.forEach { applyPulled(it) }
     }
 
     private suspend fun applyPulled(item: ProgressItemDto) {

--- a/data/sync/src/test/java/io/theficos/ereader/data/sync/SyncOrchestratorTest.kt
+++ b/data/sync/src/test/java/io/theficos/ereader/data/sync/SyncOrchestratorTest.kt
@@ -131,4 +131,37 @@ class SyncOrchestratorTest {
         val result = orchestrator.runOnce()
         assertThat(result).isInstanceOf(SyncResult.Unauthorized::class.java)
     }
+
+    @Test fun `applyProgressItems writes positions for present docs without touching watermark`() = runTest {
+        val docId = seedDoc(metadataId = "m", hash = "h")
+        val items = listOf(
+            ProgressItemDto(
+                document = DocumentIdDto(metadataId = "m", contentHash = "h"),
+                locator = "restored-loc",
+                percent = 0.4,
+                clientUpdatedAt = "1970-01-01T00:00:00.500Z",
+            )
+        )
+
+        orchestrator.applyProgressItems(items)
+
+        val saved = progress.get(docId)
+        assertThat(saved?.locator).isEqualTo("restored-loc")
+        // No network call happened and the pull cursor is untouched.
+        assertThat(db.syncStateDao().lastPulled("progress")).isNull()
+    }
+
+    @Test fun `applyProgressItems skips items with no local document`() = runTest {
+        // No seedDoc: the item has nothing to attach to and must be dropped, not crash.
+        val items = listOf(
+            ProgressItemDto(
+                document = DocumentIdDto(metadataId = "x", contentHash = "y"),
+                locator = "loc",
+                percent = 0.2,
+                clientUpdatedAt = "1970-01-01T00:00:00.500Z",
+            )
+        )
+        orchestrator.applyProgressItems(items) // should not throw
+        assertThat(db.syncStateDao().lastPulled("progress")).isNull()
+    }
 }


### PR DESCRIPTION
## Summary

Phase 0–1 of the refactoring study (`docs/refactoring-study.md`) — the **safe, no-behavioral-change** slice. The goal of this PR is to fix the one concrete crash bug, lay a test safety net over the previously-untested data-access layer, and land low-risk hygiene/dedup, **without** changing any runtime/IO/exit/logging contract. The riskier behavioral items are deliberately deferred (see below) because this was executed unattended and they need human sign-off.

Scope was reviewed by an external model (plan review) which recommended exactly this conservative partition for an unattended run.

## What's in this PR

| # | Change | Risk |
|---|--------|------|
| 0.1 | Add `pytest-cov` (dev dep + `[tool.coverage]` + CI `--cov` reporting). **No `--cov-fail-under` gate.** | none |
| 0.2/0.3 | `tests/conftest.py` + characterization tests pinning **current** `APIClient` behavior (URL handling, success path, and the existing error-swallowing/dummy-token behavior) | none (tests only) |
| 1.1 | **Bug fix:** add `params=` kwarg to `APIClient.get`. `API.get_device_data`/`get_weather_data` already call `client.get(path, params=...)`, which raised `TypeError` on every device-data/weather fetch. Covered by new regression tests. | low |
| 1.4 | Replace 3 production `assert`s (`measured.py`, `pipeline.py`) with explicit `raise` guards — `assert` is stripped under `python -O` and violates the repo's own ast-grep rule. Behavior-equivalent under normal execution. | low |
| 1.5 | Bump `requests` `2.31.0 → >=2.32.4` (CVE-2024-35195, CVE-2024-47081); drop redundant `matplotlib`/`weasyprint` from the dev group. | low |
| 1.7 | Extract the byte-identical `_quarter_label` (duplicated in `pipeline.py` and `bundle.py`) into a single `config.quarter_label`. | low |

## Verification

- `uv run pytest` → **161 passed, 2 deselected** (was 150; +11 new tests, no regressions).
- `uv run pre-commit run --all-files` → ruff check, ruff format, and ast-grep all **pass**.
- Coverage now reported in CI (was 0% on `src/api`; `src/utils/data_joiner.py` and `timeseries_generator.py` remain ~0–2% — see deferred work).

## Deliberately deferred — needs human sign-off

These were **identified and intentionally NOT done** because they change runtime behavior in zero-coverage areas where production env/consumer assumptions can't be verified unattended. Each is documented in `docs/refactoring-study.md`:

- **2.2 Honest IO** — make `authenticate()`/`get()` raise instead of returning a dummy token / `{"data": []}`. ~20 consumers assume a dict and never catch; no mid-run degrade path exists today. **The characterization tests in this PR pin the current behavior precisely so this change can be made safely as a reviewed follow-up.**
- **2.1 Config consolidation** — collapsing `config.py`/`dps_config.py` switches DPS credentials from `''` → `admin`/`password`; committed Argo manifests don't inject `API_USERNAME`/`API_PASSWORD`, so DPS may currently run silently offline. Needs prod-env confirmation.
- **2.5 Exit/error contract** & **1.2 false-success exits** — some empty-DataFrame returns are legitimately "no data", others mask failures; misclassifying breaks pvbq's relaxed-completeness handling and changes exit codes CI/Argo depend on.
- **1.3 DPS `type=bool` flag** — fix requires editing live Argo CronWorkflow manifests in lockstep.
- **1.6 RUF013 + `--unsafe-fixes`** — repo-wide implicit-Optional autofix is too much unreviewed annotation churn for an unattended run.
- **1.8 / 1.9 / 2.3 / 2.4** — config/data-key dedup, logging rewiring, dead-code deletion (`CatalogService`, `SiteReport`, …), logging-bootstrap unification: each touches import-time timing, operational log/stdout contracts, or needs a repo-wide "is this really dead / imported-by-name?" audit.
- **Phase 3** (decomposing the 1700/1015/748-line functions): separate PRs once the safety net and seams are in place.

## Reference

Full analysis, target architecture, and prioritized roadmap: `docs/refactoring-study.md`.
