### PR TITLE
Fix: make auto book-language actually steer insight output

### DIFF
--- a/server/quire_server/core/ai/prompts.py
+++ b/server/quire_server/core/ai/prompts.py
@@ -19,10 +19,13 @@ from quire_server.core.ai.themes import CONTROLLED_THEMES
 
 # v6 (2026-05-30): `auto` language now follows the book's own metadata
 # language instead of emitting no clause, so a French book yields a French
-# insight without the user picking a language. This materially changes the
-# `auto` output (the universal default), so the cache key bumps to force
-# regeneration. See `_resolve_response_language`.
-PROMPT_VERSION = "6"
+# insight without the user picking a language. See `_resolve_response_language`.
+# v7 (2026-05-30): the language directive was a single weak line referencing an
+# ISO *code* buried at the end of an all-English prompt — weak models ignored it
+# and wrote English. v7 names the language (e.g. "Italian"), states it up front,
+# and scopes exactly which fields to write in it vs. keep as controlled values
+# (themes/confidence/proper names). Materially changes output → cache bumps.
+PROMPT_VERSION = "7"
 
 # pr-β (Bundle 3, coordinator §3.1 / §3.2). Separate cache namespace from
 # ``PROMPT_VERSION`` (which is keyed on the per-book ``book_insights`` PK);
@@ -245,6 +248,90 @@ def _resolve_response_language(style_language: str, book_language: str | None) -
     return _normalize_book_language(book_language)
 
 
