### PR TITLE
Restore in-progress books: off-main-thread downloads + progress feedback

### DIFF
--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -292,35 +292,41 @@ class AppContainer(context: Context) {
         },
         isPresent = { identity -> documentRepository.findByIdentity(identity) != null },
         downloadAndInsert = { c ->
-            val fileName = "${java.util.UUID.randomUUID()}.epub"
-            val file = bookDownloader.download(c.opdsHref, fileName) { _, _ -> }
-            val coverFile: java.io.File? = null
-            // If identity extraction / OPF read / insert throws after the bytes
-            // landed, delete the temp file before rethrowing so a re-run (this
-            // feature is explicitly re-runnable) doesn't accumulate orphans.
-            try {
-                val identity = extractIdentity(file)
-                if (documentRepository.findByIdentity(identity) != null) {
+            // Identity hashing (whole-EPUB hash) and OPF zip parsing are plain
+            // CPU/IO with no internal dispatcher; the use case runs on Main
+            // (viewModelScope). Move all per-book work off the main thread to
+            // avoid an ANR while restoring.
+            withContext(Dispatchers.IO) {
+                val fileName = "${java.util.UUID.randomUUID()}.epub"
+                val file = bookDownloader.download(c.opdsHref, fileName) { _, _ -> }
+                val coverFile: java.io.File? = null
+                // If identity extraction / OPF read / insert throws after the bytes
+                // landed, delete the temp file before rethrowing so a re-run (this
+                // feature is explicitly re-runnable) doesn't accumulate orphans.
+                try {
+                    val identity = extractIdentity(file)
+                    if (documentRepository.findByIdentity(identity) != null) {
+                        file.delete()
+                        coverFile?.delete()
+                    } else {
+                        val opf = readOpfBundle(file, fallbackTitle = c.title)
+                        documentRepository.insert(
+                            identity = identity,
+                            title = c.title,
+                            author = c.authors.firstOrNull(),
+                            downloadUrl = c.opdsHref,
+                            localPath = file.absolutePath,
+                            coverPath = coverFile?.absolutePath,
+                            downloadedAt = System.currentTimeMillis(),
+                            seriesName = opf.seriesName,
+                            seriesIndex = opf.seriesPosition?.toDouble(),
+                        )
+                    }
+                } catch (t: Throwable) {
                     file.delete()
                     coverFile?.delete()
-                } else {
-                    val opf = readOpfBundle(file, fallbackTitle = c.title)
-                    documentRepository.insert(
-                        identity = identity,
-                        title = c.title,
-                        author = c.authors.firstOrNull(),
-                        downloadUrl = c.opdsHref,
-                        localPath = file.absolutePath,
-                        coverPath = coverFile?.absolutePath,
-                        downloadedAt = System.currentTimeMillis(),
-                        seriesName = opf.seriesName,
-                        seriesIndex = opf.seriesPosition?.toDouble(),
-                    )
+                    throw t
                 }
-            } catch (t: Throwable) {
-                file.delete()
-                coverFile?.delete()
-                throw t
             }
         },
         applyPositions = { items -> syncOrchestrator.applyProgressItems(items) },

--- a/app/src/main/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCase.kt
+++ b/app/src/main/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCase.kt
@@ -4,6 +4,9 @@ import io.theficos.ereader.core.model.DocumentIdentity
 import io.theficos.ereader.data.library.LibraryItemResponse
 import io.theficos.ereader.data.sync.ProgressItemDto
 
+/** Live progress of a restore run: [done] of [total] candidate books processed. */
+data class RestoreProgress(val done: Int, val total: Int)
+
 /** Outcome counters for one restore run, rendered as a snackbar summary. */
 data class RestoreSummary(
     val requested: Int,
@@ -48,7 +51,7 @@ class RestoreInProgressUseCase(
     private val applyPositions: suspend (List<ProgressItemDto>) -> Unit,
     private val minPercentExclusive: Double = 0.0,
 ) {
-    suspend fun run(): RestoreSummary {
+    suspend fun run(onProgress: (done: Int, total: Int) -> Unit = { _, _ -> }): RestoreSummary {
         val mirrorByHash = fetchLibraryItems().associateBy { it.contentHash }
         val inProgress = fetchInProgress().filter {
             it.finishedAt == null && it.abandonedAt == null && it.percent > minPercentExclusive
@@ -59,11 +62,13 @@ class RestoreInProgressUseCase(
             RestoreCandidate(progress = p, opdsHref = href, title = item.title, authors = item.authors)
         }
 
+        onProgress(0, candidates.size)
+
         var downloaded = 0
         var skippedExisting = 0
         var skippedUnfetchable = 0
         var failed = 0
-        for (c in candidates) {
+        candidates.forEachIndexed { index, c ->
             when {
                 !isHttp(c.opdsHref) -> skippedUnfetchable++
                 isPresent(c.identity) -> skippedExisting++
@@ -74,6 +79,7 @@ class RestoreInProgressUseCase(
                     failed++
                 }
             }
+            onProgress(index + 1, candidates.size)
         }
 
         // Restore positions for every in-progress item; items whose document

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -112,7 +112,7 @@ fun AppNavGraph(container: AppContainer) {
                     booksDir = container.booksDir,
                     libraryPreferencesStore = container.libraryPreferencesStore,
                     credentialStore = container.credentialStore,
-                    restoreInProgress = { container.restoreInProgressUseCase().run() },
+                    restoreInProgress = { onProgress -> container.restoreInProgressUseCase().run(onProgress) },
                 )
             }
             val catVm = remember {
@@ -142,7 +142,7 @@ fun AppNavGraph(container: AppContainer) {
                     aiRepository = container.aiRepository,
                     insightSyncRepository = container.insightSyncRepository,
                     insightDao = container.insightDao,
-                    restoreInProgress = { container.restoreInProgressUseCase().run() },
+                    restoreInProgress = { onProgress -> container.restoreInProgressUseCase().run(onProgress) },
                 )
             }
             val aiConfig by container.aiRepository.config.collectAsState()

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryScreen.kt
@@ -127,6 +127,7 @@ fun LibraryScreen(
     val query by viewModel.query.collectAsState()
     val canRestore by viewModel.canRestore.collectAsState()
     val restoreRunning by viewModel.restoreRunning.collectAsState()
+    val restoreProgress by viewModel.restoreProgress.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -179,6 +180,7 @@ fun LibraryScreen(
                 onImport = launchPicker,
                 canRestore = canRestore,
                 restoreRunning = restoreRunning,
+                restoreProgress = restoreProgress,
                 onRestore = { viewModel.restoreInProgressBooks() },
             )
             SnackbarHost(
@@ -561,6 +563,7 @@ private fun EmptyState(
     onImport: (() -> Unit)? = null,
     canRestore: Boolean = false,
     restoreRunning: Boolean = false,
+    restoreProgress: io.theficos.ereader.domain.restore.RestoreProgress? = null,
     onRestore: () -> Unit = {},
 ) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -606,10 +609,16 @@ private fun EmptyState(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(Modifier.height(8.dp))
+                val restoreLabel = when {
+                    restoreRunning && restoreProgress != null ->
+                        "Restoring… (${restoreProgress.done}/${restoreProgress.total})"
+                    restoreRunning -> "Restoring…"
+                    else -> "Restore in-progress books"
+                }
                 Button(
                     onClick = onRestore,
                     enabled = !restoreRunning,
-                ) { Text(if (restoreRunning) "Restoring…" else "Restore in-progress books") }
+                ) { Text(restoreLabel) }
             }
         }
     }

--- a/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/library/LibraryViewModel.kt
@@ -40,7 +40,7 @@ class LibraryViewModel(
     private val nowMillis: () -> Long = System::currentTimeMillis,
     private val syncEnqueuer: (Context) -> Unit = { SyncEnqueuer.enqueue(it, expedited = true, replaceExisting = true) },
     private val credentialStore: io.theficos.ereader.auth.CalibreCredentialStore? = null,
-    private val restoreInProgress: (suspend () -> io.theficos.ereader.domain.restore.RestoreSummary)? = null,
+    private val restoreInProgress: (suspend ((Int, Int) -> Unit) -> io.theficos.ereader.domain.restore.RestoreSummary)? = null,
 ) : ViewModel() {
 
     val sort: StateFlow<LibrarySort> = libraryPreferencesStore.flow
@@ -139,17 +139,30 @@ class LibraryViewModel(
     private val _restoreRunning = kotlinx.coroutines.flow.MutableStateFlow(false)
     val restoreRunning: StateFlow<Boolean> = _restoreRunning.asStateFlow()
 
+    private val _restoreProgress =
+        kotlinx.coroutines.flow.MutableStateFlow<io.theficos.ereader.domain.restore.RestoreProgress?>(null)
+    val restoreProgress: StateFlow<io.theficos.ereader.domain.restore.RestoreProgress?> =
+        _restoreProgress.asStateFlow()
+
     fun restoreInProgressBooks() {
         val restore = restoreInProgress ?: return
         if (_restoreRunning.value) return
         _restoreRunning.value = true
         viewModelScope.launch {
             try {
-                _events.tryEmit(LibraryEvent.RestoreFinished(restore()))
+                _events.tryEmit(
+                    LibraryEvent.RestoreFinished(
+                        restore { done, total ->
+                            _restoreProgress.value =
+                                io.theficos.ereader.domain.restore.RestoreProgress(done, total)
+                        },
+                    ),
+                )
             } catch (t: Throwable) {
                 _events.tryEmit(LibraryEvent.RestoreFailed(t.message ?: t.javaClass.simpleName))
             } finally {
                 _restoreRunning.value = false
+                _restoreProgress.value = null
             }
         }
     }

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsScreen.kt
@@ -76,6 +76,7 @@ fun SettingsScreen(
     val deleteInFlight by viewModel.deleteProfileInFlight.collectAsState()
     val isConnected by viewModel.isConnected.collectAsState()
     val restoreRunning by viewModel.restoreRunning.collectAsState()
+    val restoreProgress by viewModel.restoreProgress.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
@@ -262,10 +263,16 @@ fun SettingsScreen(
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
+                        val restoreLabel = when {
+                            restoreRunning && restoreProgress != null ->
+                                "Restoring… (${restoreProgress!!.done}/${restoreProgress!!.total})"
+                            restoreRunning -> "Restoring…"
+                            else -> "Restore in-progress books"
+                        }
                         TextButton(
                             onClick = { viewModel.restoreInProgressBooks() },
                             enabled = !restoreRunning,
-                        ) { Text(if (restoreRunning) "Restoring…" else "Restore in-progress books") }
+                        ) { Text(restoreLabel) }
                     }
                 }
             }

--- a/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/settings/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import io.theficos.ereader.data.local.DocumentRepository
 import io.theficos.ereader.data.local.db.InsightDao
 import io.theficos.ereader.data.local.db.SyncStateDao
 import io.theficos.ereader.data.sync.SyncEnqueuer
+import io.theficos.ereader.domain.restore.RestoreProgress
 import io.theficos.ereader.domain.restore.RestoreSummary
 import java.io.File
 import io.theficos.ereader.reader.ReaderFontFamily
@@ -74,7 +75,7 @@ class SettingsViewModel(
     private val insightSyncRepository: InsightSyncRepository? = null,
     private val insightDao: InsightDao? = null,
     private val syncEnqueuer: (Context) -> Unit = { SyncEnqueuer.enqueue(it, expedited = true, replaceExisting = true) },
-    private val restoreInProgress: (suspend () -> RestoreSummary)? = null,
+    private val restoreInProgress: (suspend ((Int, Int) -> Unit) -> RestoreSummary)? = null,
 ) : ViewModel() {
     private val _calibre = MutableStateFlow(loadInitialCalibre())
     val calibre: StateFlow<CalibreUiState> = _calibre.asStateFlow()
@@ -102,6 +103,9 @@ class SettingsViewModel(
 
     private val _restoreRunning = MutableStateFlow(false)
     val restoreRunning: StateFlow<Boolean> = _restoreRunning.asStateFlow()
+
+    private val _restoreProgress = MutableStateFlow<RestoreProgress?>(null)
+    val restoreProgress: StateFlow<RestoreProgress?> = _restoreProgress.asStateFlow()
 
     val ai: StateFlow<AiState> = combine(
         combine(aiRepository.config, aiRepository.preferences, _aiHealth) { c, p, h ->
@@ -272,11 +276,16 @@ class SettingsViewModel(
         _restoreRunning.value = true
         viewModelScope.launch {
             try {
-                _events.tryEmit(SettingsEvent.RestoreFinished(restore()))
+                _events.tryEmit(
+                    SettingsEvent.RestoreFinished(
+                        restore { done, total -> _restoreProgress.value = RestoreProgress(done, total) },
+                    ),
+                )
             } catch (t: Throwable) {
                 _events.tryEmit(SettingsEvent.RestoreFailed(t.message ?: t.javaClass.simpleName))
             } finally {
                 _restoreRunning.value = false
+                _restoreProgress.value = null
             }
         }
     }

--- a/app/src/test/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCaseTest.kt
+++ b/app/src/test/java/io/theficos/ereader/domain/restore/RestoreInProgressUseCaseTest.kt
@@ -92,6 +92,15 @@ class RestoreInProgressUseCaseTest {
         assertThat(downloaded).containsExactly("https://s/2.epub")
     }
 
+    @Test fun `run reports progress from 0 to total over candidates`() = runTest {
+        val events = mutableListOf<Pair<Int, Int>>()
+        useCase(
+            mirror = listOf(item("h1", "https://s/1.epub"), item("h2", "https://s/2.epub")),
+            prog = listOf(progress("h1"), progress("h2")),
+        ).run { done, total -> events += done to total }
+        assertThat(events).containsExactly(0 to 2, 1 to 2, 2 to 2).inOrder()
+    }
+
     @Test fun `applies positions for all in-progress items including those not in the mirror`() = runTest {
         val applied = mutableListOf<ProgressItemDto>()
         useCase(

--- a/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/library/LibraryViewModelTest.kt
@@ -295,7 +295,7 @@ class LibraryViewModelTest {
         libraryPreferencesStore = LibraryPreferencesStore(ApplicationProvider.getApplicationContext()),
         nowMillis = { 999L },
         credentialStore = store,
-        restoreInProgress = { RestoreSummary(0, 0, 0, 0, 0) },
+        restoreInProgress = { _ -> RestoreSummary(0, 0, 0, 0, 0) },
     )
 
     @Test fun `canRestore is true when connected and library empty`() = runTest {

--- a/app/src/test/java/io/theficos/ereader/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/settings/SettingsViewModelTest.kt
@@ -65,7 +65,7 @@ class SettingsViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun buildVm(restoreInProgress: (suspend () -> RestoreSummary)?): SettingsViewModel =
+    private fun buildVm(restoreInProgress: (suspend ((Int, Int) -> Unit) -> RestoreSummary)?): SettingsViewModel =
         SettingsViewModel(
             store = store,
             readerStore = ReaderPreferencesStore(context),
@@ -87,7 +87,7 @@ class SettingsViewModelTest {
             skippedUnfetchable = 0,
             failed = 0,
         )
-        val vm = buildVm(restoreInProgress = { summary })
+        val vm = buildVm(restoreInProgress = { _ -> summary })
 
         val events = mutableListOf<SettingsEvent>()
         val job = launch { vm.events.collect { events += it } }
@@ -101,9 +101,39 @@ class SettingsViewModelTest {
         job.cancel()
     }
 
+    @Test fun `restoreInProgressBooks surfaces per-book progress and clears it on completion`() = runTest {
+        store.saveBasicAccount(baseUrl = "https://books.example.com", username = "alice", password = "pw")
+        val summary = RestoreSummary(
+            requested = 2,
+            downloaded = 2,
+            skippedExisting = 0,
+            skippedUnfetchable = 0,
+            failed = 0,
+        )
+        val vm = buildVm(
+            restoreInProgress = { onProgress ->
+                onProgress(1, 2)
+                onProgress(2, 2)
+                summary
+            },
+        )
+
+        val events = mutableListOf<SettingsEvent>()
+        val job = launch { vm.events.collect { events += it } }
+
+        vm.restoreInProgressBooks()
+        advanceUntilIdle()
+
+        assertThat(events).contains(SettingsEvent.RestoreFinished(summary))
+        // finally clears progress after the run completes.
+        assertThat(vm.restoreProgress.value).isNull()
+        assertThat(vm.restoreRunning.value).isFalse()
+        job.cancel()
+    }
+
     @Test fun `restoreInProgressBooks emits RestoreFailed when the use case throws`() = runTest {
         store.saveBasicAccount(baseUrl = "https://books.example.com", username = "alice", password = "pw")
-        val vm = buildVm(restoreInProgress = { throw IllegalStateException("boom") })
+        val vm = buildVm(restoreInProgress = { _ -> throw IllegalStateException("boom") })
 
         val events = mutableListOf<SettingsEvent>()
         val job = launch { vm.events.collect { events += it } }
@@ -117,7 +147,7 @@ class SettingsViewModelTest {
     }
 
     @Test fun `isConnected is false when no account configured`() = runTest {
-        val vm = buildVm(restoreInProgress = { error("should not run") })
+        val vm = buildVm(restoreInProgress = { _ -> error("should not run") })
         advanceUntilIdle()
         assertThat(vm.isConnected.value).isFalse()
     }


### PR DESCRIPTION
## Restore in-progress books: off-main-thread downloads + progress feedback

Follow-up to #69. Two improvements to the restore flow:

### 1. Run per-book work off the main thread (fixes jank/ANR risk)
The restore use case runs inside `viewModelScope.launch` (Main dispatcher). While `BookDownloader.download` already dispatches to IO internally, `extractIdentity` (SHA-hashes the whole EPUB) and `readOpfBundle` (zip parse) are plain synchronous functions with no dispatcher — so they previously ran on Main, once per restored book. The `downloadAndInsert` wiring is now wrapped in `withContext(Dispatchers.IO)`, moving all per-book hashing/parsing/insert off the main thread.

### 2. Per-book progress feedback
`RestoreInProgressUseCase.run(onProgress)` now reports `(done, total)` as it processes each candidate. Both surfaces (Settings button + Library empty-state prompt) thread this through a new `restoreProgress: StateFlow<RestoreProgress?>` and show **"Restoring… (done/total)"** while a multi-book restore is in flight. Progress is cleared in `finally`, so it resets after both success and failure.

### Tests
- `RestoreInProgressUseCaseTest` — progress reported `0 → total` over candidates.
- `SettingsViewModelTest` — progress surfaced during a run and cleared on completion.
- Existing use-case / Settings / Library VM tests updated to the new injected-lambda type and all passing.

No behavior change to what gets restored or the summary snackbar; client-side only.
