### PR TITLE
Book scan: camera/ISBN capture → reader-affinity → optional insight (Android)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,14 +56,7 @@ android {
         }
     }
     buildTypes {
-        debug {
-            isMinifyEnabled = false
-            // Distinct package + label so a debug build installs side-by-side
-            // with a signed release "Quire" instead of failing on signature
-            // mismatch. Debug-only; release is unaffected.
-            applicationIdSuffix = ".debug"
-            versionNameSuffix = "-debug"
-        }
+        debug { isMinifyEnabled = false }
         release {
             isMinifyEnabled = false   // Phase 1 only; revisit before publishing
             // AGP 8.3+ embeds git origin/branch/SHA into the APK by default,

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,6 +103,11 @@ dependencies {
     implementation(libs.compose.material.icons.extended)
     implementation(libs.coil.compose)
     implementation(libs.aboutlibraries.compose)
+    implementation(libs.zxing.core)
+    implementation(libs.androidx.camera.core)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.androidx.camera.view)
     debugImplementation(libs.compose.ui.tooling)
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,7 +56,14 @@ android {
         }
     }
     buildTypes {
-        debug { isMinifyEnabled = false }
+        debug {
+            isMinifyEnabled = false
+            // Distinct package + label so a debug build installs side-by-side
+            // with a signed release "Quire" instead of failing on signature
+            // mismatch. Debug-only; release is unaffected.
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
         release {
             isMinifyEnabled = false   // Phase 1 only; revisit before publishing
             // AGP 8.3+ embeds git origin/branch/SHA into the APK by default,

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Debug-only override so the side-by-side debug install reads "Quire Debug". -->
+    <string name="app_name">Quire Debug</string>
+</resources>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- Debug-only override so the side-by-side debug install reads "Quire Debug". -->
-    <string name="app_name">Quire Debug</string>
-</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
          Component android:name attributes must be fully-qualified (io.theficos.ereader.Foo),
          not relative (.Foo) — relative names resolve against the namespace and won't match. -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
 
     <application
         android:name="io.theficos.ereader.EReaderApp"

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -22,6 +22,7 @@ import io.theficos.ereader.data.local.db.ProgressDao
 import io.theficos.ereader.data.opds.BookDownloader
 import io.theficos.ereader.data.opds.OpdsClient
 import io.theficos.ereader.data.opds.OpdsHttpClient
+import io.theficos.ereader.data.opds.OpenLibraryClient
 import io.theficos.ereader.data.sync.SyncClient
 import io.theficos.ereader.data.sync.SyncDependencies
 import io.theficos.ereader.data.sync.SyncEnqueuer
@@ -43,6 +44,7 @@ import io.theficos.ereader.ui.library.LibraryPreferencesStore
 import io.theficos.ereader.ui.library.LibraryStatsCache
 import io.theficos.ereader.ui.library.LibraryStatsViewModel
 import io.theficos.ereader.ui.onboarding.WelcomePreferencesStore
+import io.theficos.ereader.ui.scan.ScanResultRegistry
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -132,6 +134,21 @@ class AppContainer(context: Context) {
         baseUrlProvider = { credentialStore.getAccount()?.quireServerOrPrimaryUrl() },
         http = opdsHttp.okHttp,
     )
+
+    /**
+     * Book-scan: on-device ISBN -> metadata lookup against OpenLibrary. Plain
+     * OkHttp, NO account auth — it talks to a third-party host, so it must not
+     * reuse the account-authed [opdsHttp] client. Uses the client's own default
+     * timeouts.
+     */
+    val openLibraryClient: OpenLibraryClient = OpenLibraryClient()
+
+    /**
+     * Book-scan: process-local handoff of a scanned book's metadata + affinity
+     * verdict from the scan screen to the result screen. Mirrors
+     * [catalogDetailRegistry]; resets on process death.
+     */
+    val scanResultRegistry: ScanResultRegistry = ScanResultRegistry()
 
     /**
      * Process-lifetime scope for fire-and-forget library upload work. A

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -44,6 +44,10 @@ import io.theficos.ereader.ui.onboarding.WelcomeScreen
 import io.theficos.ereader.ui.onboarding.pickStartDestination
 import io.theficos.ereader.ui.reader.ReaderScreen
 import io.theficos.ereader.ui.reader.ReaderViewModel
+import io.theficos.ereader.ui.scan.ScanResultScreen
+import io.theficos.ereader.ui.scan.ScanResultViewModel
+import io.theficos.ereader.ui.scan.ScanScreen
+import io.theficos.ereader.ui.scan.ScanViewModel
 import io.theficos.ereader.ui.settings.LicensesScreen
 import io.theficos.ereader.ui.settings.SettingsScreen
 import io.theficos.ereader.ui.settings.SettingsViewModel
@@ -165,6 +169,7 @@ fun AppNavGraph(container: AppContainer) {
                             val key = container.catalogDetailRegistry.put(pub)
                             nav.navigate("catalog-detail/$key")
                         },
+                        onScan = { nav.navigate("scan") },
                     )
                     Tab.SETTINGS -> SettingsScreen(
                         viewModel = setVm,
@@ -246,6 +251,38 @@ fun AppNavGraph(container: AppContainer) {
                 CatalogDetailUnavailable(onBack = { nav.popBackStack() })
             } else {
                 CatalogDetailScreen(viewModel = vm, onBack = { nav.popBackStack() })
+            }
+        }
+        composable("scan") {
+            val vm = remember {
+                ScanViewModel(
+                    lookup = { isbn -> container.openLibraryClient.lookupByIsbn(isbn) },
+                    runAffinity = { body -> container.libraryClient.affinity(body) },
+                    onReauth = { container.credentialStore.notifyUnauthorized() },
+                )
+            }
+            ScanScreen(
+                viewModel = vm,
+                onResult = { data ->
+                    val key = container.scanResultRegistry.put(data)
+                    nav.navigate("scan-result/$key") { launchSingleTop = true }
+                },
+                onBack = { nav.popBackStack() },
+            )
+        }
+        composable(
+            "scan-result/{key}",
+            arguments = listOf(navArgument("key") { type = NavType.StringType }),
+        ) { backStack ->
+            val key = backStack.arguments!!.getString("key")!!
+            val data = remember(key) { container.scanResultRegistry.get(key) }
+            if (data == null) {
+                CatalogDetailUnavailable(onBack = { nav.popBackStack() })
+            } else {
+                val vm = remember(key) {
+                    ScanResultViewModel(data = data, ai = container.aiRepository)
+                }
+                ScanResultScreen(viewModel = vm, onBack = { nav.popBackStack() })
             }
         }
         composable("licenses") {

--- a/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/catalog/CatalogScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Sort
 import androidx.compose.material.icons.outlined.Info
@@ -36,6 +37,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -67,6 +69,7 @@ fun CatalogScreen(
     viewModel: CatalogViewModel,
     contentPadding: PaddingValues,
     onShowDetails: (OpdsPublication) -> Unit = {},
+    onScan: () -> Unit = {},
 ) {
     val state by viewModel.state.collectAsState()
     val downloadedUrls by viewModel.downloadedUrls.collectAsState()
@@ -106,6 +109,18 @@ fun CatalogScreen(
                     )
                 }
             }
+        }
+
+        // Scan a book: reachable from any catalog state. Overlaid as a FAB so
+        // it survives Loading/Error states (the Loaded grid has no Scaffold
+        // slot of its own).
+        FloatingActionButton(
+            onClick = onScan,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+        ) {
+            Icon(Icons.Default.QrCodeScanner, contentDescription = "Scan a book")
         }
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanResultRegistry.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanResultRegistry.kt
@@ -1,0 +1,39 @@
+package io.theficos.ereader.ui.scan
+
+import io.theficos.ereader.core.metadata.MetadataBundle
+import io.theficos.ereader.data.library.AffinityResponse
+import java.util.UUID
+
+/**
+ * The data a successful scan hands off to the result screen: the canonical
+ * ISBN-13, the resolved metadata, and the affinity verdict (null + the
+ * `affinityUnavailable` flag when the server has no affinity backend).
+ */
+data class ScanResultData(
+    val isbn13: String,
+    val bundle: MetadataBundle,
+    val affinity: AffinityResponse?,
+    val affinityUnavailable: Boolean,
+)
+
+/**
+ * Transient in-memory map keyed by a short UUID, used to pass a
+ * [ScanResultData] from `ScanScreen` to `ScanResultScreen` without encoding
+ * the whole metadata bundle + affinity payload into a nav route argument.
+ *
+ * Mirrors `CatalogDetailRegistry`: lifetime is bound to the process; on
+ * process death the registry resets and a restored result screen gets `null`
+ * and shows a fallback. That's acceptable — a scan is a transient action the
+ * user can simply repeat.
+ */
+class ScanResultRegistry {
+    private val map = mutableMapOf<String, ScanResultData>()
+
+    fun put(data: ScanResultData): String {
+        val key = UUID.randomUUID().toString()
+        synchronized(map) { map[key] = data }
+        return key
+    }
+
+    fun get(key: String): ScanResultData? = synchronized(map) { map[key] }
+}

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanResultScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanResultScreen.kt
@@ -1,0 +1,198 @@
+package io.theficos.ereader.ui.scan
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.theficos.ereader.data.library.AffinityResponse
+import io.theficos.ereader.ui.bookdetail.InsightSection
+import io.theficos.ereader.ui.bookdetail.InsightUiState
+import io.theficos.ereader.ui.components.CoverImage
+import io.theficos.ereader.ui.components.QuireCard
+
+/**
+ * Scan-result screen.
+ *
+ * Layout, top to bottom:
+ *  - Header: cover (OpenLibrary cover-by-ISBN), title, author.
+ *  - Owned banner (leads when the book is already in the user's library).
+ *  - Affinity card: score + band + reason bullets, OR "not enough history yet"
+ *    for the `unknown` band, OR an "affinity unavailable on this server" note
+ *    when the affinity backend is mode-gated off.
+ *  - "Get full insight" → triggers [ScanResultViewModel.loadInsight] and
+ *    renders the shared [InsightSection] below.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScanResultScreen(
+    viewModel: ScanResultViewModel,
+    onBack: () -> Unit,
+) {
+    val data = viewModel.data
+    val bundle = data.bundle
+    val insight by viewModel.insight.collectAsState()
+    val coverUrl = data.isbn13.takeIf { it.isNotBlank() }
+        ?.let { "https://covers.openlibrary.org/b/isbn/$it-L.jpg" }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Scan result") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(verticalAlignment = androidx.compose.ui.Alignment.Top) {
+                CoverImage(
+                    source = coverUrl,
+                    title = bundle.title,
+                    author = bundle.author,
+                    modifier = Modifier
+                        .width(96.dp)
+                        .height(144.dp),
+                )
+                Spacer(Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        bundle.title,
+                        style = MaterialTheme.typography.headlineSmall,
+                    )
+                    bundle.author?.let {
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            it,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            val owned = data.affinity?.owned
+            if (owned != null) {
+                OwnedBanner(readingStatus = owned.readingStatus)
+            }
+
+            when {
+                data.affinityUnavailable -> AffinityUnavailableCard()
+                data.affinity != null -> AffinityCard(data.affinity)
+            }
+
+            Button(
+                onClick = { viewModel.loadInsight() },
+                enabled = viewModel.insightAvailable() && insight !is InsightUiState.Loading,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Get full insight")
+            }
+
+            InsightSection(insight, onRetry = { viewModel.retryInsight() })
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun OwnedBanner(readingStatus: String) {
+    QuireCard(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        Column {
+            Text("Already in your library", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Status: ${readingStatus.replace('_', ' ')}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AffinityCard(affinity: AffinityResponse) {
+    QuireCard(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        Column {
+            if (affinity.band == "unknown") {
+                Text("Affinity", style = MaterialTheme.typography.titleSmall)
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Not enough history yet to score this for you.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                return@Column
+            }
+
+            val header = buildString {
+                append(affinity.band.replaceFirstChar { it.uppercase() })
+                affinity.score?.let { append(" · $it") }
+            }
+            Text("Affinity", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(4.dp))
+            Text(header, style = MaterialTheme.typography.titleMedium)
+            if (affinity.reasons.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                affinity.reasons.forEach { reason ->
+                    val marker = when (reason.polarity) {
+                        "positive" -> "+"
+                        "negative" -> "−"
+                        else -> "•"
+                    }
+                    Text(
+                        "$marker ${reason.message}",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AffinityUnavailableCard() {
+    QuireCard(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        Column {
+            Text("Affinity", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Affinity scoring isn't available on this server.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanResultViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanResultViewModel.kt
@@ -1,0 +1,73 @@
+package io.theficos.ereader.ui.scan
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.theficos.ereader.core.model.DocumentIdentity
+import io.theficos.ereader.data.ai.AiHttpException
+import io.theficos.ereader.data.ai.AiQuotaException
+import io.theficos.ereader.data.ai.AiRepository
+import io.theficos.ereader.ui.bookdetail.InsightUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the scan-result screen.
+ *
+ * The metadata + affinity verdict come pre-resolved from the scan flow (held
+ * in [data]); this VM owns only the on-demand "Get full insight" action. That
+ * action calls [AiRepository.lookupInsight] with an `isbn:<isbn13>` identity —
+ * the same identity the scan used for affinity, so a later library download of
+ * the same book promotes onto the cached insight row.
+ *
+ * Insight is hidden until the user asks for it (cost gate) and when AI is not
+ * configured / opted out, mirroring the book-detail screen's gating.
+ */
+class ScanResultViewModel(
+    val data: ScanResultData,
+    private val ai: AiRepository,
+) : ViewModel() {
+
+    private val _insight = MutableStateFlow<InsightUiState>(InsightUiState.Hidden)
+    val insight: StateFlow<InsightUiState> = _insight.asStateFlow()
+
+    /** True when AI is configured and the user hasn't opted out. */
+    fun insightAvailable(): Boolean {
+        val cfg = ai.config.value
+        val pref = ai.preferences.value
+        return cfg?.configured == true && pref?.aiEnabled == true
+    }
+
+    fun loadInsight() {
+        if (!insightAvailable()) {
+            _insight.value = InsightUiState.Hidden
+            return
+        }
+        val isbn13 = data.isbn13.takeIf { it.isNotBlank() } ?: run {
+            _insight.value = InsightUiState.Error("Couldn't generate insights.")
+            return
+        }
+        val identity = DocumentIdentity(metadataId = "isbn:$isbn13", isbn = isbn13)
+        _insight.value = InsightUiState.Loading
+        viewModelScope.launch {
+            runCatching { ai.lookupInsight(identity, data.bundle) }
+                .onSuccess { resp ->
+                    _insight.value = InsightUiState.Loaded(resp.payload, resp.sources)
+                }
+                .onFailure { e ->
+                    val msg = when {
+                        e is AiQuotaException ->
+                            "You've reached today's regeneration limit. Try again after ${e.info.resetsAt.take(10)}."
+                        e is AiHttpException && e.code == 429 ->
+                            "You've reached today's regeneration limit. Try again tomorrow."
+                        e is AiHttpException -> "Couldn't generate insights (${e.code})."
+                        else -> "Couldn't generate insights."
+                    }
+                    _insight.value = InsightUiState.Error(msg)
+                }
+        }
+    }
+
+    fun retryInsight() = loadInsight()
+}

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanScreen.kt
@@ -299,20 +299,21 @@ private fun CameraPreview(
             -> Unit
         }
     }
-    val reader = remember {
-        MultiFormatReader().apply {
-            setHints(
-                mapOf(
-                    DecodeHintType.POSSIBLE_FORMATS to listOf(
-                        BarcodeFormat.EAN_13,
-                        BarcodeFormat.EAN_8,
-                        BarcodeFormat.UPC_A,
-                    ),
-                    DecodeHintType.TRY_HARDER to true,
-                ),
-            )
-        }
+    // Hints are passed to reader.decode(bitmap, hints) on every frame rather
+    // than stashed once via setHints(): the single-arg MultiFormatReader.decode
+    // calls setHints(null) internally and would silently discard POSSIBLE_FORMATS
+    // and TRY_HARDER. Passing them explicitly keeps them in force every decode.
+    val decodeHints = remember {
+        mapOf<DecodeHintType, Any>(
+            DecodeHintType.POSSIBLE_FORMATS to listOf(
+                BarcodeFormat.EAN_13,
+                BarcodeFormat.EAN_8,
+                BarcodeFormat.UPC_A,
+            ),
+            DecodeHintType.TRY_HARDER to true,
+        )
     }
+    val reader = remember { MultiFormatReader() }
 
     DisposableEffect(Unit) {
         onDispose { analysisExecutor.shutdown() }
@@ -334,7 +335,7 @@ private fun CameraPreview(
                     .also { ia ->
                         ia.setAnalyzer(analysisExecutor) { proxy ->
                             try {
-                                decodeBarcode(proxy, reader)?.let { isbn ->
+                                decodeBarcode(proxy, reader, decodeHints)?.let { isbn ->
                                     if (decoded.compareAndSet(false, true)) {
                                         // Hop to the main thread: onIsbnSubmitted
                                         // touches Compose/VM state and must not be
@@ -342,6 +343,11 @@ private fun CameraPreview(
                                         mainExecutor.execute { currentOnDecoded(isbn) }
                                     }
                                 }
+                            } catch (_: Throwable) {
+                                // Never let a decode-path failure escape into
+                                // CameraX: it would be thrown once per frame on the
+                                // analysis thread (log spam, wasted CPU) and mask
+                                // genuine read failures. A no-read is just a null.
                             } finally {
                                 // Always close so STRATEGY_KEEP_ONLY_LATEST keeps
                                 // delivering frames; an un-closed proxy stalls the
@@ -385,11 +391,18 @@ private fun CameraPreview(
  *    landscape, so [androidx.camera.core.ImageInfo.rotationDegrees] is typically
  *    90/270 and a real-world-horizontal EAN-13 lands rotated in the buffer.
  *    ZXing's EAN-13 reader is a 1D *row* scanner and a single decode() does not
- *    try rotated variants, so a 90°-rotated barcode is a permanent no-read. We
- *    decode the upright source and, on a miss, its 90° CCW variant — covering
- *    both portrait orientations regardless of the actual rotation metadata.
+ *    try rotated variants, so a 90°-rotated barcode is a permanent no-read.
+ *    [PlanarYUVLuminanceSource] does NOT support rotateCounterClockwise() in
+ *    zxing 3.5.x (the base throws UnsupportedOperationException), so we rotate
+ *    the packed Y buffer ourselves: we decode the frame as delivered and, on a
+ *    miss, a 90°-transposed variant — covering an EAN-13 held horizontally in
+ *    either portrait rotation regardless of the rotation metadata.
  */
-private fun decodeBarcode(proxy: ImageProxy, reader: MultiFormatReader): String? {
+private fun decodeBarcode(
+    proxy: ImageProxy,
+    reader: MultiFormatReader,
+    hints: Map<DecodeHintType, Any>,
+): String? {
     val plane = proxy.planes.firstOrNull() ?: return null
     val width = proxy.width
     val height = proxy.height
@@ -399,12 +412,36 @@ private fun decodeBarcode(proxy: ImageProxy, reader: MultiFormatReader): String?
     // dataWidth == width because we repacked the plane tightly above.
     val source = PlanarYUVLuminanceSource(yData, width, height, 0, 0, width, height, false)
 
-    // Try the frame as delivered, then rotated 90° CCW. rotateCounterClockwise()
-    // on PlanarYUVLuminanceSource is supported in zxing 3.5.3 and is cheap
-    // (index remap, no extra decode of the whole image). The two orientations
-    // cover an EAN-13 held horizontally in either portrait rotation.
-    return decodeOrNull(source, reader)
-        ?: decodeOrNull(source.rotateCounterClockwise(), reader)
+    // Try the frame as delivered first.
+    decodeOrNull(source, reader, hints)?.let { return it }
+
+    // On a miss, try the 90°-transposed buffer. We rotate the bytes ourselves
+    // because PlanarYUVLuminanceSource.rotateCounterClockwise() throws in zxing
+    // 3.5.x. A single transpose makes a real-world-horizontal barcode that
+    // landed vertical (or vice-versa) line up with ZXing's 1D row scanner; one
+    // orientation suffices since the row scanner reads a full line either way.
+    val rotated = rotateYPlane90(yData, width, height)
+    val rotatedSource =
+        PlanarYUVLuminanceSource(rotated, height, width, 0, 0, height, width, false)
+    return decodeOrNull(rotatedSource, reader, hints)
+}
+
+/**
+ * Transpose a tightly-packed width×height luma buffer by 90° into a new
+ * height×width buffer. dst[x, y] = src[y, x]; this maps a horizontal feature in
+ * the source to a vertical one in the result, which is exactly what we need to
+ * present a sideways barcode upright to ZXing's 1D row scanner.
+ */
+private fun rotateYPlane90(src: ByteArray, width: Int, height: Int): ByteArray {
+    val dst = ByteArray(width * height)
+    for (y in 0 until height) {
+        val rowBase = y * width
+        for (x in 0 until width) {
+            // Destination is height(=newWidth) wide; row index is x, col is y.
+            dst[x * height + y] = src[rowBase + x]
+        }
+    }
+    return dst
 }
 
 /**
@@ -448,11 +485,20 @@ private fun packYPlane(plane: ImageProxy.PlaneProxy, width: Int, height: Int): B
     return out
 }
 
-/** Decode a single luminance source, swallowing no-reads. */
-private fun decodeOrNull(source: LuminanceSource, reader: MultiFormatReader): String? {
+/**
+ * Decode a single luminance source, swallowing no-reads. Hints are passed
+ * explicitly (not via the reader's stashed state) because the single-arg
+ * MultiFormatReader.decode wipes hints with setHints(null); the two-arg form
+ * re-applies POSSIBLE_FORMATS and TRY_HARDER on every call.
+ */
+private fun decodeOrNull(
+    source: LuminanceSource,
+    reader: MultiFormatReader,
+    hints: Map<DecodeHintType, Any>,
+): String? {
     val bitmap = BinaryBitmap(HybridBinarizer(source))
     return try {
-        reader.decode(bitmap).text
+        reader.decode(bitmap, hints).text
     } catch (_: Exception) {
         null
     } finally {

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanScreen.kt
@@ -56,6 +56,7 @@ import androidx.core.content.ContextCompat
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.BinaryBitmap
 import com.google.zxing.DecodeHintType
+import com.google.zxing.LuminanceSource
 import com.google.zxing.MultiFormatReader
 import com.google.zxing.PlanarYUVLuminanceSource
 import com.google.zxing.common.HybridBinarizer
@@ -271,6 +272,9 @@ private fun CameraPreview(
     val currentOnDecoded by rememberUpdatedState(onIsbnDecoded)
 
     val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+    // Used to marshal a successful decode back onto the main thread, since the
+    // analyzer runs on the dedicated single-thread analysis executor.
+    val mainExecutor = remember(context) { ContextCompat.getMainExecutor(context) }
     // Latch so one held barcode doesn't fire repeatedly. The VM also dedups
     // via its generation guard, but latching avoids submit spam.
     val decoded = remember { AtomicBoolean(false) }
@@ -299,7 +303,12 @@ private fun CameraPreview(
         MultiFormatReader().apply {
             setHints(
                 mapOf(
-                    DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.EAN_13),
+                    DecodeHintType.POSSIBLE_FORMATS to listOf(
+                        BarcodeFormat.EAN_13,
+                        BarcodeFormat.EAN_8,
+                        BarcodeFormat.UPC_A,
+                    ),
+                    DecodeHintType.TRY_HARDER to true,
                 ),
             )
         }
@@ -324,12 +333,21 @@ private fun CameraPreview(
                     .build()
                     .also { ia ->
                         ia.setAnalyzer(analysisExecutor) { proxy ->
-                            decodeBarcode(proxy, reader)?.let { isbn ->
-                                if (decoded.compareAndSet(false, true)) {
-                                    currentOnDecoded(isbn)
+                            try {
+                                decodeBarcode(proxy, reader)?.let { isbn ->
+                                    if (decoded.compareAndSet(false, true)) {
+                                        // Hop to the main thread: onIsbnSubmitted
+                                        // touches Compose/VM state and must not be
+                                        // called from the analysis worker thread.
+                                        mainExecutor.execute { currentOnDecoded(isbn) }
+                                    }
                                 }
+                            } finally {
+                                // Always close so STRATEGY_KEEP_ONLY_LATEST keeps
+                                // delivering frames; an un-closed proxy stalls the
+                                // pipeline after a single frame.
+                                proxy.close()
                             }
-                            proxy.close()
                         }
                     }
                 runCatching {
@@ -348,27 +366,90 @@ private fun CameraPreview(
 }
 
 /**
- * Pull the Y (luminance) plane out of a YUV [ImageProxy] and run ZXing over
- * it. Returns the decoded barcode text, or null on no-read. Caller owns
+ * Pull the Y (luminance) plane out of a YUV_420_888 [ImageProxy] and run ZXing
+ * over it. Returns the decoded barcode text, or null on no-read. Caller owns
  * closing the proxy.
+ *
+ * Two things the naive path got wrong (why preview rendered but auto-decode
+ * never fired):
+ *
+ *  - **Row stride.** A YUV_420_888 Y plane's [ImageProxy.PlaneProxy.rowStride]
+ *    is generally larger than the image width (and its pixelStride can be >1),
+ *    so the backing buffer is *not* a tight width×height array. We build a
+ *    tightly-packed Y buffer by copying `width` luma samples per row honouring
+ *    rowStride/pixelStride, then hand ZXing a dataWidth == width source. (An
+ *    alternative is to pass the raw buffer with dataWidth = rowStride and crop;
+ *    repacking is simpler to reason about and lets us rotate cheaply.)
+ *
+ *  - **Rotation.** On a portrait-held phone the back sensor is mounted
+ *    landscape, so [androidx.camera.core.ImageInfo.rotationDegrees] is typically
+ *    90/270 and a real-world-horizontal EAN-13 lands rotated in the buffer.
+ *    ZXing's EAN-13 reader is a 1D *row* scanner and a single decode() does not
+ *    try rotated variants, so a 90°-rotated barcode is a permanent no-read. We
+ *    decode the upright source and, on a miss, its 90° CCW variant — covering
+ *    both portrait orientations regardless of the actual rotation metadata.
  */
 private fun decodeBarcode(proxy: ImageProxy, reader: MultiFormatReader): String? {
     val plane = proxy.planes.firstOrNull() ?: return null
-    val buffer = plane.buffer
-    val data = ByteArray(buffer.remaining())
-    buffer.get(data)
     val width = proxy.width
     val height = proxy.height
-    val source = PlanarYUVLuminanceSource(
-        data,
-        plane.rowStride,
-        height,
-        0,
-        0,
-        width,
-        height,
-        false,
-    )
+    if (width <= 0 || height <= 0) return null
+
+    val yData = packYPlane(plane, width, height) ?: return null
+    // dataWidth == width because we repacked the plane tightly above.
+    val source = PlanarYUVLuminanceSource(yData, width, height, 0, 0, width, height, false)
+
+    // Try the frame as delivered, then rotated 90° CCW. rotateCounterClockwise()
+    // on PlanarYUVLuminanceSource is supported in zxing 3.5.3 and is cheap
+    // (index remap, no extra decode of the whole image). The two orientations
+    // cover an EAN-13 held horizontally in either portrait rotation.
+    return decodeOrNull(source, reader)
+        ?: decodeOrNull(source.rotateCounterClockwise(), reader)
+}
+
+/**
+ * Copy the Y (luma) plane into a tightly-packed width×height byte array,
+ * honouring the plane's rowStride and pixelStride. Returns null if the buffer
+ * is too short to satisfy the declared geometry.
+ */
+private fun packYPlane(plane: ImageProxy.PlaneProxy, width: Int, height: Int): ByteArray? {
+    val buffer = plane.buffer
+    val rowStride = plane.rowStride
+    val pixelStride = plane.pixelStride
+    val out = ByteArray(width * height)
+
+    if (pixelStride == 1 && rowStride == width) {
+        // Fast path: already tightly packed.
+        if (buffer.remaining() < width * height) return null
+        buffer.get(out, 0, width * height)
+        return out
+    }
+
+    val rowBuf = ByteArray(rowStride)
+    var outPos = 0
+    for (row in 0 until height) {
+        val rowStart = row * rowStride
+        if (rowStart >= buffer.limit()) return null
+        val toRead = minOf(rowStride, buffer.limit() - rowStart)
+        buffer.position(rowStart)
+        buffer.get(rowBuf, 0, toRead)
+        var col = 0
+        var src = 0
+        while (col < width && src < toRead) {
+            out[outPos++] = rowBuf[src]
+            src += pixelStride
+            col++
+        }
+        // If a row was short (last row of an odd buffer), leave the remainder
+        // as zero; ZXing tolerates a few dark pixels far better than misaligned
+        // rows.
+        outPos = (row + 1) * width
+    }
+    return out
+}
+
+/** Decode a single luminance source, swallowing no-reads. */
+private fun decodeOrNull(source: LuminanceSource, reader: MultiFormatReader): String? {
     val bitmap = BinaryBitmap(HybridBinarizer(source))
     return try {
         reader.decode(bitmap).text

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanScreen.kt
@@ -151,6 +151,7 @@ fun ScanScreen(
             if (hasCameraPermission) {
                 CameraPreview(
                     onIsbnDecoded = { viewModel.onIsbnSubmitted(it) },
+                    state = state,
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(3f / 4f),
@@ -255,11 +256,14 @@ private fun StatusArea(state: ScanUiState) {
  * tears the analysis executor down on dispose. The [onIsbnDecoded] callback is
  * captured via [rememberUpdatedState] so the long-lived analyzer always calls
  * the latest lambda. A successful decode latches [decoded] so we don't fire a
- * burst of submits for the same barcode held in frame.
+ * burst of submits for the same barcode held in frame; the latch is released
+ * again whenever [state] settles into a re-scannable outcome (a miss, error, or
+ * idle) so auto-decoding resumes without forcing the manual-entry fallback.
  */
 @Composable
 private fun CameraPreview(
     onIsbnDecoded: (String) -> Unit,
+    state: ScanUiState,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -270,6 +274,27 @@ private fun CameraPreview(
     // Latch so one held barcode doesn't fire repeatedly. The VM also dedups
     // via its generation guard, but latching avoids submit spam.
     val decoded = remember { AtomicBoolean(false) }
+
+    // Release the latch whenever the scan settles into a state the user can
+    // re-scan from. Without this, the first decode would wedge auto-scanning:
+    // for any outcome that keeps us on this screen (NotFound / Failed /
+    // ReauthRequired / InvalidIsbn / back to Idle) the camera would otherwise
+    // never auto-decode again, silently forcing manual entry. A successful
+    // Result navigates away and disposes this composable, so it deliberately
+    // does not reset; Working keeps the latch held while a scan is in flight.
+    LaunchedEffect(state) {
+        when (state) {
+            ScanUiState.Idle,
+            ScanUiState.InvalidIsbn,
+            ScanUiState.NotFound,
+            ScanUiState.ReauthRequired,
+            is ScanUiState.Failed,
+            -> decoded.set(false)
+            ScanUiState.Working,
+            is ScanUiState.Result,
+            -> Unit
+        }
+    }
     val reader = remember {
         MultiFormatReader().apply {
             setHints(

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanScreen.kt
@@ -1,0 +1,355 @@
+package io.theficos.ereader.ui.scan
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.PlanarYUVLuminanceSource
+import com.google.zxing.common.HybridBinarizer
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Book-scan entry screen.
+ *
+ * Two acquisition paths, both feeding [ScanViewModel.onIsbnSubmitted]:
+ *  - Live camera: CameraX [Preview] in a [PreviewView] plus an [ImageAnalysis]
+ *    stage that runs a ZXing [MultiFormatReader] restricted to EAN_13 (the
+ *    barcode symbology printed on book back-covers). First clean decode fires
+ *    the submit, then auto-decoding pauses until the user re-scans.
+ *  - Manual entry: an always-visible "Enter ISBN" field + submit button. This
+ *    is the camera-less fallback (permission denied / no camera) and a manual
+ *    override.
+ *
+ * State mapping (see [ScanUiState]):
+ *  - Working → inline spinner.
+ *  - InvalidIsbn → inline error on the field.
+ *  - NotFound / Failed → message + the field stays available to retry.
+ *  - ReauthRequired → recoverable message (re-auth nav is driven elsewhere).
+ *  - Result → register the payload and call [onResult] with the nav key.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScanScreen(
+    viewModel: ScanViewModel,
+    onResult: (ScanResultData) -> Unit,
+    onBack: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+
+    var hasCameraPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+                PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    var permissionDenied by remember { mutableStateOf(false) }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        hasCameraPermission = granted
+        permissionDenied = !granted
+    }
+    LaunchedEffect(Unit) {
+        if (!hasCameraPermission) {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    // Surface a successful scan to the caller for navigation. Done in an
+    // effect so navigation is a side effect of state, not of composition.
+    LaunchedEffect(state) {
+        val s = state
+        if (s is ScanUiState.Result) {
+            onResult(
+                ScanResultData(
+                    isbn13 = s.bundle.isbn ?: "",
+                    bundle = s.bundle,
+                    affinity = s.affinity,
+                    affinityUnavailable = s.affinityUnavailable,
+                ),
+            )
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Scan a book") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            if (hasCameraPermission) {
+                CameraPreview(
+                    onIsbnDecoded = { viewModel.onIsbnSubmitted(it) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(3f / 4f),
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(3f / 4f),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = if (permissionDenied) {
+                            "Camera permission denied. Enter the ISBN below, or grant " +
+                                "camera access in Settings to scan the barcode."
+                        } else {
+                            "Camera unavailable. Enter the ISBN below."
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(24.dp),
+                    )
+                }
+            }
+
+            ManualIsbnField(
+                isError = state is ScanUiState.InvalidIsbn,
+                onSubmit = { viewModel.onIsbnSubmitted(it) },
+            )
+
+            StatusArea(state = state)
+        }
+    }
+}
+
+@Composable
+private fun ManualIsbnField(
+    isError: Boolean,
+    onSubmit: (String) -> Unit,
+) {
+    var value by rememberSaveable { mutableStateOf("") }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = { value = it },
+            label = { Text("Enter ISBN") },
+            isError = isError,
+            supportingText = if (isError) {
+                { Text("That doesn't look like a valid ISBN.") }
+            } else null,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(onDone = {
+                if (value.isNotBlank()) onSubmit(value.trim())
+            }),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Button(
+            onClick = { if (value.isNotBlank()) onSubmit(value.trim()) },
+            enabled = value.isNotBlank(),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Look up")
+        }
+    }
+}
+
+@Composable
+private fun StatusArea(state: ScanUiState) {
+    when (state) {
+        ScanUiState.Idle,
+        is ScanUiState.Result,
+        ScanUiState.InvalidIsbn,
+        -> Unit
+        ScanUiState.Working -> Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator()
+        }
+        ScanUiState.NotFound -> Text(
+            "No book found for that ISBN. Try the barcode again or check the digits.",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        ScanUiState.ReauthRequired -> Text(
+            "Your session expired. Sign in again, then re-scan.",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        is ScanUiState.Failed -> Text(
+            state.message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+/**
+ * CameraX preview + barcode analysis. Binds to the current lifecycle and
+ * tears the analysis executor down on dispose. The [onIsbnDecoded] callback is
+ * captured via [rememberUpdatedState] so the long-lived analyzer always calls
+ * the latest lambda. A successful decode latches [decoded] so we don't fire a
+ * burst of submits for the same barcode held in frame.
+ */
+@Composable
+private fun CameraPreview(
+    onIsbnDecoded: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val currentOnDecoded by rememberUpdatedState(onIsbnDecoded)
+
+    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+    // Latch so one held barcode doesn't fire repeatedly. The VM also dedups
+    // via its generation guard, but latching avoids submit spam.
+    val decoded = remember { AtomicBoolean(false) }
+    val reader = remember {
+        MultiFormatReader().apply {
+            setHints(
+                mapOf(
+                    DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.EAN_13),
+                ),
+            )
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { analysisExecutor.shutdown() }
+    }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            val previewView = PreviewView(ctx)
+            val providerFuture = ProcessCameraProvider.getInstance(ctx)
+            providerFuture.addListener({
+                val provider = providerFuture.get()
+                val preview = Preview.Builder().build().also {
+                    it.setSurfaceProvider(previewView.surfaceProvider)
+                }
+                val analysis = ImageAnalysis.Builder()
+                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                    .build()
+                    .also { ia ->
+                        ia.setAnalyzer(analysisExecutor) { proxy ->
+                            decodeBarcode(proxy, reader)?.let { isbn ->
+                                if (decoded.compareAndSet(false, true)) {
+                                    currentOnDecoded(isbn)
+                                }
+                            }
+                            proxy.close()
+                        }
+                    }
+                runCatching {
+                    provider.unbindAll()
+                    provider.bindToLifecycle(
+                        lifecycleOwner,
+                        CameraSelector.DEFAULT_BACK_CAMERA,
+                        preview,
+                        analysis,
+                    )
+                }
+            }, ContextCompat.getMainExecutor(ctx))
+            previewView
+        },
+    )
+}
+
+/**
+ * Pull the Y (luminance) plane out of a YUV [ImageProxy] and run ZXing over
+ * it. Returns the decoded barcode text, or null on no-read. Caller owns
+ * closing the proxy.
+ */
+private fun decodeBarcode(proxy: ImageProxy, reader: MultiFormatReader): String? {
+    val plane = proxy.planes.firstOrNull() ?: return null
+    val buffer = plane.buffer
+    val data = ByteArray(buffer.remaining())
+    buffer.get(data)
+    val width = proxy.width
+    val height = proxy.height
+    val source = PlanarYUVLuminanceSource(
+        data,
+        plane.rowStride,
+        height,
+        0,
+        0,
+        width,
+        height,
+        false,
+    )
+    val bitmap = BinaryBitmap(HybridBinarizer(source))
+    return try {
+        reader.decode(bitmap).text
+    } catch (_: Exception) {
+        null
+    } finally {
+        reader.reset()
+    }
+}

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanViewModel.kt
@@ -28,7 +28,8 @@ import kotlinx.coroutines.withContext
  *      A miss yields [ScanUiState.NotFound].
  *   4. Ask the Quire server to score the book via [runAffinity]. Success →
  *      [ScanUiState.Result] with the affinity attached. A 404 (no affinity
- *      backend / book not scoreable) degrades to a Result with
+ *      backend / book not scoreable) or a code-0 unreachable/unconfigured
+ *      server (split / metadata-only deployment) degrades to a Result with
  *      `affinityUnavailable = true` — the metadata is still useful. A 401
  *      signals stale credentials: [onReauth] is fired and the screen returns
  *      to [ScanUiState.ReauthRequired] so the user has a recoverable, non-
@@ -89,7 +90,14 @@ class ScanViewModel(
                     ScanUiState.Result(bundle = bundle, affinity = resp, affinityUnavailable = false)
                 } catch (e: LibraryHttpException) {
                     when (e.code) {
-                        404 -> ScanUiState.Result(
+                        // 404: no affinity backend / book not scoreable.
+                        // 0: the affinity client never reached a server
+                        //    (e.g. baseUrl not configured in a metadata-only /
+                        //    split deployment). In both cases the OpenLibrary
+                        //    metadata we already resolved is still useful, so
+                        //    degrade to a Result with affinity unavailable
+                        //    rather than hiding it behind a red Failed error.
+                        0, 404 -> ScanUiState.Result(
                             bundle = bundle,
                             affinity = null,
                             affinityUnavailable = true,

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanViewModel.kt
@@ -8,11 +8,14 @@ import io.theficos.ereader.data.library.AffinityIdentity
 import io.theficos.ereader.data.library.AffinityRequestBody
 import io.theficos.ereader.data.library.AffinityResponse
 import io.theficos.ereader.data.library.LibraryHttpException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Drives the "Scan a book" screen.
@@ -27,16 +30,23 @@ import kotlinx.coroutines.launch
  *      [ScanUiState.Result] with the affinity attached. A 404 (no affinity
  *      backend / book not scoreable) degrades to a Result with
  *      `affinityUnavailable = true` — the metadata is still useful. A 401
- *      signals stale credentials and triggers [onReauth]. Anything else →
- *      [ScanUiState.Failed].
+ *      signals stale credentials: [onReauth] is fired and the screen returns
+ *      to [ScanUiState.ReauthRequired] so the user has a recoverable, non-
+ *      spinning state to act on. Anything else → [ScanUiState.Failed].
  *
  * Collaborators are injected as suspend lambdas so the state machine is
- * unit-testable without real HTTP clients. Blocking IO is expected to be
- * dispatched by the supplied lambdas (e.g. the OpenLibrary client / library
- * client already hop to Dispatchers.IO internally).
+ * unit-testable without real HTTP clients. [lookup] is invoked on
+ * [Dispatchers.IO] by this VM because the production OpenLibrary client does a
+ * blocking OkHttp call without hopping dispatchers itself; [runAffinity] (the
+ * library client) already hops to Dispatchers.IO internally, so the extra hop
+ * is harmless for it.
  *
- * Cancellation: a fresh [onIsbnSubmitted] cancels any in-flight scan job, so
- * rapid re-scans never race a stale result onto the screen.
+ * Cancellation / staleness: each scan is tagged with a monotonic [generation].
+ * A fresh [onIsbnSubmitted] cancels any in-flight job and bumps the generation;
+ * every state write after a suspension point is guarded by a generation check,
+ * and [CancellationException] is rethrown rather than swallowed. A slow, stale
+ * scan therefore can never clobber a newer scan's result — even if its network
+ * resolves after the newer one's.
  */
 class ScanViewModel(
     private val lookup: suspend (String) -> MetadataBundle?,
@@ -49,6 +59,8 @@ class ScanViewModel(
 
     private var scanJob: Job? = null
 
+    @Volatile private var generation: Long = 0L
+
     fun onIsbnSubmitted(raw: String) {
         val isbn13 = Isbn.toIsbn13(raw)
         if (isbn13 == null) {
@@ -58,37 +70,47 @@ class ScanViewModel(
 
         scanJob?.cancel()
         _state.value = ScanUiState.Working
+        val mine = ++generation
         scanJob = viewModelScope.launch {
-            val bundle = lookup(isbn13)
-            if (bundle == null) {
-                _state.value = ScanUiState.NotFound
-                return@launch
-            }
-
-            val body = AffinityRequestBody(
-                identity = AffinityIdentity(isbn = isbn13, metadataId = "isbn:$isbn13"),
-                bundle = bundle,
-            )
-            _state.value = try {
-                val resp = runAffinity(body)
-                ScanUiState.Result(bundle = bundle, affinity = resp, affinityUnavailable = false)
-            } catch (e: LibraryHttpException) {
-                when (e.code) {
-                    404 -> ScanUiState.Result(
-                        bundle = bundle,
-                        affinity = null,
-                        affinityUnavailable = true,
-                    )
-                    401 -> {
-                        onReauth()
-                        // Leave the user on Working; the re-auth flow drives
-                        // navigation and they can re-scan once re-authenticated.
-                        ScanUiState.Working
-                    }
-                    else -> ScanUiState.Failed(e.localizedMessage ?: "Affinity request failed.")
+            try {
+                val bundle = withContext(Dispatchers.IO) { lookup(isbn13) }
+                if (mine != generation) return@launch
+                if (bundle == null) {
+                    _state.value = ScanUiState.NotFound
+                    return@launch
                 }
+
+                val body = AffinityRequestBody(
+                    identity = AffinityIdentity(isbn = isbn13, metadataId = "isbn:$isbn13"),
+                    bundle = bundle,
+                )
+                val next = try {
+                    val resp = runAffinity(body)
+                    ScanUiState.Result(bundle = bundle, affinity = resp, affinityUnavailable = false)
+                } catch (e: LibraryHttpException) {
+                    when (e.code) {
+                        404 -> ScanUiState.Result(
+                            bundle = bundle,
+                            affinity = null,
+                            affinityUnavailable = true,
+                        )
+                        401 -> {
+                            onReauth()
+                            // Recoverable, non-spinning state: the re-auth flow
+                            // can drive navigation, and if the user stays here
+                            // they have an actionable screen to re-scan from.
+                            ScanUiState.ReauthRequired
+                        }
+                        else -> ScanUiState.Failed(e.localizedMessage ?: "Affinity request failed.")
+                    }
+                }
+                if (mine != generation) return@launch
+                _state.value = next
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
-                ScanUiState.Failed(e.localizedMessage ?: "Something went wrong.")
+                if (mine != generation) return@launch
+                _state.value = ScanUiState.Failed(e.localizedMessage ?: "Something went wrong.")
             }
         }
     }
@@ -100,6 +122,13 @@ sealed interface ScanUiState {
     object Working : ScanUiState
     object InvalidIsbn : ScanUiState
     object NotFound : ScanUiState
+
+    /**
+     * Affinity scoring returned 401 (stale credentials). [onReauth] has been
+     * fired; the screen should prompt the user to re-authenticate and offer a
+     * re-scan rather than spin indefinitely.
+     */
+    object ReauthRequired : ScanUiState
     data class Result(
         val bundle: MetadataBundle,
         val affinity: AffinityResponse?,

--- a/app/src/main/java/io/theficos/ereader/ui/scan/ScanViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/scan/ScanViewModel.kt
@@ -1,0 +1,109 @@
+package io.theficos.ereader.ui.scan
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.theficos.ereader.core.metadata.Isbn
+import io.theficos.ereader.core.metadata.MetadataBundle
+import io.theficos.ereader.data.library.AffinityIdentity
+import io.theficos.ereader.data.library.AffinityRequestBody
+import io.theficos.ereader.data.library.AffinityResponse
+import io.theficos.ereader.data.library.LibraryHttpException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the "Scan a book" screen.
+ *
+ * Flow of a single scan (one [onIsbnSubmitted] call):
+ *   1. Canonicalise the raw input via [Isbn.toIsbn13]; a non-ISBN yields
+ *      [ScanUiState.InvalidIsbn] and stops.
+ *   2. Emit [ScanUiState.Working] and launch on `viewModelScope`.
+ *   3. [lookup] the ISBN-13 against an external metadata source (OpenLibrary).
+ *      A miss yields [ScanUiState.NotFound].
+ *   4. Ask the Quire server to score the book via [runAffinity]. Success →
+ *      [ScanUiState.Result] with the affinity attached. A 404 (no affinity
+ *      backend / book not scoreable) degrades to a Result with
+ *      `affinityUnavailable = true` — the metadata is still useful. A 401
+ *      signals stale credentials and triggers [onReauth]. Anything else →
+ *      [ScanUiState.Failed].
+ *
+ * Collaborators are injected as suspend lambdas so the state machine is
+ * unit-testable without real HTTP clients. Blocking IO is expected to be
+ * dispatched by the supplied lambdas (e.g. the OpenLibrary client / library
+ * client already hop to Dispatchers.IO internally).
+ *
+ * Cancellation: a fresh [onIsbnSubmitted] cancels any in-flight scan job, so
+ * rapid re-scans never race a stale result onto the screen.
+ */
+class ScanViewModel(
+    private val lookup: suspend (String) -> MetadataBundle?,
+    private val runAffinity: suspend (AffinityRequestBody) -> AffinityResponse,
+    private val onReauth: () -> Unit,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<ScanUiState>(ScanUiState.Idle)
+    val state: StateFlow<ScanUiState> = _state.asStateFlow()
+
+    private var scanJob: Job? = null
+
+    fun onIsbnSubmitted(raw: String) {
+        val isbn13 = Isbn.toIsbn13(raw)
+        if (isbn13 == null) {
+            _state.value = ScanUiState.InvalidIsbn
+            return
+        }
+
+        scanJob?.cancel()
+        _state.value = ScanUiState.Working
+        scanJob = viewModelScope.launch {
+            val bundle = lookup(isbn13)
+            if (bundle == null) {
+                _state.value = ScanUiState.NotFound
+                return@launch
+            }
+
+            val body = AffinityRequestBody(
+                identity = AffinityIdentity(isbn = isbn13, metadataId = "isbn:$isbn13"),
+                bundle = bundle,
+            )
+            _state.value = try {
+                val resp = runAffinity(body)
+                ScanUiState.Result(bundle = bundle, affinity = resp, affinityUnavailable = false)
+            } catch (e: LibraryHttpException) {
+                when (e.code) {
+                    404 -> ScanUiState.Result(
+                        bundle = bundle,
+                        affinity = null,
+                        affinityUnavailable = true,
+                    )
+                    401 -> {
+                        onReauth()
+                        // Leave the user on Working; the re-auth flow drives
+                        // navigation and they can re-scan once re-authenticated.
+                        ScanUiState.Working
+                    }
+                    else -> ScanUiState.Failed(e.localizedMessage ?: "Affinity request failed.")
+                }
+            } catch (e: Throwable) {
+                ScanUiState.Failed(e.localizedMessage ?: "Something went wrong.")
+            }
+        }
+    }
+}
+
+/** UI state for the scan screen. Sealed so the screen can `when`-exhaust. */
+sealed interface ScanUiState {
+    object Idle : ScanUiState
+    object Working : ScanUiState
+    object InvalidIsbn : ScanUiState
+    object NotFound : ScanUiState
+    data class Result(
+        val bundle: MetadataBundle,
+        val affinity: AffinityResponse?,
+        val affinityUnavailable: Boolean,
+    ) : ScanUiState
+    data class Failed(val message: String) : ScanUiState
+}

--- a/app/src/test/java/io/theficos/ereader/ui/scan/ScanViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/scan/ScanViewModelTest.kt
@@ -6,6 +6,7 @@ import io.theficos.ereader.core.metadata.MetadataBundle
 import io.theficos.ereader.data.library.AffinityRequestBody
 import io.theficos.ereader.data.library.AffinityResponse
 import io.theficos.ereader.data.library.LibraryHttpException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -114,14 +115,23 @@ class ScanViewModelTest {
         }
     }
 
-    @Test fun `affinity 401 invokes onReauth`() = runTest {
+    @Test fun `affinity 401 invokes onReauth and lands on ReauthRequired not Working`() = runTest {
         var reauthCalls = 0
         val vm = ScanViewModel(
             lookup = { bundle },
             runAffinity = { throw LibraryHttpException(401, "unauthorized") },
             onReauth = { reauthCalls++ },
         )
-        vm.onIsbnSubmitted(isbn13)
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn13)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            // Must NOT be left wedged on the Working spinner; must be a
+            // recoverable terminal state.
+            assertThat(s).isEqualTo(ScanUiState.ReauthRequired)
+            cancelAndIgnoreRemainingEvents()
+        }
         assertThat(reauthCalls).isEqualTo(1)
     }
 
@@ -155,6 +165,78 @@ class ScanViewModelTest {
             assertThat(s).isInstanceOf(ScanUiState.Failed::class.java)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    /**
+     * Regression: a slow, superseded scan must never clobber a newer scan's
+     * terminal state. Scan A suspends inside runAffinity; scan B is submitted
+     * and succeeds; then A's affinity fails late. With the generation guard +
+     * CancellationException rethrow, A's stale write is dropped and B's Result
+     * stands. Uses UnconfinedTestDispatcher (set in setUp) so each launch runs
+     * eagerly up to its first real suspension; lookup returns synchronously and
+     * the IO hop completes inline, so A reliably parks on gateA before B runs.
+     */
+    @Test fun `stale scan does not clobber a newer scan's result`() = runTest {
+        val gateA = CompletableDeferred<AffinityResponse>()
+        var call = 0
+        val vm = ScanViewModel(
+            lookup = { bundle },
+            runAffinity = {
+                call++
+                if (call == 1) gateA.await() else affinity
+            },
+            onReauth = { error("onReauth should not be called") },
+        )
+
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+
+            vm.onIsbnSubmitted(isbn13) // scan A — will park awaiting gateA
+            // A's lookup IO hop completes, then A parks in runAffinity; the only
+            // emission is the Working flash.
+            var s = awaitItem()
+            while (s is ScanUiState.Idle) s = awaitItem()
+            assertThat(s).isEqualTo(ScanUiState.Working)
+
+            vm.onIsbnSubmitted(isbn13) // scan B — cancels A, resolves immediately
+            // B re-emits Working (dedup may collapse it) then a Result.
+            var b = awaitItem()
+            while (b is ScanUiState.Working) b = awaitItem()
+            assertThat(b).isInstanceOf(ScanUiState.Result::class.java)
+            assertThat((b as ScanUiState.Result).affinity).isEqualTo(affinity)
+
+            // Release scan A with a late failure. A is superseded: its
+            // CancellationException is rethrown and the generation guard drops
+            // any write, so NO stale Failed must reach the screen.
+            gateA.completeExceptionally(LibraryHttpException(500, "stale A"))
+            expectNoEvents()
+        }
+    }
+
+    /**
+     * Regression: lookup() must run off the main thread. The production
+     * OpenLibrary client does a blocking OkHttp call without hopping dispatchers
+     * itself, so the VM must do the hop. We assert lookup observed a
+     * Dispatchers.IO worker thread, not the test/main dispatcher.
+     */
+    @Test fun `lookup runs off the main thread`() = runTest {
+        var lookupThread: String? = null
+        val vm = ScanViewModel(
+            lookup = { lookupThread = Thread.currentThread().name; bundle },
+            runAffinity = { affinity },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn13)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            assertThat(s).isInstanceOf(ScanUiState.Result::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+        // Dispatchers.IO worker threads are named "DefaultDispatcher-worker-*".
+        assertThat(lookupThread).isNotNull()
+        assertThat(lookupThread).contains("DefaultDispatcher-worker")
     }
 
     @Test fun `isbn-10 input is canonicalized to isbn-13`() = runTest {

--- a/app/src/test/java/io/theficos/ereader/ui/scan/ScanViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/scan/ScanViewModelTest.kt
@@ -115,6 +115,26 @@ class ScanViewModelTest {
         }
     }
 
+    @Test fun `affinity code 0 (server unreachable) yields Result with affinity null and unavailable true`() = runTest {
+        val vm = ScanViewModel(
+            lookup = { bundle },
+            runAffinity = { throw LibraryHttpException(0, "baseUrl not configured") },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn13)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            assertThat(s).isInstanceOf(ScanUiState.Result::class.java)
+            val result = s as ScanUiState.Result
+            assertThat(result.bundle).isEqualTo(bundle)
+            assertThat(result.affinity).isNull()
+            assertThat(result.affinityUnavailable).isTrue()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     @Test fun `affinity 401 invokes onReauth and lands on ReauthRequired not Working`() = runTest {
         var reauthCalls = 0
         val vm = ScanViewModel(

--- a/app/src/test/java/io/theficos/ereader/ui/scan/ScanViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/scan/ScanViewModelTest.kt
@@ -1,0 +1,178 @@
+package io.theficos.ereader.ui.scan
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.core.metadata.MetadataBundle
+import io.theficos.ereader.data.library.AffinityRequestBody
+import io.theficos.ereader.data.library.AffinityResponse
+import io.theficos.ereader.data.library.LibraryHttpException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScanViewModelTest {
+
+    // A valid ISBN-13 (978-0-306-40615-7).
+    private val isbn13 = "9780306406157"
+    // The ISBN-10 form of the same book (0-306-40615-2).
+    private val isbn10 = "0306406152"
+
+    private val bundle = MetadataBundle(title = "Some Book", author = "Some Author")
+
+    private val affinity = AffinityResponse(
+        affinityVersion = 1,
+        owned = null,
+        score = 42,
+        band = "maybe",
+        reasons = emptyList(),
+        generatedAt = "2026-05-29T00:00:00Z",
+    )
+
+    @Before fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test fun `invalid isbn transitions to InvalidIsbn`() = runTest {
+        val vm = ScanViewModel(
+            lookup = { error("lookup should not be called") },
+            runAffinity = { error("affinity should not be called") },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.onIsbnSubmitted("not-an-isbn")
+        assertThat(vm.state.value).isEqualTo(ScanUiState.InvalidIsbn)
+    }
+
+    @Test fun `valid isbn with lookup miss transitions to NotFound`() = runTest {
+        val vm = ScanViewModel(
+            lookup = { null },
+            runAffinity = { error("affinity should not be called") },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn13)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            assertThat(s).isEqualTo(ScanUiState.NotFound)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `valid isbn with lookup hit and affinity ok yields Result with affinity`() = runTest {
+        var sentBody: AffinityRequestBody? = null
+        val vm = ScanViewModel(
+            lookup = { bundle },
+            runAffinity = { body -> sentBody = body; affinity },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn13)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            assertThat(s).isInstanceOf(ScanUiState.Result::class.java)
+            val result = s as ScanUiState.Result
+            assertThat(result.bundle).isEqualTo(bundle)
+            assertThat(result.affinity).isEqualTo(affinity)
+            assertThat(result.affinityUnavailable).isFalse()
+            cancelAndIgnoreRemainingEvents()
+        }
+        // Identity is built from the canonical ISBN-13.
+        assertThat(sentBody!!.identity.isbn).isEqualTo(isbn13)
+        assertThat(sentBody!!.identity.metadataId).isEqualTo("isbn:$isbn13")
+        assertThat(sentBody!!.bundle).isEqualTo(bundle)
+    }
+
+    @Test fun `affinity 404 yields Result with affinity null and unavailable true`() = runTest {
+        val vm = ScanViewModel(
+            lookup = { bundle },
+            runAffinity = { throw LibraryHttpException(404, "not found") },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn13)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            assertThat(s).isInstanceOf(ScanUiState.Result::class.java)
+            val result = s as ScanUiState.Result
+            assertThat(result.bundle).isEqualTo(bundle)
+            assertThat(result.affinity).isNull()
+            assertThat(result.affinityUnavailable).isTrue()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `affinity 401 invokes onReauth`() = runTest {
+        var reauthCalls = 0
+        val vm = ScanViewModel(
+            lookup = { bundle },
+            runAffinity = { throw LibraryHttpException(401, "unauthorized") },
+            onReauth = { reauthCalls++ },
+        )
+        vm.onIsbnSubmitted(isbn13)
+        assertThat(reauthCalls).isEqualTo(1)
+    }
+
+    @Test fun `affinity other error yields Failed`() = runTest {
+        val vm = ScanViewModel(
+            lookup = { bundle },
+            runAffinity = { throw LibraryHttpException(500, "boom") },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn13)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            assertThat(s).isInstanceOf(ScanUiState.Failed::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `non-library throwable yields Failed`() = runTest {
+        val vm = ScanViewModel(
+            lookup = { bundle },
+            runAffinity = { throw RuntimeException("network down") },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn13)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            assertThat(s).isInstanceOf(ScanUiState.Failed::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `isbn-10 input is canonicalized to isbn-13`() = runTest {
+        var sentBody: AffinityRequestBody? = null
+        val vm = ScanViewModel(
+            lookup = { bundle },
+            runAffinity = { body -> sentBody = body; affinity },
+            onReauth = { error("onReauth should not be called") },
+        )
+        vm.state.test {
+            assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
+            vm.onIsbnSubmitted(isbn10)
+            var s = awaitItem()
+            while (s is ScanUiState.Working) s = awaitItem()
+            assertThat(s).isInstanceOf(ScanUiState.Result::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertThat(sentBody!!.identity.isbn).isEqualTo(isbn13)
+        assertThat(sentBody!!.identity.metadataId).isEqualTo("isbn:$isbn13")
+    }
+}

--- a/core/metadata/src/main/java/io/theficos/ereader/core/metadata/Isbn.kt
+++ b/core/metadata/src/main/java/io/theficos/ereader/core/metadata/Isbn.kt
@@ -1,0 +1,38 @@
+package io.theficos.ereader.core.metadata
+
+object Isbn {
+    fun toIsbn13(raw: String?): String? {
+        if (raw.isNullOrBlank()) return null
+        val s = raw.trim().replace("-", "").replace(" ", "").uppercase()
+        if (isIsbn13(s)) return s
+        if (isIsbn10(s)) return isbn10to13(s)
+        return null
+    }
+
+    private fun isIsbn13(s: String): Boolean {
+        if (s.length != 13 || !s.all { it.isDigit() }) return false
+        val sum = s.mapIndexed { i, c -> (if (i % 2 == 0) 1 else 3) * (c - '0') }.sum()
+        return sum % 10 == 0
+    }
+
+    private fun isIsbn10(s: String): Boolean {
+        if (s.length != 10) return false
+        var total = 0
+        for (i in 0 until 10) {
+            val c = s[i]
+            val v = when {
+                c == 'X' && i == 9 -> 10
+                c.isDigit() -> c - '0'
+                else -> return false
+            }
+            total += (10 - i) * v
+        }
+        return total % 11 == 0
+    }
+
+    private fun isbn10to13(s: String): String {
+        val core = "978" + s.substring(0, 9)
+        val check = (10 - core.mapIndexed { i, c -> (if (i % 2 == 0) 1 else 3) * (c - '0') }.sum() % 10) % 10
+        return core + check
+    }
+}

--- a/core/metadata/src/test/java/io/theficos/ereader/core/metadata/IsbnTest.kt
+++ b/core/metadata/src/test/java/io/theficos/ereader/core/metadata/IsbnTest.kt
@@ -1,0 +1,21 @@
+package io.theficos.ereader.core.metadata
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class IsbnTest {
+    @Test fun `isbn13 passthrough and cleaning`() {
+        assertThat(Isbn.toIsbn13("978-0-261-10357-3")).isEqualTo("9780261103573")
+    }
+
+    @Test fun `isbn10 converts`() {
+        assertThat(Isbn.toIsbn13("0261103571")).isEqualTo("9780261103573")
+        assertThat(Isbn.toIsbn13("080442957X")).isEqualTo("9780804429573")
+    }
+
+    @Test fun `invalid returns null`() {
+        assertThat(Isbn.toIsbn13("9780261103574")).isNull()
+        assertThat(Isbn.toIsbn13("hello")).isNull()
+        assertThat(Isbn.toIsbn13("")).isNull()
+    }
+}

--- a/data/library/build.gradle.kts
+++ b/data/library/build.gradle.kts
@@ -21,6 +21,7 @@ android {
 
 dependencies {
     api(project(":core:model"))
+    implementation(project(":core:metadata"))
     implementation(project(":data:local"))
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.coroutines.android)

--- a/data/library/src/main/java/io/theficos/ereader/data/library/AffinityDtos.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/AffinityDtos.kt
@@ -1,0 +1,40 @@
+package io.theficos.ereader.data.library
+
+import io.theficos.ereader.core.metadata.MetadataBundle
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AffinityIdentity(
+    val isbn: String,
+    @SerialName("metadata_id") val metadataId: String,
+)
+
+@Serializable
+data class AffinityRequestBody(
+    val identity: AffinityIdentity,
+    val bundle: MetadataBundle,
+)
+
+@Serializable
+data class AffinityOwned(
+    @SerialName("in_library") val inLibrary: Boolean,
+    @SerialName("reading_status") val readingStatus: String,
+)
+
+@Serializable
+data class AffinityReasonDto(
+    val kind: String,
+    val polarity: String,
+    val message: String,
+)
+
+@Serializable
+data class AffinityResponse(
+    @SerialName("affinity_version") val affinityVersion: Int,
+    val owned: AffinityOwned? = null,
+    val score: Int? = null,
+    val band: String,
+    val reasons: List<AffinityReasonDto> = emptyList(),
+    @SerialName("generated_at") val generatedAt: String,
+)

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryApi.kt
@@ -5,4 +5,6 @@ object LibraryApi {
     const val PATH_ITEMS = "/library/v1/items"
     // Phase 0 / S-2 (server) + A-4 (Android): bulk library-mirror push.
     const val PATH_SYNC = "/library/v1/sync"
+    // Book Scan: per-title affinity scoring against the user's library.
+    const val PATH_AFFINITY = "/library/v1/affinity"
 }

--- a/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/LibraryClient.kt
@@ -172,6 +172,31 @@ class LibraryClient(
         all
     }
 
+    /**
+     * Request a per-title affinity score against the user's library.
+     *
+     * Drives the Book Scan flow: given a scanned book's identity + metadata
+     * bundle, the server returns a score/band, ownership state, and the
+     * human-readable reasons behind the verdict.
+     *
+     * Failure modes (caller/ViewModel maps codes):
+     * - 401 → `LibraryHttpException(401)` — credentials need attention.
+     * - 404 → `LibraryHttpException(404)` — feature mode-gated off.
+     * - other 4xx/5xx → `LibraryHttpException(code)`.
+     */
+    suspend fun affinity(body: AffinityRequestBody): AffinityResponse = withContext(Dispatchers.IO) {
+        val bodyJson = json.encodeToString(AffinityRequestBody.serializer(), body)
+        val req = Request.Builder()
+            .url(resolveBaseUrl() + LibraryApi.PATH_AFFINITY)
+            .post(bodyJson.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        http.newCall(req).execute().use { resp ->
+            val respBody = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) throw LibraryHttpException(resp.code, respBody)
+            json.decodeFromString(AffinityResponse.serializer(), respBody)
+        }
+    }
+
     private companion object {
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
     }

--- a/data/library/src/test/java/io/theficos/ereader/data/library/AffinityClientTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/AffinityClientTest.kt
@@ -1,0 +1,96 @@
+package io.theficos.ereader.data.library
+
+import com.google.common.truth.Truth.assertThat
+import io.theficos.ereader.core.metadata.MetadataBundle
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class AffinityClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: LibraryClient
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = LibraryClient(
+            baseUrlProvider = { server.url("").toString().trimEnd('/') },
+            http = OkHttpClient.Builder().callTimeout(5, TimeUnit.SECONDS).build(),
+        )
+    }
+
+    @After fun tearDown() = server.shutdown()
+
+    private fun sampleBody() = AffinityRequestBody(
+        identity = AffinityIdentity(isbn = "9780441013593", metadataId = "m1"),
+        bundle = MetadataBundle(title = "Dune", author = "Frank Herbert", isbn = "9780441013593"),
+    )
+
+    @Test
+    fun `affinity parses full response and hits correct path`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "affinity_version": 3,
+                  "owned": {"in_library": true, "reading_status": "finished"},
+                  "score": 82,
+                  "band": "high",
+                  "reasons": [
+                    {"kind": "author", "polarity": "positive", "message": "You like Frank Herbert"},
+                    {"kind": "theme", "polarity": "negative", "message": "Not your usual genre"}
+                  ],
+                  "generated_at": "2026-05-29T00:00:00+00:00"
+                }
+                """.trimIndent()
+            )
+        )
+
+        val out = client.affinity(sampleBody())
+
+        assertThat(out.affinityVersion).isEqualTo(3)
+        assertThat(out.score).isEqualTo(82)
+        assertThat(out.band).isEqualTo("high")
+        assertThat(out.owned).isNotNull()
+        assertThat(out.owned!!.inLibrary).isTrue()
+        assertThat(out.owned!!.readingStatus).isEqualTo("finished")
+        assertThat(out.reasons).hasSize(2)
+        assertThat(out.reasons[0].kind).isEqualTo("author")
+        assertThat(out.reasons[0].polarity).isEqualTo("positive")
+        assertThat(out.generatedAt).isEqualTo("2026-05-29T00:00:00+00:00")
+
+        val req = server.takeRequest()
+        assertThat(req.method).isEqualTo("POST")
+        assertThat(req.path).isEqualTo("/library/v1/affinity")
+        val body = req.body.readUtf8()
+        assertThat(body).contains("\"metadata_id\":\"m1\"")
+        assertThat(body).contains("\"title\":\"Dune\"")
+    }
+
+    @Test
+    fun `affinity 404 raises LibraryHttpException with code 404`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404).setBody("not_found"))
+        try {
+            client.affinity(sampleBody())
+            error("expected throw")
+        } catch (e: LibraryHttpException) {
+            assertThat(e.code).isEqualTo(404)
+        }
+    }
+
+    @Test
+    fun `affinity 401 raises LibraryHttpException with code 401`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("unauthorized"))
+        try {
+            client.affinity(sampleBody())
+            error("expected throw")
+        } catch (e: LibraryHttpException) {
+            assertThat(e.code).isEqualTo(401)
+        }
+    }
+}

--- a/data/opds/build.gradle.kts
+++ b/data/opds/build.gradle.kts
@@ -22,6 +22,7 @@ android {
 
 dependencies {
     api(project(":core:model"))
+    implementation(project(":core:metadata"))
     implementation(project(":auth"))
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.coroutines.android)

--- a/data/opds/src/main/java/io/theficos/ereader/data/opds/OpenLibraryClient.kt
+++ b/data/opds/src/main/java/io/theficos/ereader/data/opds/OpenLibraryClient.kt
@@ -1,0 +1,54 @@
+package io.theficos.ereader.data.opds
+
+import io.theficos.ereader.core.metadata.MetadataBundle
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+/**
+ * On-device ISBN -> MetadataBundle lookup via the OpenLibrary Books API.
+ * Plain OkHttp with NO account auth (talks to a third-party host). Returns
+ * null on not-found / network / parse failure.
+ */
+class OpenLibraryClient(
+    private val http: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .build(),
+    private val baseUrl: String = "https://openlibrary.org",
+) {
+    fun lookupByIsbn(isbn13: String): MetadataBundle? {
+        val url = "$baseUrl/api/books?bibkeys=ISBN:$isbn13&format=json&jscmd=data"
+        val req = Request.Builder().url(url)
+            .header("User-Agent", "QuireAndroid (book-scan)")
+            .header("Accept", "application/json")
+            .get().build()
+        return runCatching {
+            http.newCall(req).execute().use { resp ->
+                if (!resp.isSuccessful) return null
+                val root = Json.parseToJsonElement(resp.body?.string().orEmpty()) as? JsonObject
+                    ?: return null
+                val rec = root["ISBN:$isbn13"] as? JsonObject ?: return null
+                val title = (rec["title"] as? JsonPrimitive)?.content
+                    ?: return null
+                val author = (rec["authors"] as? JsonArray)?.firstOrNull()
+                    ?.jsonObject?.get("name")?.jsonPrimitive?.content
+                val subjects = (rec["subjects"] as? JsonArray)
+                    ?.mapNotNull { (it as? JsonObject)?.get("name")?.jsonPrimitive?.content }
+                    ?: emptyList()
+                MetadataBundle(
+                    title = title,
+                    author = author,
+                    isbn = isbn13,
+                    subjects = subjects,
+                )
+            }
+        }.getOrNull()
+    }
+}

--- a/data/opds/src/test/java/io/theficos/ereader/data/opds/OpenLibraryClientTest.kt
+++ b/data/opds/src/test/java/io/theficos/ereader/data/opds/OpenLibraryClientTest.kt
@@ -1,0 +1,51 @@
+package io.theficos.ereader.data.opds
+
+import com.google.common.truth.Truth.assertThat
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class OpenLibraryClientTest {
+    private lateinit var server: MockWebServer
+
+    @Before fun setUp() { server = MockWebServer().apply { start() } }
+    @After fun tearDown() { server.shutdown() }
+
+    private fun client() = OpenLibraryClient(
+        http = OkHttpClient.Builder().build(),
+        baseUrl = server.url("/").toString().trimEnd('/'),
+    )
+
+    @Test fun `parses title author and subjects for a found isbn`() {
+        server.enqueue(
+            MockResponse().setBody(
+                """{"ISBN:9780261103573":{"title":"The Hobbit",""" +
+                    """"authors":[{"name":"J.R.R. Tolkien"}],""" +
+                    """"subjects":[{"name":"Fantasy"},{"name":"Fiction"}]}}""",
+            ),
+        )
+
+        val result = client().lookupByIsbn("9780261103573")
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.title).isEqualTo("The Hobbit")
+        assertThat(result.author).isEqualTo("J.R.R. Tolkien")
+        assertThat(result.isbn).isEqualTo("9780261103573")
+        assertThat(result.subjects).contains("Fantasy")
+    }
+
+    @Test fun `returns null when record is absent`() {
+        server.enqueue(MockResponse().setBody("{}"))
+
+        assertThat(client().lookupByIsbn("9780261103573")).isNull()
+    }
+
+    @Test fun `returns null when record present but has no title`() {
+        server.enqueue(MockResponse().setBody("""{"ISBN:9780261103573":{}}"""))
+
+        assertThat(client().lookupByIsbn("9780261103573")).isNull()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ truth = "1.4.4"
 espresso = "3.6.1"
 coil = "2.7.0"
 aboutlibraries = "11.2.3"
+zxing-core = "3.5.3"
+camerax = "1.3.4"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.13.1" }
@@ -68,6 +70,11 @@ androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "andro
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 aboutlibraries-compose = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutlibraries" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
+androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "camerax" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
+androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "camerax" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Track B of the **book-scan** feature — the Android client for the deterministic affinity endpoint shipped in #68. **Device-validated on a real phone** (camera decode confirmed working).

## What it does
Catalog tab → **scan FAB** → `ScanScreen`: live **CameraX preview + ZXing EAN-13** decode, with an always-available **manual ISBN** field + permission flow. On an ISBN → on-device **OpenLibrary** metadata lookup → `POST /library/v1/affinity` → result screen showing **score + band + reasons** (or "already in your library" / "not enough history" / "affinity unavailable"), plus a **"Get full insight"** button that reuses the existing `InsightSection`.

## Layers
- `:core:metadata` `Isbn` (ISBN-10/13 canonicalization, mirrors the server) · `:data:opds` `OpenLibraryClient` (plain OkHttp, no account auth) · `:data:library` `LibraryClient.affinity()` + DTOs (account-authed) · `:app` `ScanViewModel` (state machine) + `ScanScreen`/`ScanResultScreen` + nav/Catalog FAB/DI.
- Push-model preserved: ISBN→metadata resolves on-device; `quire_server` stays metadata-only.

## Correctness
Built and hardened with multi-agent **adversarial** passes (implement → independent reviewers told to refute → fix). Real bugs caught + fixed before they ever shipped: camera **rotation** (portrait-held horizontal barcode) + YUV **row-stride**, a `rotateCounterClockwise()` call that **throws** in ZXing 3.5.3, single-arg `decode()` **wiping hints**, a `401` **dead-spinner**, a **cancellation/stale-result race**, and the no-server case now **degrades to metadata-only** instead of a red error.

## Testing
Unit tests for ISBN, OpenLibrary parsing (MockWebServer), affinity client, and the `ScanViewModel` state machine. Full `:app` **test + lint + assembleDebug** green. The camera analyzer itself isn't unit-tested (verified on-device); a Compose UI test could be added now that `main` ships a Compose test harness.

## Known follow-ups (non-blocking)
- Camera decode is full-frame (no ROI crop / 180° variant) — works in practice; tune if field misses appear.
- Debug/release side-by-side install config lands in a separate small PR.

Requires the affinity endpoint (#68, merged) deployed to the server the client targets.