### PR TITLE
fix(network): trust user-installed CAs for custom/internal CA servers (#80)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.Quire">
         <!-- configChanges keeps the Activity alive across rotation/keyboard/navigation
              changes. Required because EpubNavigatorFragment has no no-arg constructor:

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Trust user-installed CAs in addition to system CAs (issue #80).
+
+  Quire connects to arbitrary, user-configured servers (Calibre-web, OPDS,
+  sync, AI). Self-hosters commonly front those with a private/internal CA that
+  lives in the device's *user* CA store. On API 24+ apps trust system CAs only
+  by default, so without this Quire fails such servers with
+  "Trust anchor for certification path not found" even though the browser
+  (which does trust user CAs) connects fine.
+
+  This is a deliberate, bounded trust expansion appropriate for a self-hosted
+  app: only CAs the device owner installed themselves are honored, and modern
+  Android (11+) requires CA installation to go through Settings. The hosts can't
+  be enumerated at build time, so a global base-config is the only practical
+  option.
+
+  cleartextTrafficPermitted is intentionally left unset: with targetSdk 34 the
+  platform default already disables cleartext, so omitting it keeps current
+  behavior without hardcoding.
+
+  Fixed third-party public endpoints (Open Library metadata + covers) are pinned
+  back to system-only — they're served by public CAs and never need a private
+  CA, so they shouldn't inherit the user-CA trust expansion.
+-->
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+
+    <domain-config>
+        <domain includeSubdomains="true">openlibrary.org</domain>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Problem

Issue #80: self-hosters who front their Calibre-web/OPDS/sync/AI servers with a **private/internal CA** (installed in the Android *user* CA store) hit:

```
java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.
```

The device browser connects fine, but Quire fails — because on API 24+ apps trust **system CAs only** by default. Quire shipped no network-security-config, so user-installed CAs were never honored.

## Fix

Add `app/src/main/res/xml/network_security_config.xml` and reference it from the manifest:

- `base-config` trusts `system` + `user` → user-installed CAs are now honored app-wide.
- `domain-config` pins `openlibrary.org` (+ subdomains, covering `covers.openlibrary.org`) back to **system-only** — the one fixed third-party public host shouldn't inherit the user-CA trust expansion.

Every network path (OkHttp clients, Readium's `DefaultHttpClient`) uses platform-default trust, so this single config covers them all — **no Kotlin changes, no new deps**.

`cleartextTrafficPermitted` is intentionally left unset: with `targetSdk 34` the platform already disables cleartext by default, so omitting it preserves current behavior.

## Why this is acceptable

A deliberate, bounded trust expansion appropriate for a self-hosted app: only CAs the **device owner installed themselves** are honored, and Android 11+ forces CA installation through Settings (no silent malware CAs). Hosts are user-configured at runtime and can't be enumerated at build time, so a global base-config is the only practical option. Same fix path adopted by Home Assistant and Audiobookshelf.

## Verification

- `./scripts/dgradle :app:processDebugManifest :app:processDebugResources` → **BUILD SUCCESSFUL** (manifest merges, resource links via aapt).
- No automated test possible — this is platform trust config. Final confirmation needs the reporter to retest against their private-CA server on a build with this change.

Closes #80