### PR TITLE
Reader display: page margins, paragraph indent/spacing, immersive full-screen

### DIFF
--- a/app/src/main/java/io/theficos/ereader/MainActivity.kt
+++ b/app/src/main/java/io/theficos/ereader/MainActivity.kt
@@ -3,6 +3,7 @@ package io.theficos.ereader
 import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
 import androidx.fragment.app.FragmentActivity
 import io.theficos.ereader.ui.AppNavGraph
 import io.theficos.ereader.ui.theme.EReaderTheme
@@ -14,6 +15,13 @@ class MainActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Go edge-to-edge for the whole app: the single Activity window keeps a stable
+        // geometry, so entering/leaving the immersive reader never flips decorFits and
+        // never resizes the shared window (which used to show a visible jump on Back).
+        // Screens own their insets: Material3 Scaffold/TopAppBar/NavigationBar handle it
+        // automatically; the few bare screens are wrapped in a safeDrawing inset in
+        // AppNavGraph. Android 15 forces this anyway.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             EReaderTheme {
                 AppNavGraph(container = (application as EReaderApp).container)

--- a/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
+++ b/app/src/main/java/io/theficos/ereader/di/AppContainer.kt
@@ -28,6 +28,7 @@ import io.theficos.ereader.data.sync.SyncDependencies
 import io.theficos.ereader.data.sync.SyncEnqueuer
 import io.theficos.ereader.data.sync.SyncOrchestrator
 import io.theficos.ereader.domain.restore.RestoreInProgressUseCase
+import io.theficos.ereader.domain.restore.RestoreSummary
 import io.theficos.ereader.reader.ReaderPreferencesStore
 import io.theficos.ereader.reader.ReadiumFactory
 import io.theficos.ereader.sideload.SideloadImporter
@@ -348,6 +349,16 @@ class AppContainer(context: Context) {
         },
         applyPositions = { items -> syncOrchestrator.applyProgressItems(items) },
     )