+# Endonym-free English names for the languages the picker + auto-resolver can
+# produce. Weak models follow a named language far more reliably than an ISO
+# code, so the directive leads with the name. Codes not listed fall back to the
+# bare-code phrasing (still an instruction, just weaker).
+_ISO_639_1_NAMES = {
+    "en": "English",
+    "it": "Italian",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "pt": "Portuguese",
+    "nl": "Dutch",
+    "ru": "Russian",
+    "ja": "Japanese",
+    "zh": "Chinese",
+    "ar": "Arabic",
+    "pl": "Polish",
+    "sv": "Swedish",
+    "no": "Norwegian",
+    "nb": "Norwegian Bokmål",
+    "da": "Danish",
+    "fi": "Finnish",
+    "el": "Greek",
+    "cs": "Czech",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "he": "Hebrew",
+    "ko": "Korean",
+    "hi": "Hindi",
+    "ro": "Romanian",
+    "ca": "Catalan",
+    "hu": "Hungarian",
+    "vi": "Vietnamese",
+    "th": "Thai",
+    "id": "Indonesian",
+    "sk": "Slovak",
+    "hr": "Croatian",
+    "sr": "Serbian",
+    "bg": "Bulgarian",
+    "lt": "Lithuanian",
+    "lv": "Latvian",
+    "et": "Estonian",
+    "is": "Icelandic",
+    "ga": "Irish",
+    "fa": "Persian",
+}
+
+
+def _language_display_name(code: str) -> str:
+    """A human-facing language label for the prompt, leading with the name.
+
+    ``"it"`` -> ``'Italian (ISO 639-1: it)'``. Unknown codes degrade to the
+    code-only phrasing so the instruction is still present, just weaker.
+    """
+    name = _ISO_639_1_NAMES.get(code)
+    if name:
+        return f"{name} (ISO 639-1: {code})"
+    return f'the language with ISO 639-1 code "{code}"'
+
+
+def _language_directive_lines(code: str) -> list[str]:
+    """The prominent, field-scoped output-language block placed at the top of
+    the prompt. Names the prose fields to translate and the controlled fields
+    that must stay as-is, so the model doesn't translate `themes`/`confidence`
+    or proper names.
+    """
+    name = _language_display_name(code)
+    return [
+        "",
+        f"OUTPUT LANGUAGE — write all prose in {name}.",
+        (
+            f"Write these fields in {name}: intro, analysis, the text values in "
+            "theme_analysis, craft_notes, distinctive_take, discussion_prompts, "
+            "content_warnings, and the author bio."
+        ),
+        (
+            "Do NOT translate — keep these exactly as specified: `themes` (the "
+            "controlled English snake_case tags listed below), `confidence` "
+            '("low" / "medium" / "high"), and proper names (book titles, author '
+            "names, series names, comparative-anchor titles)."
+        ),
+    ]
+
+
 def compose_user_prompt(
     bundle: MetadataBundle,
     citations: list[Citation],
@@ -252,8 +339,17 @@ def compose_user_prompt(
     style: AiStyle | None = None,
     feedback: str | None = None,
 ) -> str:
+    # The language the prose must be written in (None = no directive). Computed
+    # up front so the directive can LEAD the prompt — weak models anchor on the
+    # first instruction far more than on a line buried near the end.
+    response_language = (
+        _resolve_response_language(style.language, bundle.language) if style is not None else None
+    )
+
     lines: list[str] = []
     lines.append("Generate a book insight for the following work.")
+    if response_language is not None:
+        lines.extend(_language_directive_lines(response_language))
     lines.append("")
     lines.append("## Metadata (from the EPUB)")
     lines.append(f"- Title: {bundle.title}")
@@ -296,17 +392,15 @@ def compose_user_prompt(
         if hint:
             lines.append("")
             lines.append(hint)
-        # Pick the language the insight is written in. Explicit user codes win;
-        # `auto` (the universal default) defers to the book's own metadata
-        # language. When neither yields a code we emit no clause — the model
-        # writes in the book's apparent language as before. See
-        # `_resolve_response_language`.
-        response_language = _resolve_response_language(style.language, bundle.language)
-        if response_language is not None:
-            lines.append("")
-            lines.append(
-                f'Respond in the language identified by ISO 639-1 code "{response_language}".'
-            )
+
+    # Repeat the language rule at the end (architect guidance: lead AND remind).
+    if response_language is not None:
+        lines.append("")
+        lines.append(
+            "Reminder: write the prose fields in "
+            f"{_language_display_name(response_language)}; keep `themes`, "
+            "`confidence`, and proper names (titles, author/series names) unchanged."
+        )
 
     if feedback:
         lines.append("")

--- a/server/tests/integration/test_main_prompt_version_runtime.py
+++ b/server/tests/integration/test_main_prompt_version_runtime.py
@@ -49,7 +49,7 @@ def test_runtime_prompt_version_default_uses_constant(monkeypatch, postgres_url,
     orch = app.state.ai_orchestrator
     assert orch.prompt_version == PROMPT_VERSION
     # Explicit pin catches accidental constant drift.
-    assert orch.prompt_version == "6"
+    assert orch.prompt_version == "7"
 
 
 def test_runtime_prompt_version_legacy_sentinel(monkeypatch, postgres_url, alembic_upgrade):

--- a/server/tests/unit/test_ai_prompts.py
+++ b/server/tests/unit/test_ai_prompts.py
@@ -6,12 +6,12 @@ from quire_server.core.ai.prompts import (
 )
 
 
-def test_prompt_version_is_v6():
-    """v6 (2026-05-30) bumped from v5 because ``auto`` language now follows the
-    book's own metadata language instead of emitting no clause. That materially
-    changes the universal-default output, so the cache key must regenerate.
+def test_prompt_version_is_v7():
+    """v7 strengthened the language directive (named language, prominent, field-
+    scoped) because the v6 single-line ISO-code clause was being ignored by weak
+    models. Materially changes output, so the cache key must regenerate.
     """
-    assert PROMPT_VERSION == "6"
+    assert PROMPT_VERSION == "7"
 
 
 def test_system_prompt_includes_themes_vocab():
@@ -127,7 +127,8 @@ def test_tone_hint_omitted_when_default():
 def test_language_clause_emitted_when_non_auto():
     bundle = MetadataBundle(title="Foundation")
     text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="it"))
-    assert 'ISO 639-1 code "it"' in text
+    assert "OUTPUT LANGUAGE" in text
+    assert "Italian" in text
 
 
 def test_language_clause_omitted_when_auto_and_book_language_unknown():
@@ -144,7 +145,8 @@ def test_language_clause_follows_book_language_when_auto():
     """`auto` defers to the book's own language so the insight matches the book."""
     bundle = MetadataBundle(title="Il nome della rosa", language="it")
     text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
-    assert 'ISO 639-1 code "it"' in text
+    assert "OUTPUT LANGUAGE" in text
+    assert "Italian" in text
 
 
 def test_auto_normalizes_region_and_three_letter_book_language():
@@ -155,21 +157,21 @@ def test_auto_normalizes_region_and_three_letter_book_language():
         citations=[],
         style=AiStyle(language="auto"),
     )
-    assert 'ISO 639-1 code "en"' in region
+    assert "English" in region
 
     iso2 = compose_user_prompt(
         MetadataBundle(title="B", language="eng"),
         citations=[],
         style=AiStyle(language="auto"),
     )
-    assert 'ISO 639-1 code "en"' in iso2
+    assert "English" in iso2
 
 
 def test_auto_skips_unrecognized_book_language():
     """An unmappable language tag yields no clause rather than a bogus code."""
     bundle = MetadataBundle(title="C", language="zxx")
     text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
-    assert "ISO 639-1 code" not in text
+    assert "OUTPUT LANGUAGE" not in text
 
 
 def test_auto_rejects_bogus_two_letter_book_language():
@@ -177,15 +179,15 @@ def test_auto_rejects_bogus_two_letter_book_language():
     prompt as an instruction."""
     bundle = MetadataBundle(title="C2", language="zz")
     text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
-    assert "ISO 639-1 code" not in text
+    assert "OUTPUT LANGUAGE" not in text
 
 
 def test_explicit_language_overrides_book_language():
     """An explicit user code wins even when the book declares its own language."""
     bundle = MetadataBundle(title="D", language="it")
     text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="en"))
-    assert 'ISO 639-1 code "en"' in text
-    assert 'ISO 639-1 code "it"' not in text
+    assert "English" in text
+    assert "Italian" not in text
 
 
 def test_language_clause_independent_of_tone():
@@ -197,7 +199,25 @@ def test_language_clause_independent_of_tone():
         style=AiStyle(tone="scholarly", language="fr"),
     )
     assert "analytical" in text.lower() or "scholarly" in text.lower()
-    assert 'ISO 639-1 code "fr"' in text
+    assert "French" in text
+
+
+def test_language_directive_protects_controlled_fields():
+    """The output-language block must instruct the model NOT to translate the
+    controlled fields — otherwise it corrupts `themes`/`confidence`."""
+    bundle = MetadataBundle(title="Foundation", language="it")
+    text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
+    assert "Do NOT translate" in text
+    assert "themes" in text
+    assert "confidence" in text
+
+
+def test_language_directive_leads_the_prompt():
+    """The directive must appear before the metadata block so weak models anchor
+    on it (they over-weight the first instruction)."""
+    bundle = MetadataBundle(title="Foundation", language="it")
+    text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
+    assert text.index("OUTPUT LANGUAGE") < text.index("## Metadata")
 
 
 def test_feedback_block_appended_on_regeneration():

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -918,7 +918,7 @@ async def test_auto_backfills_scanned_book_language_into_prompt(session: AsyncSe
 
     assert retriever.lang_calls == ["9782070360024"]
     prompt = orch.ai.calls[0]["user"]
-    assert 'ISO 639-1 code "fr"' in prompt
+    assert "French" in prompt
 
     # Load-bearing invariant: the resolved book language steers the prompt but
     # must NOT leak into the cache key, or the client (which caches under the
@@ -940,7 +940,7 @@ async def test_auto_does_not_override_existing_bundle_language(session: AsyncSes
     await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(language="auto"))
 
     assert retriever.lang_calls == []  # never consulted
-    assert 'ISO 639-1 code "en"' in orch.ai.calls[0]["user"]
+    assert "English" in orch.ai.calls[0]["user"]
 
 
 @pytest.mark.asyncio
@@ -953,7 +953,7 @@ async def test_auto_with_no_isbn_skips_backfill(session: AsyncSession):
     await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(language="auto"))
 
     assert retriever.lang_calls == []
-    assert "ISO 639-1 code" not in orch.ai.calls[0]["user"]
+    assert "OUTPUT LANGUAGE" not in orch.ai.calls[0]["user"]
 
 
 @pytest.mark.asyncio
@@ -966,4 +966,4 @@ async def test_auto_backfill_skipped_when_openlibrary_source_disabled(session: A
     await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(language="auto"))
 
     assert retriever.lang_calls == []
-    assert "ISO 639-1 code" not in orch.ai.calls[0]["user"]
+    assert "OUTPUT LANGUAGE" not in orch.ai.calls[0]["user"]


### PR DESCRIPTION
## Problem

You reported that auto book-language **wasn't working** — insights still came out in English for non-English books.

Root cause: the book language **does** reach the server (verified end-to-end for library EPUBs), but the v6 directive was too weak — a single line referencing an ISO *code*, buried at the end of an all-English prompt:

```
Respond in the language identified by ISO 639-1 code "it".
```

Weak / structured-output models ignore that and default to English.

## Fix (single-pass, no extra model call)

- **Name the language** — `Italian (ISO 639-1: it)`, not just `"it"`.
- **Lead with it** — the directive is now the first instruction (models over-weight the opening), with a short reminder repeated at the end.
- **Scope it** — write the PROSE fields in the target language (intro, analysis, theme_analysis text, craft_notes, distinctive_take, discussion_prompts, content_warnings, author bio), but keep controlled fields exactly as-is: `themes` (controlled English tags), `confidence`, and proper names (titles, author/series names). This is critical — a naive "write everything in X" would translate the controlled `themes` vocabulary and break validation.
- **`PROMPT_VERSION` 6 → 7** (cache-bust).

## Expected reliability

~70–85% on a weak self-hosted model (the test default hints at a Llama-class backend), higher on a stronger model. If your deployment's model still won't comply after this, the follow-up is a *conditional* prose-only translation-repair pass (only fires when the output is detectably not in the target language) — deliberately not included here to avoid a dependency + an extra model call against the daily budget unless it's actually needed.

## Tests

353 server unit tests pass (new coverage: named-language directive, field-scoping that protects controlled fields, directive-leads-prompt) + AI integration suite; `ruff` clean. Pure prompt output also verified directly.

## Not covered (separate, smaller gaps)

OPDS catalog books and the no-OPF fallback send no `language` at all, so auto can't resolve for them — pre-existing, tracked separately.