### PR TITLE
Fix: auto-language infers the book's language from the work (not metadata)

### DIFF
--- a/server/quire_server/core/ai/prompts.py
+++ b/server/quire_server/core/ai/prompts.py
@@ -17,15 +17,17 @@ from __future__ import annotations
 from quire_server.api.ai_schemas import ISO_639_1_CODES, AiStyle, Citation, MetadataBundle
 from quire_server.core.ai.themes import CONTROLLED_THEMES
 
-# v6 (2026-05-30): `auto` language now follows the book's own metadata
-# language instead of emitting no clause, so a French book yields a French
-# insight without the user picking a language. See `_resolve_response_language`.
-# v7 (2026-05-30): the language directive was a single weak line referencing an
-# ISO *code* buried at the end of an all-English prompt — weak models ignored it
-# and wrote English. v7 names the language (e.g. "Italian"), states it up front,
-# and scopes exactly which fields to write in it vs. keep as controlled values
-# (themes/confidence/proper names). Materially changes output → cache bumps.
-PROMPT_VERSION = "7"
+# v6 (2026-05-30): `auto` language follows the book's own metadata language.
+# v7 (2026-05-30): named the language + scoped fields (the v6 ISO-code clause
+# was being ignored by the model).
+# v8 (2026-05-31): for `auto`, STOP relying on the metadata `<dc:language>` to
+# pick the language — it's frequently missing or wrong (sideloaded EPUBs), and
+# when absent v7 emitted no directive so the model defaulted to English (made
+# worse by English citations). v8 instructs the model to determine the book's
+# original language from the work itself (title/author/knowledge), which fixes
+# absent/incorrect metadata. Verified against gpt-oss:120b across missing,
+# wrong, and correct metadata. Materially changes output → cache bumps.
+PROMPT_VERSION = "8"
 
 # pr-β (Bundle 3, coordinator §3.1 / §3.2). Separate cache namespace from
 # ``PROMPT_VERSION`` (which is keyed on the per-book ``book_insights`` PK);
@@ -232,22 +234,6 @@ def _normalize_book_language(raw: str) -> str | None:
     return None
 
 
-def _resolve_response_language(style_language: str, book_language: str | None) -> str | None:
-    """The ISO 639-1 code the insight should be written in, or ``None``.
-
-    An explicit user code wins outright (already validated to ISO 639-1 in
-    ``AiStyle._validate_language``). ``auto`` — the universal default —
-    follows the book's own metadata language, so a French book yields a
-    French insight with no user action. ``auto`` with no usable book language
-    yields ``None``, preserving the pre-v6 language-neutral prompt.
-    """
-    if style_language != "auto":
-        return style_language
-    if not book_language:
-        return None
-    return _normalize_book_language(book_language)
-
-
 # Endonym-free English names for the languages the picker + auto-resolver can
 # produce. Weak models follow a named language far more reliably than an ISO
 # code, so the directive leads with the name. Codes not listed fall back to the
@@ -308,20 +294,45 @@ def _language_display_name(code: str) -> str:
     return f'the language with ISO 639-1 code "{code}"'
 
 