+
+    /**
+     * Entry point for the "Restore in-progress books" action. Runs the whole use case
+     * off the main thread: its network pulls (library mirror + progress) and Room reads
+     * otherwise execute on the caller's viewModelScope (Main) and throw
+     * NetworkOnMainThreadException. downloadAndInsert already has its own IO context; the
+     * nested withContext is harmless.
+     */
+    suspend fun runRestoreInProgress(onProgress: (Int, Int) -> Unit): RestoreSummary =
+        withContext(Dispatchers.IO) { restoreInProgressUseCase().run(onProgress) }
 
     private suspend fun readOpfBytes(doc: Document): ByteArray? = withContext(Dispatchers.IO) {
         runCatching {

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -1,9 +1,13 @@
 package io.theficos.ereader.ui
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -78,34 +82,40 @@ fun AppNavGraph(container: AppContainer) {
     }
     NavHost(navController = nav, startDestination = startDestination) {
         composable("welcome") {
-            WelcomeScreen(
-                onConnectServer = { nav.navigate("connect-server") },
-                onCloudSignIn = { nav.navigate("cloud-coming-soon") },
-                onSkipOffline = {
-                    container.welcomePreferencesStore.markCompleted()
-                    nav.navigate("home") {
-                        popUpTo("welcome") { inclusive = true }
-                    }
-                },
-            )
+            InsetSurface {
+                WelcomeScreen(
+                    onConnectServer = { nav.navigate("connect-server") },
+                    onCloudSignIn = { nav.navigate("cloud-coming-soon") },
+                    onSkipOffline = {
+                        container.welcomePreferencesStore.markCompleted()
+                        nav.navigate("home") {
+                            popUpTo("welcome") { inclusive = true }
+                        }
+                    },
+                )
+            }
         }
         composable("connect-server") {
             val vm = remember {
                 ConnectServerViewModel(credentialStore = container.credentialStore)
             }
-            ConnectServerScreen(
-                viewModel = vm,
-                onBack = { nav.popBackStack() },
-                onCompleted = {
-                    container.welcomePreferencesStore.markCompleted()
-                    nav.navigate("home") {
-                        popUpTo("welcome") { inclusive = true }
-                    }
-                },
-            )
+            InsetSurface {
+                ConnectServerScreen(
+                    viewModel = vm,
+                    onBack = { nav.popBackStack() },
+                    onCompleted = {
+                        container.welcomePreferencesStore.markCompleted()
+                        nav.navigate("home") {
+                            popUpTo("welcome") { inclusive = true }
+                        }
+                    },
+                )
+            }
         }
         composable("cloud-coming-soon") {
-            CloudComingSoonScreen(onBack = { nav.popBackStack() })
+            InsetSurface {
+                CloudComingSoonScreen(onBack = { nav.popBackStack() })
+            }
         }
         composable("home") {
             val libVm = remember {
@@ -247,10 +257,12 @@ fun AppNavGraph(container: AppContainer) {
         ) { backStack ->
             val key = backStack.arguments!!.getString("key")!!
             val vm = remember(key) { container.catalogDetailViewModelFactory.create(key) }
-            if (vm == null) {
-                CatalogDetailUnavailable(onBack = { nav.popBackStack() })
-            } else {
-                CatalogDetailScreen(viewModel = vm, onBack = { nav.popBackStack() })
+            InsetSurface {
+                if (vm == null) {
+                    CatalogDetailUnavailable(onBack = { nav.popBackStack() })
+                } else {
+                    CatalogDetailScreen(viewModel = vm, onBack = { nav.popBackStack() })
+                }
             }
         }
         composable("scan") {
@@ -277,7 +289,7 @@ fun AppNavGraph(container: AppContainer) {
             val key = backStack.arguments!!.getString("key")!!
             val data = remember(key) { container.scanResultRegistry.get(key) }
             if (data == null) {
-                CatalogDetailUnavailable(onBack = { nav.popBackStack() })
+                InsetSurface { CatalogDetailUnavailable(onBack = { nav.popBackStack() }) }
             } else {
                 val vm = remember(key) {
                     ScanResultViewModel(data = data, ai = container.aiRepository)
@@ -321,6 +333,22 @@ fun AppNavGraph(container: AppContainer) {
                 // Settings from the bottom-nav).
                 onOpenSettings = { nav.popBackStack() },
             )
+        }
+    }
+}
+
+/**
+ * Full-bleed surface that insets its content by [WindowInsets.safeDrawing] (system bars +
+ * display cutout + IME). The app is edge-to-edge (see MainActivity), so screens that don't
+ * already manage their own insets via a Material3 Scaffold/TopAppBar are wrapped in this to
+ * keep content clear of the system bars and the keyboard. The outer Surface paints behind
+ * the (opaque) bars so there's no window-background seam.
+ */
+@Composable
+private fun InsetSurface(content: @Composable () -> Unit) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().windowInsetsPadding(WindowInsets.safeDrawing)) {
+            content()
         }
     }
 }

--- a/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/AppNavGraph.kt
@@ -116,7 +116,7 @@ fun AppNavGraph(container: AppContainer) {
                     booksDir = container.booksDir,
                     libraryPreferencesStore = container.libraryPreferencesStore,
                     credentialStore = container.credentialStore,
-                    restoreInProgress = { onProgress -> container.restoreInProgressUseCase().run(onProgress) },
+                    restoreInProgress = { onProgress -> container.runRestoreInProgress(onProgress) },
                 )
             }
             val catVm = remember {
@@ -146,7 +146,7 @@ fun AppNavGraph(container: AppContainer) {
                     aiRepository = container.aiRepository,
                     insightSyncRepository = container.insightSyncRepository,
                     insightDao = container.insightDao,
-                    restoreInProgress = { onProgress -> container.restoreInProgressUseCase().run(onProgress) },
+                    restoreInProgress = { onProgress -> container.runRestoreInProgress(onProgress) },
                 )
             }
             val aiConfig by container.aiRepository.config.collectAsState()

--- a/app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt
@@ -4,7 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -34,7 +37,14 @@ fun FontSettingsSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            // Scrollable + nav-bar inset so every control stays reachable — the sheet is
+            // taller than the screen once all sliders are shown, and the last item
+            // ("Full-screen reading") otherwise falls off the bottom / under the nav bar.
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text("Font size: ${"%.1fx".format(prefs.fontScale)}", style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/FontSettingsSheet.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import io.theficos.ereader.reader.ReaderFontFamily
 import io.theficos.ereader.reader.ReaderPreferences
@@ -43,14 +45,75 @@ fun FontSettingsSheet(
                 steps = 14,
                 modifier = Modifier.fillMaxWidth(),
             )
-            Text("Line spacing: ${"%.1f".format(prefs.lineSpacing)}", style = MaterialTheme.typography.bodyMedium)
+            val advancedEnabled = !prefs.usePublisherStyles
+
+            val lineSpacingLabel = "Line spacing: ${"%.1f".format(prefs.lineSpacing)}"
+            Text(lineSpacingLabel, style = MaterialTheme.typography.bodyMedium)
             Slider(
                 value = prefs.lineSpacing.toFloat(),
                 onValueChange = { onChange(prefs.copy(lineSpacing = it.toDouble().coerceIn(1.0, 1.8))) },
                 valueRange = 1.0f..1.8f,
                 steps = 7,
-                modifier = Modifier.fillMaxWidth(),
+                enabled = advancedEnabled,
+                modifier = Modifier.fillMaxWidth().semantics { contentDescription = lineSpacingLabel },
             )
+
+            val marginLabel = "Page margins: ${"%.1f".format(prefs.pageMargins)}"
+            Text(marginLabel, style = MaterialTheme.typography.bodyMedium)
+            Slider(
+                value = prefs.pageMargins.toFloat(),
+                onValueChange = { onChange(prefs.copy(pageMargins = it.toDouble().coerceIn(0.5, 2.0))) },
+                valueRange = 0.5f..2.0f,
+                steps = 14,
+                modifier = Modifier.fillMaxWidth().semantics { contentDescription = marginLabel },
+            )
+
+            val indentLabel = prefs.paragraphIndent
+                ?.let { "Paragraph indent: ${"%.1f".format(it)}" } ?: "Paragraph indent: Default"
+            Text(indentLabel, style = MaterialTheme.typography.bodyMedium)
+            Slider(
+                value = (prefs.paragraphIndent ?: 0.0).toFloat(),
+                onValueChange = { v ->
+                    onChange(prefs.copy(paragraphIndent = v.toDouble().takeIf { it > 0.0 }?.coerceIn(0.0, 3.0)))
+                },
+                valueRange = 0.0f..3.0f,
+                steps = 5,
+                enabled = advancedEnabled,
+                modifier = Modifier.fillMaxWidth().semantics { contentDescription = indentLabel },
+            )
+
+            val spacingLabel = prefs.paragraphSpacing
+                ?.let { "Paragraph spacing: ${"%.1f".format(it)}" } ?: "Paragraph spacing: Default"
+            Text(spacingLabel, style = MaterialTheme.typography.bodyMedium)
+            Slider(
+                value = (prefs.paragraphSpacing ?: 0.0).toFloat(),
+                onValueChange = { v ->
+                    onChange(prefs.copy(paragraphSpacing = v.toDouble().takeIf { it > 0.0 }?.coerceIn(0.0, 2.0)))
+                },
+                valueRange = 0.0f..2.0f,
+                steps = 7,
+                enabled = advancedEnabled,
+                modifier = Modifier.fillMaxWidth().semantics { contentDescription = spacingLabel },
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Use the book's paragraph styling", style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        "Keeps the book's own line spacing, indent and paragraph spacing — turn off to adjust them",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = prefs.usePublisherStyles,
+                    onCheckedChange = { onChange(prefs.copy(usePublisherStyles = it)) },
+                )
+            }
+
             Text("Theme", style = MaterialTheme.typography.bodyMedium)
             Row(verticalAlignment = Alignment.CenterVertically) {
                 ReaderTheme.values().forEach { t ->
@@ -99,6 +162,25 @@ fun FontSettingsSheet(
                 Switch(
                     checked = prefs.tapNavigationEnabled,
                     onCheckedChange = { onChange(prefs.copy(tapNavigationEnabled = it)) },
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Full-screen reading", style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        "Hide the status and navigation bars while reading",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = prefs.immersiveReading,
+                    onCheckedChange = { onChange(prefs.copy(immersiveReading = it)) },
                 )
             }
         }

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderChrome.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderChrome.kt
@@ -10,11 +10,17 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -47,6 +53,7 @@ fun ReaderTopBar(
     onBack: () -> Unit,
     onOverflow: () -> Unit,
     modifier: Modifier = Modifier,
+    edgeToEdge: Boolean = false,
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -58,6 +65,16 @@ fun ReaderTopBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.96f))
+                // In immersive mode the reader draws edge-to-edge, so keep the bar clear
+                // of the status bar and any display cutout. No-op when not edge-to-edge
+                // (decor still fits system windows), avoiding a double inset.
+                .then(
+                    if (edgeToEdge) {
+                        Modifier.windowInsetsPadding(WindowInsets.statusBars.union(WindowInsets.displayCutout))
+                    } else {
+                        Modifier
+                    },
+                )
                 .padding(horizontal = 4.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -91,6 +108,7 @@ fun ReaderBottomBar(
     onSeekChange: (Double) -> Unit,
     onSeekFinished: () -> Unit,
     modifier: Modifier = Modifier,
+    edgeToEdge: Boolean = false,
 ) {
     val pct = (percent * 100).toInt().coerceIn(0, 100)
     val haptics = LocalHapticFeedback.current
@@ -105,6 +123,13 @@ fun ReaderBottomBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.96f))
+                .then(
+                    if (edgeToEdge) {
+                        Modifier.windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.displayCutout))
+                    } else {
+                        Modifier
+                    },
+                )
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
             BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderChrome.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderChrome.kt
@@ -61,35 +61,43 @@ fun ReaderTopBar(
         exit = slideOutVertically { -it } + fadeOut(),
         modifier = modifier,
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.96f))
-                // In immersive mode the reader draws edge-to-edge, so keep the bar clear
-                // of the status bar and any display cutout. No-op when not edge-to-edge
-                // (decor still fits system windows), avoiding a double inset.
-                .then(
-                    if (edgeToEdge) {
-                        Modifier.windowInsetsPadding(WindowInsets.statusBars.union(WindowInsets.displayCutout))
-                    } else {
-                        Modifier
-                    },
-                )
-                .padding(horizontal = 4.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
+        // Surface (not a bare background) so LocalContentColor is set to onSurface —
+        // otherwise the icons/title fall back to the Compose default (black) and vanish
+        // against the dark bar in dark mode.
+        Surface(
+            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.96f),
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            IconButton(onClick = onBack) {
-                Icon(Icons.Default.ArrowBack, contentDescription = "Back")
-            }
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
-            )
-            IconButton(onClick = onOverflow) {
-                Icon(Icons.Default.MoreVert, contentDescription = "Menu")
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // In immersive mode the reader draws edge-to-edge, so keep the bar clear
+                    // of the status bar and any display cutout. No-op when not edge-to-edge
+                    // (decor still fits system windows), avoiding a double inset.
+                    .then(
+                        if (edgeToEdge) {
+                            Modifier.windowInsetsPadding(WindowInsets.statusBars.union(WindowInsets.displayCutout))
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                }
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
+                )
+                IconButton(onClick = onOverflow) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "Menu")
+                }
             }
         }
     }

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
@@ -2,11 +2,15 @@ package io.theficos.ereader.ui.reader
 
 import android.app.Activity
 import android.content.Context
