### PR TITLE
Fix crash on Android 9–11 from expedited sync workers (#78)

### DIFF
--- a/data/library/src/main/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorker.kt
+++ b/data/library/src/main/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorker.kt
@@ -1,8 +1,12 @@
 package io.theficos.ereader.data.library.sync
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import io.theficos.ereader.data.library.LibraryClient
 import io.theficos.ereader.data.library.LibraryHttpException
@@ -60,6 +64,37 @@ class LibraryMirrorPushWorker(
     appContext: Context,
     params: WorkerParameters,
 ) : CoroutineWorker(appContext, params) {
+
+    /**
+     * Required for expedited work on API < 31. The app-start trigger
+     * ([LibraryMirrorPushScheduler.enqueueOneTime] with `expedited = true`)
+     * runs as a foreground service on Android 9–11, where WorkManager calls
+     * this to get the notification to display. The default `CoroutineWorker`
+     * implementation throws `IllegalStateException("Not implemented")`,
+     * which crashed the app at startup (issue #78). On API 31+ expedited
+     * work uses JobScheduler and this is never called.
+     */
+    override suspend fun getForegroundInfo(): ForegroundInfo =
+        createForegroundInfo(applicationContext)
+
+    private fun createForegroundInfo(context: Context): ForegroundInfo {
+        // minSdk is 26, so the channel API is always available.
+        val manager = context.getSystemService(NotificationManager::class.java)
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Library sync",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { setShowBadge(false) }
+        manager.createNotificationChannel(channel)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle("Syncing your library")
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+        return ForegroundInfo(NOTIFICATION_ID, notification)
+    }
 
     override suspend fun doWork(): Result {
         val deps = LibraryMirrorPushDependencies.holder ?: run {
@@ -190,6 +225,8 @@ class LibraryMirrorPushWorker(
 
     private companion object {
         const val TAG = "LibraryMirrorPush"
+        const val CHANNEL_ID = "quire-library-sync"
+        const val NOTIFICATION_ID = 4202
         // Mirrors `library_sync_max_items` (default 500) in the server's
         // Settings — we chunk client-side rather than catching a 422 on
         // oversize batches.

--- a/data/library/src/test/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorkerTest.kt
+++ b/data/library/src/test/java/io/theficos/ereader/data/library/sync/LibraryMirrorPushWorkerTest.kt
@@ -83,6 +83,24 @@ class LibraryMirrorPushWorkerTest {
     private fun buildWorker(): LibraryMirrorPushWorker =
         TestListenableWorkerBuilder<LibraryMirrorPushWorker>(context).build()
 
+    // -------------------- expedited foreground (issue #78) --------------------
+
+    /**
+     * Regression for #78: on API < 31 WorkManager runs the app-start
+     * expedited push as a foreground service and calls `getForegroundInfo()`.
+     * The default `CoroutineWorker` implementation throws
+     * `IllegalStateException("Not implemented")` and crashed the app on
+     * Android 9. The override must return a valid [ForegroundInfo].
+     */
+    @Test
+    @Config(sdk = [28])
+    fun `getForegroundInfo returns a notification on Android 9`() = runTest {
+        val info = buildWorker().getForegroundInfo()
+
+        assertThat(info.notificationId).isNotEqualTo(0)
+        assertThat(info.notification).isNotNull()
+    }
+
     // -------------------- success / wire shape --------------------
 
     @Test

--- a/data/sync/build.gradle.kts
+++ b/data/sync/build.gradle.kts
@@ -37,4 +37,5 @@ dependencies {
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.room.testing)
+    testImplementation(libs.work.testing)
 }

--- a/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncWorker.kt
+++ b/data/sync/src/main/java/io/theficos/ereader/data/sync/SyncWorker.kt
@@ -1,10 +1,14 @@
 package io.theficos.ereader.data.sync
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
 import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
@@ -15,6 +19,36 @@ class SyncWorker(
     appContext: Context,
     params: WorkerParameters,
 ) : CoroutineWorker(appContext, params) {
+
+    /**
+     * Required for expedited work on API < 31. There, WorkManager backs an
+     * expedited request with a foreground service and calls this to obtain
+     * the notification to display; the default `CoroutineWorker`
+     * implementation throws `IllegalStateException("Not implemented")`,
+     * which crashed the app on Android 9–11 (issue #78). On API 31+
+     * expedited work uses JobScheduler and this is never called.
+     */
+    override suspend fun getForegroundInfo(): ForegroundInfo =
+        createForegroundInfo(applicationContext)
+
+    private fun createForegroundInfo(context: Context): ForegroundInfo {
+        // minSdk is 26, so the channel API is always available.
+        val manager = context.getSystemService(NotificationManager::class.java)
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Sync",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { setShowBadge(false) }
+        manager.createNotificationChannel(channel)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle("Syncing reading progress")
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+        return ForegroundInfo(NOTIFICATION_ID, notification)
+    }
 
     override suspend fun doWork(): Result {
         val deps = SyncDependencies.holder ?: run {
@@ -34,6 +68,8 @@ class SyncWorker(
 
     private companion object {
         const val TAG = "QuireSync"
+        const val CHANNEL_ID = "quire-sync"
+        const val NOTIFICATION_ID = 4201
     }
 }
 

--- a/data/sync/src/test/java/io/theficos/ereader/data/sync/SyncWorkerForegroundTest.kt
+++ b/data/sync/src/test/java/io/theficos/ereader/data/sync/SyncWorkerForegroundTest.kt
@@ -1,0 +1,34 @@
+package io.theficos.ereader.data.sync
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression for #78: on API < 31 WorkManager runs an expedited
+ * [SyncWorker] as a foreground service and calls `getForegroundInfo()`.
+ * The default `CoroutineWorker` implementation throws
+ * `IllegalStateException("Not implemented")`, which crashed the app on
+ * Android 9. The override must return a valid `ForegroundInfo`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class SyncWorkerForegroundTest {
+
+    private val context get() = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun `getForegroundInfo returns a notification on Android 9`() = runTest {
+        val worker = TestListenableWorkerBuilder<SyncWorker>(context).build()
+
+        val info = worker.getForegroundInfo()
+
+        assertThat(info.notificationId).isNotEqualTo(0)
+        assertThat(info.notification).isNotNull()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #78 — a crash on Android 9 (and any Android < 12), most visibly at app startup.

## Root cause

On **API < 31**, WorkManager backs an expedited work request with a **foreground service** and calls `CoroutineWorker.getForegroundInfo()` to obtain the notification to display. The default `CoroutineWorker` implementation throws `IllegalStateException("Not implemented")`:

```
java.lang.IllegalStateException: Not implemented
    at androidx.work.CoroutineWorker.getForegroundInfo$suspendImpl(CoroutineWorker.kt:100)
```

On **API 31+** expedited work uses JobScheduler expedited jobs, so `getForegroundInfo()` is never called — which is why the crash only surfaced on older devices.

Two workers opt into expedited work and were missing the override:
- `LibraryMirrorPushWorker` — enqueued **expedited at app start** (`LibraryMirrorPushScheduler.enqueueOneTime(expedited = true)`), the most likely culprit for crash-on-launch.
- `SyncWorker` — enqueued expedited for user-initiated "Sync now".

The reporter's `OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST` doesn't help here: that policy only governs quota exhaustion, not the foreground-service requirement on pre-12.

## Fix

Override `getForegroundInfo()` in both workers to return a `ForegroundInfo` backed by a **silent, low-importance** (`IMPORTANCE_LOW`) notification on a dedicated channel.

## Resulting behavior

| Version | Before | After |
|---|---|---|
| Android 8–11 (API 26–30) | **Crash** when an expedited worker ran | Brief, silent, ongoing notification while the worker runs; auto-clears on completion. No crash. |
| Android 12+ (API 31+) | Worked (JobScheduler expedited jobs) | **Unchanged** — `getForegroundInfo()` is never called, no notification. |

Non-expedited triggers (ambient sync, daily periodic library push, `enqueueAfterLibraryChange`) never run as a foreground service, so they show no notification on any version.

No manifest changes needed: `FOREGROUND_SERVICE` is already merged transitively from `work-runtime`, and the foreground-service path only executes on API ≤ 30, so `targetSdk 34`'s foreground-service-type / `DATA_SYNC` permission requirements don't apply. No `POST_NOTIFICATIONS` concern either (that's API 33+, where this path never runs).

## Tests

Regression tests in both modules under `@Config(sdk = [28])` (Android 9) asserting `getForegroundInfo()` returns a valid notification instead of throwing. Added `work.testing` as a test dependency to `:data:sync`.

Verified locally via `scripts/dgradle :data:sync:testDebugUnitTest :data:library:testDebugUnitTest` — BUILD SUCCESSFUL.