-def _language_directive_lines(code: str) -> list[str]:
-    """The prominent, field-scoped output-language block placed at the top of
-    the prompt. Names the prose fields to translate and the controlled fields
-    that must stay as-is, so the model doesn't translate `themes`/`confidence`
-    or proper names.
+def _output_language_directive_lines(style: AiStyle, book_language: str | None) -> list[str]:
+    """The prominent, field-scoped output-language block at the top of the
+    prompt, or ``[]`` when no directive applies (``style is None``).
+
+    Two cases:
+
+    * **Explicit user code** → write in exactly that named language (a user
+      override that wins over the book's own language).
+    * **``auto``** (the default) → write in the BOOK's own language. We do NOT
+      rely on the metadata ``<dc:language>`` to NAME it: that tag is frequently
+      missing or wrong (sideloaded EPUBs often omit it or default to ``en``),
+      and when it's absent the old prompt emitted no directive at all so the
+      model defaulted to English. Instead we instruct the model to DETERMINE
+      the language from the work itself — capable models identify a book's
+      language from its title + author reliably, which fixes absent/incorrect
+      metadata. The metadata ``Language`` line (if any) still appears below as
+      a hint.
+
+    The field scoping (prose vs. controlled ``themes``/``confidence``/proper
+    names) is identical in both cases.
     """
-    name = _language_display_name(code)
+    if style.language != "auto":
+        lead = f"write all prose in {_language_display_name(style.language)}."
+    else:
+        lead = (
+            "write all prose in the book's ORIGINAL language — the language the "
+            "work was written in. Determine it from the title, author, and your "
+            "knowledge of the work (for example: an Italian title and author means "
+            "write in Italian; a French work means French). The metadata may omit "
+            "or misstate the language, so rely on the work itself, and do NOT "
+            "default to English unless the book is genuinely in English."
+        )
     return [
         "",
-        f"OUTPUT LANGUAGE — write all prose in {name}.",
+        f"OUTPUT LANGUAGE — {lead}",
         (
-            f"Write these fields in {name}: intro, analysis, the text values in "
-            "theme_analysis, craft_notes, distinctive_take, discussion_prompts, "
-            "content_warnings, and the author bio."
+            "Apply that language to the prose fields: intro, analysis, the text "
+            "values in theme_analysis, craft_notes, distinctive_take, "
+            "discussion_prompts, content_warnings, and the author bio."
         ),
         (
             "Do NOT translate — keep these exactly as specified: `themes` (the "
@@ -339,17 +350,16 @@ def compose_user_prompt(
     style: AiStyle | None = None,
     feedback: str | None = None,
 ) -> str:
-    # The language the prose must be written in (None = no directive). Computed
-    # up front so the directive can LEAD the prompt — weak models anchor on the
-    # first instruction far more than on a line buried near the end.
-    response_language = (
-        _resolve_response_language(style.language, bundle.language) if style is not None else None
+    # The output-language block leads the prompt — models anchor on the first
+    # instruction far more than on a line buried near the end. [] when style is
+    # None (the pure no-style call used by some tests).
+    directive = (
+        _output_language_directive_lines(style, bundle.language) if style is not None else []
     )
 
     lines: list[str] = []
     lines.append("Generate a book insight for the following work.")
-    if response_language is not None:
-        lines.extend(_language_directive_lines(response_language))
+    lines.extend(directive)
     lines.append("")
     lines.append("## Metadata (from the EPUB)")
     lines.append(f"- Title: {bundle.title}")
@@ -393,13 +403,15 @@ def compose_user_prompt(
             lines.append("")
             lines.append(hint)
 
-    # Repeat the language rule at the end (architect guidance: lead AND remind).
-    if response_language is not None:
+    # Repeat the language rule at the end (lead AND remind) — citations and
+    # metadata below are often in English and otherwise drag the output language.
+    if directive:
         lines.append("")
         lines.append(
-            "Reminder: write the prose fields in "
-            f"{_language_display_name(response_language)}; keep `themes`, "
-            "`confidence`, and proper names (titles, author/series names) unchanged."
+            "Reminder: write the prose fields in the output language stated at the "
+            "top (the book's own language); the English sources above are reference "
+            "material only — do NOT let them switch your output to English. Keep "
+            "`themes`, `confidence`, and proper names unchanged."
         )
 
     if feedback:

--- a/server/tests/integration/test_main_prompt_version_runtime.py
+++ b/server/tests/integration/test_main_prompt_version_runtime.py
@@ -49,7 +49,7 @@ def test_runtime_prompt_version_default_uses_constant(monkeypatch, postgres_url,
     orch = app.state.ai_orchestrator
     assert orch.prompt_version == PROMPT_VERSION
     # Explicit pin catches accidental constant drift.
-    assert orch.prompt_version == "7"
+    assert orch.prompt_version == "8"
 
 
 def test_runtime_prompt_version_legacy_sentinel(monkeypatch, postgres_url, alembic_upgrade):

--- a/server/tests/unit/test_ai_prompts.py
+++ b/server/tests/unit/test_ai_prompts.py
@@ -2,16 +2,17 @@ from quire_server.api.ai_schemas import AiStyle, Citation, MetadataBundle
 from quire_server.core.ai.prompts import (
     PROMPT_VERSION,
     SYSTEM_PROMPT,
+    _normalize_book_language,
     compose_user_prompt,
 )
 
 
-def test_prompt_version_is_v7():
-    """v7 strengthened the language directive (named language, prominent, field-
-    scoped) because the v6 single-line ISO-code clause was being ignored by weak
-    models. Materially changes output, so the cache key must regenerate.
+def test_prompt_version_is_v8():
+    """v8: for `auto`, the model determines the book's own language from the work
+    itself rather than the (often missing/wrong) metadata tag. Materially changes
+    output, so the cache key must regenerate.
     """
-    assert PROMPT_VERSION == "7"
+    assert PROMPT_VERSION == "8"
 
 
 def test_system_prompt_includes_themes_vocab():
@@ -117,11 +118,11 @@ def test_tone_hint_emitted_when_non_default():
 
 
 def test_tone_hint_omitted_when_default():
-    """Default tone must not bloat the prompt — quota matters."""
+    """Default (neutral) tone must not add a tone hint — quota matters. (The
+    `auto` language directive IS still emitted; that's a separate knob.)"""
     bundle = MetadataBundle(title="Foundation")
-    text_no_style = compose_user_prompt(bundle, citations=[])
-    text_default_style = compose_user_prompt(bundle, citations=[], style=AiStyle())
-    assert text_no_style == text_default_style
+    text = compose_user_prompt(bundle, citations=[], style=AiStyle())  # neutral tone
+    assert "Tone:" not in text
 
 
 def test_language_clause_emitted_when_non_auto():
@@ -131,55 +132,44 @@ def test_language_clause_emitted_when_non_auto():
     assert "Italian" in text
 
 
-def test_language_clause_omitted_when_auto_and_book_language_unknown():
-    """`auto` with no book language must produce a prompt byte-for-byte
-    identical to the no-style call (the language-neutral default)."""
-    bundle = MetadataBundle(title="Foundation")
-    text_no_style = compose_user_prompt(bundle, citations=[])
-    text_auto = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
-    text_default = compose_user_prompt(bundle, citations=[], style=AiStyle())
-    assert text_no_style == text_auto == text_default
-
-
-def test_language_clause_follows_book_language_when_auto():
-    """`auto` defers to the book's own language so the insight matches the book."""
-    bundle = MetadataBundle(title="Il nome della rosa", language="it")
+def test_auto_directive_present_and_infers_book_language():
+    """`auto` no longer depends on the metadata tag (often missing/wrong): it
+    instructs the model to determine the book's ORIGINAL language from the work
+    itself. The directive is therefore present even with NO metadata language."""
+    bundle = MetadataBundle(title="Cristo si è fermato a Eboli", author="Carlo Levi")
     text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
     assert "OUTPUT LANGUAGE" in text
-    assert "Italian" in text
+    assert "original language" in text.lower()
+    assert "determine it from the title" in text.lower()
 
 
-def test_auto_normalizes_region_and_three_letter_book_language():
-    """EPUB/OpenLibrary emit shapes like `en-US` and `eng`; `auto` folds them
-    down to a bare ISO 639-1 code before instructing the model."""
-    region = compose_user_prompt(
-        MetadataBundle(title="A", language="en-US"),
-        citations=[],
-        style=AiStyle(language="auto"),
-    )
-    assert "English" in region
-
-    iso2 = compose_user_prompt(
-        MetadataBundle(title="B", language="eng"),
-        citations=[],
-        style=AiStyle(language="auto"),
-    )
-    assert "English" in iso2
-
-
-def test_auto_skips_unrecognized_book_language():
-    """An unmappable language tag yields no clause rather than a bogus code."""
-    bundle = MetadataBundle(title="C", language="zxx")
-    text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
-    assert "OUTPUT LANGUAGE" not in text
+def test_auto_directive_does_not_hard_name_from_metadata():
+    """The `auto` directive must be identical whether the metadata tag is
+    correct, wrong, or absent — baking a name from a wrong `<dc:language>` is
+    exactly what forced English output before. Metadata only appears later as a
+    hint line; it must never turn the directive into 'write in English'."""
+    base = MetadataBundle(title="Cristo si è fermato a Eboli", author="Carlo Levi")
+    lead = "OUTPUT LANGUAGE — write all prose in the book's ORIGINAL language"
+    for lang in (None, "it", "en"):
+        text = compose_user_prompt(
+            base.model_copy(update={"language": lang}),
+            citations=[],
+            style=AiStyle(language="auto"),
+        )
+        assert lead in text
+        assert "write all prose in English" not in text  # wrong tag must not win
 
 
-def test_auto_rejects_bogus_two_letter_book_language():
-    """A two-letter tag that isn't a real ISO 639-1 code must not leak into the
-    prompt as an instruction."""
-    bundle = MetadataBundle(title="C2", language="zz")
-    text = compose_user_prompt(bundle, citations=[], style=AiStyle(language="auto"))
-    assert "OUTPUT LANGUAGE" not in text
+def test_normalize_book_language():
+    """The OpenLibrary/EPUB language normalizer (used by the ISBN backfill) folds
+    region/3-letter tags to ISO 639-1 and rejects bogus codes."""
+    assert _normalize_book_language("it") == "it"
+    assert _normalize_book_language("en-US") == "en"
+    assert _normalize_book_language("pt_BR") == "pt"
+    assert _normalize_book_language("eng") == "en"
+    assert _normalize_book_language("fre") == "fr"
+    assert _normalize_book_language("zz") is None  # not a real ISO 639-1
+    assert _normalize_book_language("zxx") is None  # 3-letter, unmapped
 
 
 def test_explicit_language_overrides_book_language():

--- a/server/tests/unit/test_ai_service.py
+++ b/server/tests/unit/test_ai_service.py
@@ -909,7 +909,8 @@ def _orchestrator_with(retriever, *, sources_enabled=("openlibrary",)):
 @pytest.mark.asyncio
 async def test_auto_backfills_scanned_book_language_into_prompt(session: AsyncSession):
     """A scanned book (ISBN, no language) under `auto` gets its language
-    resolved from OpenLibrary and injected into the prompt (fre -> fr)."""
+    resolved from OpenLibrary and added to the bundle as a metadata hint
+    (fre -> fr); the model still determines the output language itself."""
     retriever = FakeRetrieverWithLanguage(language="fre")
     orch = _orchestrator_with(retriever)
     ident = DocumentIdentity(metadata_id=None, content_hash="ch-scan-fr")
@@ -918,7 +919,7 @@ async def test_auto_backfills_scanned_book_language_into_prompt(session: AsyncSe
 
     assert retriever.lang_calls == ["9782070360024"]
     prompt = orch.ai.calls[0]["user"]
-    assert "French" in prompt
+    assert "Language: fr" in prompt  # backfilled hint line
 
     # Load-bearing invariant: the resolved book language steers the prompt but
     # must NOT leak into the cache key, or the client (which caches under the
@@ -940,7 +941,7 @@ async def test_auto_does_not_override_existing_bundle_language(session: AsyncSes
     await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(language="auto"))
 
     assert retriever.lang_calls == []  # never consulted
-    assert "English" in orch.ai.calls[0]["user"]
+    assert "Language: en" in orch.ai.calls[0]["user"]  # client-provided hint kept
 
 
 @pytest.mark.asyncio
@@ -953,7 +954,8 @@ async def test_auto_with_no_isbn_skips_backfill(session: AsyncSession):
     await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(language="auto"))
 
     assert retriever.lang_calls == []
-    assert "OUTPUT LANGUAGE" not in orch.ai.calls[0]["user"]
+    # No backfill, but `auto` still emits the infer directive (model decides).
+    assert "OUTPUT LANGUAGE" in orch.ai.calls[0]["user"]
 
 
 @pytest.mark.asyncio
@@ -966,4 +968,5 @@ async def test_auto_backfill_skipped_when_openlibrary_source_disabled(session: A
     await orch.generate(session, ident, bundle, user_id="u1", style=AiStyle(language="auto"))
 
     assert retriever.lang_calls == []
-    assert "OUTPUT LANGUAGE" not in orch.ai.calls[0]["user"]
+    # Backfill is gated off, but `auto` still emits the infer directive.
+    assert "OUTPUT LANGUAGE" in orch.ai.calls[0]["user"]


### PR DESCRIPTION
## Real-world root cause (found by testing against local Ollama gpt-oss:120b)

The reported book ("Cristo si è fermato a Eboli") came back in **English** even though prompt v7 was live and the model was gpt-oss:120b. Reproduced exactly: an Italian book whose EPUB `<dc:language>` is **missing or wrong**. v7 only emitted the language directive when the metadata tag was present/valid, so for these books it emitted **nothing** → the model defaulted to English, reinforced by the English Wikipedia/OpenLibrary citations in the prompt. Sideloaded EPUBs very commonly lack or misstate that tag.

## Fix (v8)

For `auto`, stop trusting the metadata tag to *pick* the language. Instruct the model to **determine the book's original language from the work itself** (title, author, its own knowledge), and not default to English unless the book is genuinely English. The metadata language stays only as a hint line. Explicit user-language selection is unchanged (still a named directive).

## Empirically verified (gpt-oss:120b)

Ran the real generation path (`SYSTEM_PROMPT` + `compose_user_prompt` + `AIClient`) against Ollama:

| Book | Metadata `<dc:language>` | Output |
|------|--------------------------|--------|
| Cristo si è fermato a Eboli (+EN citations) | **missing** | 🇮🇹 Italian ✓ |
| Cristo si è fermato a Eboli (+EN citations) | **wrong (`en`)** | 🇮🇹 Italian ✓ |
| The Great Gatsby | en | 🇬🇧 English ✓ |
| Il nome della rosa / Eboli | correct `it` | 🇮🇹 Italian ✓ |
| L'Étranger | fr | 🇫🇷 French ✓ |

`themes` stayed controlled English tags and `confidence` stayed `low/medium/high` in every case.

`PROMPT_VERSION` 7 → 8 (cache-bust). 359 server tests pass; `ruff` clean. Dead `_resolve_response_language` removed; `_normalize_book_language` kept (still used by the ISBN backfill).