+import android.graphics.Color as AndroidColor
+import android.os.Build
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.view.WindowManager
+import android.view.accessibility.AccessibilityManager
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,7 +28,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
 import androidx.lifecycle.Lifecycle
@@ -82,8 +90,13 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
 
     LaunchedEffect(Unit) { viewModel.load() }
 
-    LaunchedEffect(chromeVisible, isDragging) {
-        if (chromeVisible && !isDragging) {
+    LaunchedEffect(chromeVisible, isDragging, showFontSheet) {
+        // Don't auto-hide while the settings sheet is open (bars would slide out from under
+        // the modal), nor while a screen reader is exploring (immersive also hides the OS
+        // navigation bar, which a TalkBack user cannot re-summon on a 2.5s timer).
+        val touchExploring = (context.getSystemService(Context.ACCESSIBILITY_SERVICE)
+            as? AccessibilityManager)?.isTouchExplorationEnabled == true
+        if (chromeVisible && !isDragging && !showFontSheet && !touchExploring) {
             delay(2_500)
             viewModel.setChromeVisible(false)
         }
@@ -94,6 +107,18 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
             ReaderUiState.Loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
             is ReaderUiState.Error -> Text(s.message, Modifier.align(Alignment.Center))
             is ReaderUiState.Open -> {
+                // Declared before ReaderContent so decor-fits is applied before the navigator
+                // fragment is created (cold start paginates at final edge-to-edge geometry).
+                // Scoped to the Open state so Loading/Error keep normal, themed system bars.
+                ImmersiveWindowEffects(
+                    immersive = preferences.immersiveReading,
+                    lightBarsForTheme = preferences.theme != io.theficos.ereader.reader.ReaderTheme.DARK,
+                    chromeVisible = chromeVisible,
+                    onBeforeResize = viewModel::beginViewportResize,
+                    onResizeSettled = viewModel::completeViewportResize,
+                    onExit = viewModel::clearPendingResize,
+                )
+
                 ReaderContent(
                     publication = s.publication,
                     initialLocator = s.initialLocator,
@@ -112,6 +137,7 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
                     onBack = onClose,
                     onOverflow = { showFontSheet = true },
                     modifier = Modifier.align(Alignment.TopCenter),
+                    edgeToEdge = preferences.immersiveReading,
                 )
                 val positionsList = positions
                 val locationTotal = positionsList?.size?.takeIf { it > 0 }
@@ -142,6 +168,7 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
                         dragPreview = null
                     },
                     modifier = Modifier.align(Alignment.BottomCenter),
+                    edgeToEdge = preferences.immersiveReading,
                 )
 
                 if (showFontSheet) {
@@ -247,6 +274,162 @@ private fun ReaderContent(
     LaunchedEffect(preferences) {
         fragment?.submitPreferences(preferences.toEpubPreferences())
     }
+}
+
+/**
+ * Drives immersive full-screen: binds the OS status + navigation bars to the reader
+ * chrome. Every window mutation is snapshotted once and reverted on exit so the rest of
+ * the single-Activity app keeps its normal, themed bars.
+ */
+@Composable
+private fun ImmersiveWindowEffects(
+    immersive: Boolean,
+    lightBarsForTheme: Boolean,
+    chromeVisible: Boolean,
+    onBeforeResize: () -> Unit,
+    onResizeSettled: () -> Unit,
+    onExit: () -> Unit,
+) {
+    val view = LocalView.current
+    val window = (LocalContext.current as Activity).window
+    val controller = remember(window, view) { WindowCompat.getInsetsController(window, view) }
+
+    // Snapshot the pre-reader system-bar state ONCE, so re-runs restore the true originals
+    // rather than a previously-applied transparent/immersive value.
+    val original = remember {
+        OriginalBarState(
+            statusColor = window.statusBarColor,
+            navColor = window.navigationBarColor,
+            lightStatus = controller.isAppearanceLightStatusBars,
+            lightNav = controller.isAppearanceLightNavigationBars,
+            contrastEnforced = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                window.isNavigationBarContrastEnforced
+            } else {
+                true
+            },
+            cutoutMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                window.attributes.layoutInDisplayCutoutMode
+            } else {
+                0
+            },
+        )
+    }
+
+    // Skip arming a viewport resize on the very first application: the fragment is created
+    // edge-to-edge from the start, so there's nothing to re-anchor.
+    val firstRun = remember { booleanArrayOf(true) }
+
+    // Apply the window mode whenever immersive flips. Arm the re-anchor BEFORE the
+    // decor-fits change (which resizes the WebView) so Readium's drifted emissions are
+    // suppressed until onPageChanged (or the fallback below) restores the anchor. Skipped
+    // on first run — the fragment is created at the final geometry, so no resize occurs.
+    DisposableEffect(immersive) {
+        if (!firstRun[0]) onBeforeResize()
+        if (immersive) applyImmersive(window, controller) else restoreBars(window, controller, original)
+        onDispose { }
+    }
+
+    // Exit-only cleanup (keyed on Unit so an immersive toggle never triggers it): revert
+    // every window mutation so the rest of the single-Activity app keeps normal bars, and
+    // clear any resize left armed by a mid-transition teardown.
+    DisposableEffect(Unit) {
+        onDispose {
+            restoreBars(window, controller, original)
+            onExit()
+        }
+    }
+
+    // Re-anchor fallback for a live immersive toggle. onPageChanged normally completes the
+    // resize; this guarantees the anchor is honored (and publishing un-suppressed) even if
+    // the toggle didn't re-paginate. Idempotent — a no-op once already completed.
+    LaunchedEffect(immersive) {
+        if (firstRun[0]) {
+            firstRun[0] = false
+        } else {
+            delay(600)
+            onResizeSettled()
+        }
+    }
+
+    // Bar-icon appearance follows the reader theme, but only while immersive. Kept separate
+    // from the mode effect so a theme change never cycles decor-fits (which would re-paginate).
+    LaunchedEffect(immersive, lightBarsForTheme) {
+        if (immersive) {
+            controller.isAppearanceLightStatusBars = lightBarsForTheme
+            controller.isAppearanceLightNavigationBars = lightBarsForTheme
+        }
+    }
+
+    // Bind system-bar visibility to the reader chrome.
+    LaunchedEffect(immersive, chromeVisible) {
+        if (immersive) {
+            if (chromeVisible) {
+                controller.show(WindowInsetsCompat.Type.systemBars())
+            } else {
+                controller.hide(WindowInsetsCompat.Type.systemBars())
+            }
+        }
+    }
+
+    // Re-assert the hidden state when the window regains focus (notification shade, system
+    // dialog, or app switch can reset it) so bars don't get stuck visible over the page.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, immersive, chromeVisible) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME && immersive && !chromeVisible) {
+                controller.hide(WindowInsetsCompat.Type.systemBars())
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+}
+
+private data class OriginalBarState(
+    val statusColor: Int,
+    val navColor: Int,
+    val lightStatus: Boolean,
+    val lightNav: Boolean,
+    val contrastEnforced: Boolean,
+    val cutoutMode: Int,
+)
+
+private fun applyImmersive(window: Window, controller: WindowInsetsControllerCompat) {
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    window.statusBarColor = AndroidColor.TRANSPARENT
+    window.navigationBarColor = AndroidColor.TRANSPARENT
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        window.isNavigationBarContrastEnforced = false
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        window.attributes = window.attributes.apply {
+            layoutInDisplayCutoutMode =
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        }
+    }
+    controller.systemBarsBehavior =
+        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+}
+
+private fun restoreBars(
+    window: Window,
+    controller: WindowInsetsControllerCompat,
+    original: OriginalBarState,
+) {
+    WindowCompat.setDecorFitsSystemWindows(window, true)
+    window.statusBarColor = original.statusColor
+    window.navigationBarColor = original.navColor
+    controller.isAppearanceLightStatusBars = original.lightStatus
+    controller.isAppearanceLightNavigationBars = original.lightNav
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        window.isNavigationBarContrastEnforced = original.contrastEnforced
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        window.attributes = window.attributes.apply {
+            layoutInDisplayCutoutMode = original.cutoutMode
+        }
+    }
+    controller.show(WindowInsetsCompat.Type.systemBars())
 }
 
 /**

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderScreen.kt
@@ -12,8 +12,12 @@ import android.view.Window
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityManager
 import android.widget.FrameLayout
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -88,6 +92,22 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
         onDispose { mainActivity.onBeforeReaderConfigChange = null }
     }
 
+    // Reveal the system bars the instant the user leaves the reader (top-bar back button
+    // or system/predictive back), before the pop animation starts. Immersive reading hides
+    // them, which drops WindowInsets.systemBars to zero; if they're only re-shown when the
+    // reader finishes disposing at the END of the pop, the incoming screen's Scaffold
+    // re-pads the moment they reappear — a visible resize/jump. Showing them up-front lets
+    // the insets settle while the destination is still fading in.
+    val readerView = LocalView.current
+    val insetsController = remember(activity.window, readerView) {
+        WindowCompat.getInsetsController(activity.window, readerView)
+    }
+    val leaveReader: () -> Unit = {
+        insetsController.show(WindowInsetsCompat.Type.systemBars())
+        onClose()
+    }
+    BackHandler { leaveReader() }
+
     LaunchedEffect(Unit) { viewModel.load() }
 
     LaunchedEffect(chromeVisible, isDragging, showFontSheet) {
@@ -107,8 +127,6 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
             ReaderUiState.Loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
             is ReaderUiState.Error -> Text(s.message, Modifier.align(Alignment.Center))
             is ReaderUiState.Open -> {
-                // Declared before ReaderContent so decor-fits is applied before the navigator
-                // fragment is created (cold start paginates at final edge-to-edge geometry).
                 // Scoped to the Open state so Loading/Error keep normal, themed system bars.
                 ImmersiveWindowEffects(
                     immersive = preferences.immersiveReading,
@@ -119,64 +137,80 @@ fun ReaderScreen(viewModel: ReaderViewModel, onClose: () -> Unit) {
                     onExit = viewModel::clearPendingResize,
                 )
 
-                ReaderContent(
-                    publication = s.publication,
-                    initialLocator = s.initialLocator,
-                    preferences = preferences,
-                    onLocator = viewModel::publishLocator,
-                    onNavigatorReady = viewModel::bindNavigator,
-                    onPrev = viewModel::pageBackward,
-                    onNext = viewModel::pageForward,
-                    onToggleChrome = viewModel::toggleChrome,
-                    onPageLoaded = viewModel::completeViewportResize,
-                )
-
-                ReaderTopBar(
-                    visible = chromeVisible,
-                    title = s.document.title,
-                    onBack = onClose,
-                    onOverflow = { showFontSheet = true },
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    edgeToEdge = preferences.immersiveReading,
-                )
-                val positionsList = positions
-                val locationTotal = positionsList?.size?.takeIf { it > 0 }
-                val locationIndex = dragPercent?.let { p ->
-                    locationTotal?.let { total ->
-                        (p.coerceIn(0.0, 1.0) * (total - 1)).toInt().coerceIn(0, total - 1) + 1
-                    }
-                }
-                ReaderBottomBar(
-                    visible = chromeVisible,
-                    chapterTitle = dragPreview?.title
-                        ?: liveLocator?.title
-                        ?: s.initialLocator?.title,
-                    percent = dragPreview?.locations?.let { it.totalProgression ?: it.progression }
-                        ?: liveLocator?.locations?.let { it.totalProgression ?: it.progression }
-                        ?: s.savedProgress?.percent ?: 0.0,
-                    enabled = positionsList?.isNotEmpty() == true,
-                    isDragging = isDragging,
-                    locationIndex = locationIndex,
-                    locationTotal = locationTotal,
-                    onSeekChange = { p ->
-                        dragPercent = p
-                        dragPreview = viewModel.previewLocator(p)
-                    },
-                    onSeekFinished = {
-                        dragPercent?.let { viewModel.seek(it) }
-                        dragPercent = null
-                        dragPreview = null
-                    },
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                    edgeToEdge = preferences.immersiveReading,
-                )
-
-                if (showFontSheet) {
-                    FontSettingsSheet(
-                        prefs = preferences,
-                        onChange = { next -> viewModel.updatePreferences(next) },
-                        onDismiss = { showFontSheet = false },
+                // The app is edge-to-edge (MainActivity). Immersive reading uses that full
+                // bleed: content draws behind the (hidden) bars and the chrome self-insets.
+                // With immersive off, the reader behaves like any normal screen — inset the
+                // whole subtree (content + chrome) clear of the opaque system bars. Toggling
+                // this padding is what resizes the WebView on an immersive flip; the
+                // re-anchor machinery in ImmersiveWindowEffects handles that.
+                val immersive = preferences.immersiveReading
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .then(
+                            if (immersive) Modifier
+                            else Modifier.windowInsetsPadding(WindowInsets.systemBars),
+                        ),
+                ) {
+                    ReaderContent(
+                        publication = s.publication,
+                        initialLocator = s.initialLocator,
+                        preferences = preferences,
+                        onLocator = viewModel::publishLocator,
+                        onNavigatorReady = viewModel::bindNavigator,
+                        onPrev = viewModel::pageBackward,
+                        onNext = viewModel::pageForward,
+                        onToggleChrome = viewModel::toggleChrome,
+                        onPageLoaded = viewModel::completeViewportResize,
                     )
+
+                    ReaderTopBar(
+                        visible = chromeVisible,
+                        title = s.document.title,
+                        onBack = leaveReader,
+                        onOverflow = { showFontSheet = true },
+                        modifier = Modifier.align(Alignment.TopCenter),
+                        edgeToEdge = immersive,
+                    )
+                    val positionsList = positions
+                    val locationTotal = positionsList?.size?.takeIf { it > 0 }
+                    val locationIndex = dragPercent?.let { p ->
+                        locationTotal?.let { total ->
+                            (p.coerceIn(0.0, 1.0) * (total - 1)).toInt().coerceIn(0, total - 1) + 1
+                        }
+                    }
+                    ReaderBottomBar(
+                        visible = chromeVisible,
+                        chapterTitle = dragPreview?.title
+                            ?: liveLocator?.title
+                            ?: s.initialLocator?.title,
+                        percent = dragPreview?.locations?.let { it.totalProgression ?: it.progression }
+                            ?: liveLocator?.locations?.let { it.totalProgression ?: it.progression }
+                            ?: s.savedProgress?.percent ?: 0.0,
+                        enabled = positionsList?.isNotEmpty() == true,
+                        isDragging = isDragging,
+                        locationIndex = locationIndex,
+                        locationTotal = locationTotal,
+                        onSeekChange = { p ->
+                            dragPercent = p
+                            dragPreview = viewModel.previewLocator(p)
+                        },
+                        onSeekFinished = {
+                            dragPercent?.let { viewModel.seek(it) }
+                            dragPercent = null
+                            dragPreview = null
+                        },
+                        modifier = Modifier.align(Alignment.BottomCenter),
+                        edgeToEdge = immersive,
+                    )
+
+                    if (showFontSheet) {
+                        FontSettingsSheet(
+                            prefs = preferences,
+                            onChange = { next -> viewModel.updatePreferences(next) },
+                            onDismiss = { showFontSheet = false },
+                        )
+                    }
                 }
             }
         }
@@ -319,10 +353,11 @@ private fun ImmersiveWindowEffects(
     // edge-to-edge from the start, so there's nothing to re-anchor.
     val firstRun = remember { booleanArrayOf(true) }
 
-    // Apply the window mode whenever immersive flips. Arm the re-anchor BEFORE the
-    // decor-fits change (which resizes the WebView) so Readium's drifted emissions are
-    // suppressed until onPageChanged (or the fallback below) restores the anchor. Skipped
-    // on first run — the fragment is created at the final geometry, so no resize occurs.
+    // Apply the bar cosmetics whenever immersive flips, and arm the re-anchor BEFORE the
+    // recomposition toggles the reader content's systemBars inset (which resizes the
+    // WebView) so Readium's drifted emissions are suppressed until onPageChanged (or the
+    // fallback below) restores the anchor. Skipped on first run — the fragment is created
+    // at the final geometry, so no resize occurs.
     DisposableEffect(immersive) {
         if (!firstRun[0]) onBeforeResize()
         if (immersive) applyImmersive(window, controller) else restoreBars(window, controller, original)
@@ -395,7 +430,9 @@ private data class OriginalBarState(
 )
 
 private fun applyImmersive(window: Window, controller: WindowInsetsControllerCompat) {
-    WindowCompat.setDecorFitsSystemWindows(window, false)
+    // NB: decorFitsSystemWindows is set false once, app-wide, in MainActivity — never
+    // toggled here. Toggling it on the shared single-Activity window resized the window
+    // on reader exit and showed a visible jump. This only tweaks bar cosmetics/behavior.
     window.statusBarColor = AndroidColor.TRANSPARENT
     window.navigationBarColor = AndroidColor.TRANSPARENT
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -416,7 +453,8 @@ private fun restoreBars(
     controller: WindowInsetsControllerCompat,
     original: OriginalBarState,
 ) {
-    WindowCompat.setDecorFitsSystemWindows(window, true)
+    // Colors/appearance/contrast/cutout only — decorFitsSystemWindows stays false
+    // (owned by MainActivity), so restoring bars never resizes the window.
     window.statusBarColor = original.statusColor
     window.navigationBarColor = original.navColor
     controller.isAppearanceLightStatusBars = original.lightStatus

--- a/app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/io/theficos/ereader/ui/reader/ReaderViewModel.kt
@@ -158,6 +158,14 @@ class ReaderViewModel(
         }
     }
 
+    // Safety valve for the immersive decor-fits transitions: if a resize was armed
+    // (beginViewportResize) but no re-pagination completed it — e.g. the reader is torn
+    // down mid-transition — clear the anchor so publishing is never left suppressed.
+    fun clearPendingResize() {
+        pendingRotationAnchor = null
+        suppressLocatorPublishing = false
+    }
+
     fun previewLocator(percent: Double): Locator? {
         val list = _positions.value ?: return null
         return locatorAtPercent(list, percent)

--- a/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferences.kt
+++ b/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferences.kt
@@ -21,11 +21,28 @@ data class ReaderPreferences(
     val lineSpacing: Double = 1.4,
     val tapNavigationEnabled: Boolean = true,
     val pageMargins: Double = 1.4,
+    // Nullable: null means "leave the book's / ReadiumCSS default" (Readium emits no
+    // override). A concrete value force-applies the override, so 0.0 is NOT "off" — it
+    // would collapse the book's paragraph spacing. Defaulting to null keeps upgrades a
+    // no-op until the reader explicitly drags the slider.
+    val paragraphIndent: Double? = null,
+    val paragraphSpacing: Double? = null,
+    // When true, keep the book's publisher paragraph styling. Readium gates lineHeight,
+    // paragraphIndent and paragraphSpacing behind advancedSettings = !publisherStyles, so
+    // those controls only take effect when this is false (the default).
+    val usePublisherStyles: Boolean = false,
+    val immersiveReading: Boolean = true,
 ) {
     init {
         require(fontScale in 0.5..2.0) { "fontScale out of range: $fontScale" }
         require(lineSpacing in 1.0..1.8) { "lineSpacing out of range: $lineSpacing" }
         require(pageMargins in 0.5..2.0) { "pageMargins out of range: $pageMargins" }
+        require(paragraphIndent == null || paragraphIndent in 0.0..3.0) {
+            "paragraphIndent out of range: $paragraphIndent"
+        }
+        require(paragraphSpacing == null || paragraphSpacing in 0.0..2.0) {
+            "paragraphSpacing out of range: $paragraphSpacing"
+        }
     }
 }
 
@@ -39,4 +56,7 @@ fun ReaderPreferences.toEpubPreferences(): EpubPreferences = EpubPreferences(
     fontFamily = fontFamily.readium,
     lineHeight = lineSpacing,
     pageMargins = pageMargins,
+    publisherStyles = usePublisherStyles,
+    paragraphIndent = paragraphIndent,
+    paragraphSpacing = paragraphSpacing,
 )

--- a/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferencesStore.kt
+++ b/reader/src/main/java/io/theficos/ereader/reader/ReaderPreferencesStore.kt
@@ -21,6 +21,11 @@ class ReaderPreferencesStore(context: Context) {
             .putFloat(KEY_LINE_SPACING, next.lineSpacing.toFloat())
             .putBoolean(KEY_TAP_NAVIGATION, next.tapNavigationEnabled)
             .putFloat(KEY_PAGE_MARGINS, next.pageMargins.toFloat())
+            // NaN is the "unset / use book default" sentinel for the nullable knobs.
+            .putFloat(KEY_PARAGRAPH_INDENT, next.paragraphIndent?.toFloat() ?: Float.NaN)
+            .putFloat(KEY_PARAGRAPH_SPACING, next.paragraphSpacing?.toFloat() ?: Float.NaN)
+            .putBoolean(KEY_USE_PUBLISHER_STYLES, next.usePublisherStyles)
+            .putBoolean(KEY_IMMERSIVE_READING, next.immersiveReading)
             .apply()
         _flow.value = next
     }
@@ -36,6 +41,12 @@ class ReaderPreferencesStore(context: Context) {
         val lineSpacing = prefs.getFloat(KEY_LINE_SPACING, 1.4f).toDouble().coerceIn(1.0, 1.8)
         val tap = prefs.getBoolean(KEY_TAP_NAVIGATION, true)
         val pageMargins = prefs.getFloat(KEY_PAGE_MARGINS, 1.4f).toDouble().coerceIn(0.5, 2.0)
+        val paragraphIndent = prefs.getFloat(KEY_PARAGRAPH_INDENT, Float.NaN)
+            .takeUnless { it.isNaN() }?.toDouble()?.coerceIn(0.0, 3.0)
+        val paragraphSpacing = prefs.getFloat(KEY_PARAGRAPH_SPACING, Float.NaN)
+            .takeUnless { it.isNaN() }?.toDouble()?.coerceIn(0.0, 2.0)
+        val usePublisherStyles = prefs.getBoolean(KEY_USE_PUBLISHER_STYLES, false)
+        val immersiveReading = prefs.getBoolean(KEY_IMMERSIVE_READING, true)
         return ReaderPreferences(
             fontScale = fontScale,
             theme = theme,
@@ -43,6 +54,10 @@ class ReaderPreferencesStore(context: Context) {
             lineSpacing = lineSpacing,
             tapNavigationEnabled = tap,
             pageMargins = pageMargins,
+            paragraphIndent = paragraphIndent,
+            paragraphSpacing = paragraphSpacing,
+            usePublisherStyles = usePublisherStyles,
+            immersiveReading = immersiveReading,
         )
     }
 
@@ -53,5 +68,9 @@ class ReaderPreferencesStore(context: Context) {
         const val KEY_LINE_SPACING = "line_spacing"
         const val KEY_TAP_NAVIGATION = "tap_navigation_enabled"
         const val KEY_PAGE_MARGINS = "page_margins"
+        const val KEY_PARAGRAPH_INDENT = "paragraph_indent"
+        const val KEY_PARAGRAPH_SPACING = "paragraph_spacing"
+        const val KEY_USE_PUBLISHER_STYLES = "use_publisher_styles"
+        const val KEY_IMMERSIVE_READING = "immersive_reading"
     }
 }

--- a/reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt
+++ b/reader/src/test/java/io/theficos/ereader/reader/ReaderPreferencesStoreTest.kt
@@ -1,5 +1,6 @@
 package io.theficos.ereader.reader
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -10,6 +11,11 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
 class ReaderPreferencesStoreTest {
+
+    private fun context(): Context = ApplicationProvider.getApplicationContext()
+
+    private fun rawPrefs() =
+        context().getSharedPreferences("reader_prefs", Context.MODE_PRIVATE)
 
     private fun freshStore() = ReaderPreferencesStore(ApplicationProvider.getApplicationContext()).also {
         it.update { ReaderPreferences() }
@@ -41,5 +47,65 @@ class ReaderPreferencesStoreTest {
 
         val store2 = ReaderPreferencesStore(ApplicationProvider.getApplicationContext())
         assertThat(store2.flow.value.pageMargins).isWithin(0.001).of(1.8)
+    }
+
+    @Test fun `defaults for the new typography and immersive fields`() {
+        val store = freshStore()
+        assertThat(store.flow.value.paragraphIndent).isNull()
+        assertThat(store.flow.value.paragraphSpacing).isNull()
+        assertThat(store.flow.value.usePublisherStyles).isFalse()
+        assertThat(store.flow.value.immersiveReading).isTrue()
+    }
+
+    @Test fun `paragraphIndent round-trips (including back to null)`() {
+        val store1 = freshStore()
+        store1.update { it.copy(paragraphIndent = 1.5) }
+        assertThat(store1.flow.value.paragraphIndent).isWithin(0.001).of(1.5)
+
+        val store2 = ReaderPreferencesStore(context())
+        assertThat(store2.flow.value.paragraphIndent).isWithin(0.001).of(1.5)
+
+        store2.update { it.copy(paragraphIndent = null) }
+        val store3 = ReaderPreferencesStore(context())
+        assertThat(store3.flow.value.paragraphIndent).isNull()
+    }
+
+    @Test fun `paragraphSpacing round-trips`() {
+        val store1 = freshStore()
+        store1.update { it.copy(paragraphSpacing = 1.0) }
+        assertThat(store1.flow.value.paragraphSpacing).isWithin(0.001).of(1.0)
+
+        val store2 = ReaderPreferencesStore(context())
+        assertThat(store2.flow.value.paragraphSpacing).isWithin(0.001).of(1.0)
+    }
+
+    @Test fun `usePublisherStyles and immersiveReading round-trip`() {
+        val store1 = freshStore()
+        store1.update { it.copy(usePublisherStyles = true, immersiveReading = false) }
+
+        val store2 = ReaderPreferencesStore(context())
+        assertThat(store2.flow.value.usePublisherStyles).isTrue()
+        assertThat(store2.flow.value.immersiveReading).isFalse()
+    }
+
+    @Test fun `out-of-range stored paragraph values are clamped on load, never throw`() {
+        rawPrefs().edit()
+            .putFloat("paragraph_indent", 9.0f)
+            .putFloat("paragraph_spacing", -1.0f)
+            .apply()
+
+        val store = ReaderPreferencesStore(context())
+        assertThat(store.flow.value.paragraphIndent).isWithin(0.001).of(3.0)
+        assertThat(store.flow.value.paragraphSpacing).isWithin(0.001).of(0.0)
+    }
+
+    @Test fun `upgrade over empty prefs yields the intended defaults`() {
+        rawPrefs().edit().clear().apply()
+
+        val store = ReaderPreferencesStore(context())
+        assertThat(store.flow.value.paragraphIndent).isNull()
+        assertThat(store.flow.value.paragraphSpacing).isNull()
+        assertThat(store.flow.value.usePublisherStyles).isFalse()
+        assertThat(store.flow.value.immersiveReading).isTrue()
     }
 }


### PR DESCRIPTION
Implements the two open reader-display issues and hardens the surrounding UX after on-device testing.

Closes #82
Closes #83

## Features

**#82 — Page margins & paragraph styling.** Adds page-margin, paragraph-indent, and paragraph-spacing sliders to the reader settings. paragraphIndent/paragraphSpacing are modelled as nullable (`null` = keep the book's default) so upgrading doesn't force overrides onto every book. Readium 3.0.0 gates lineHeight/paragraphIndent/paragraphSpacing behind `advancedSettings = !publisherStyles`, which Quire never set — so the pre-existing line-spacing slider was a silent no-op. A new **"Use the book's paragraph styling"** toggle (default on) controls that gate and greys the three advanced sliders when enabled.

**#83 — Immersive full-screen reading.** Default-on mode that hides the status and navigation bars while reading, bound to the reader chrome (tap centre to reveal, auto-hide after 2.5s). Skips auto-hide while a screen reader is exploring.

## Fixes found while testing on-device

- **Restore-in-progress crashed** with `NetworkOnMainThreadException` — the use case ran on the caller's `viewModelScope` (Main). Now routed through `AppContainer.runRestoreInProgress` on `Dispatchers.IO`.
- **Reader chrome icons were black-on-dark** (nearly invisible in dark mode) — the bar used a bare background, so `LocalContentColor` fell back to Compose's default. Wrapped in a `Surface(contentColor = onSurface)`.
- **Visible resize/jump when leaving the immersive reader.** Two causes on the shared single-Activity window: toggling `decorFitsSystemWindows` at teardown, and the hidden system bars collapsing `WindowInsets.systemBars` to zero so the incoming screen re-padded when the bars reappeared. Fixed by going **edge-to-edge app-wide** (set once in `MainActivity`, never toggled) and revealing the bars at back-press so insets settle during the fade-in. Bare screens are wrapped in a `safeDrawing` inset; Scaffold screens already handle insets. (Also aligns the app with Android 15's forced edge-to-edge.)
- **Reader settings sheet wasn't scrollable**, so the "Full-screen reading" toggle (last item) fell off the bottom / under the nav bar. Now scrollable + nav-bar padded.

## Testing

- `ReaderPreferencesStore` unit tests: 10/10 pass (defaults, null round-trips, out-of-range clamping, empty-prefs upgrade).
- Debug APK verified on a Motorola edge 40 neo (Android 14): both features, restore, chrome visibility, immersive on/off, and a smooth jump-free exit across the app's screens.