### PR TITLE
Debug builds install side-by-side as 'Quire Debug'

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,7 +56,14 @@ android {
         }
     }
     buildTypes {
-        debug { isMinifyEnabled = false }
+        debug {
+            isMinifyEnabled = false
+            // Distinct package + label so a debug build installs side-by-side
+            // with a signed release "Quire" instead of failing on signature
+            // mismatch. Debug-only; release is unaffected.
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
         release {
             isMinifyEnabled = false   // Phase 1 only; revisit before publishing
             // AGP 8.3+ embeds git origin/branch/SHA into the APK by default,

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Debug-only override so a debug build installs/reads as "Quire Debug". -->
+    <string name="app_name">Quire Debug</string>
+</resources>


### PR DESCRIPTION
Tiny dev-ergonomics change, debug-only — **release is unaffected**.

Gives the `debug` build type `applicationIdSuffix = ".debug"` (+ `versionNameSuffix`) and a `Quire Debug` app label, so a debug APK installs **alongside** a signed release "Quire" on a dev device instead of failing with a signature-mismatch (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`).

- `applicationId` becomes `io.theficos.quire.debug` for debug builds only.
- Release `applicationId`/label/signing are untouched.

Split out of the book-scan feature branch (#71) to keep that PR focused.