### PR TITLE
ci: stop duplicate workflow runs + fix two pre-existing test failures

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -1,7 +1,11 @@
 name: android-ci
 
 on:
+  # Only main pushes here — that's where the version bump + release run. Feature
+  # branches are validated by the pull_request trigger below; without this filter a
+  # push to a branch with an open PR fires this workflow twice (once per event).
   push:
+    branches: [main]
     paths:
       - "app/**"
       - "auth/**"

--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -1,7 +1,11 @@
 name: server-ci
 
 on:
+  # Only main pushes here; feature branches are validated by the pull_request trigger
+  # below. Without the branch filter a push to a branch with an open PR runs this
+  # workflow twice (once per event). Mirrors android-ci.yaml / codeql.yaml.
   push:
+    branches: [main]
     paths:
       - "server/**"
       - ".github/workflows/server-ci.yaml"

--- a/app/src/test/java/io/theficos/ereader/ui/scan/ScanViewModelTest.kt
+++ b/app/src/test/java/io/theficos/ereader/ui/scan/ScanViewModelTest.kt
@@ -190,20 +190,31 @@ class ScanViewModelTest {
     /**
      * Regression: a slow, superseded scan must never clobber a newer scan's
      * terminal state. Scan A suspends inside runAffinity; scan B is submitted
-     * and succeeds; then A's affinity fails late. With the generation guard +
-     * CancellationException rethrow, A's stale write is dropped and B's Result
-     * stands. Uses UnconfinedTestDispatcher (set in setUp) so each launch runs
-     * eagerly up to its first real suspension; lookup returns synchronously and
-     * the IO hop completes inline, so A reliably parks on gateA before B runs.
+     * and succeeds; then A's gate is released late. The generation guard +
+     * CancellationException rethrow drop A's stale write and B's Result stands.
+     *
+     * [lookup] hops through the real [Dispatchers.IO] (see [ScanViewModel]), so
+     * we must NOT assume A parks on its gate before B is submitted — that race
+     * used to make this test flaky (if B lands first it cancels A before A ever
+     * calls runAffinity, and then B itself becomes call #1 and parks). Instead A
+     * signals [aReachedAffinity] the moment it enters runAffinity, and the test
+     * awaits that signal before submitting B — deterministic regardless of when
+     * the IO hop lands.
      */
     @Test fun `stale scan does not clobber a newer scan's result`() = runTest {
+        val aReachedAffinity = CompletableDeferred<Unit>()
         val gateA = CompletableDeferred<AffinityResponse>()
         var call = 0
         val vm = ScanViewModel(
             lookup = { bundle },
             runAffinity = {
                 call++
-                if (call == 1) gateA.await() else affinity
+                if (call == 1) {
+                    aReachedAffinity.complete(Unit)
+                    gateA.await()
+                } else {
+                    affinity
+                }
             },
             onReauth = { error("onReauth should not be called") },
         )
@@ -212,8 +223,10 @@ class ScanViewModelTest {
             assertThat(awaitItem()).isEqualTo(ScanUiState.Idle)
 
             vm.onIsbnSubmitted(isbn13) // scan A — will park awaiting gateA
-            // A's lookup IO hop completes, then A parks in runAffinity; the only
-            // emission is the Working flash.
+            // Block until A is provably the in-flight scan parked in runAffinity,
+            // so submitting B can only ever supersede A (never the reverse).
+            aReachedAffinity.await()
+
             var s = awaitItem()
             while (s is ScanUiState.Idle) s = awaitItem()
             assertThat(s).isEqualTo(ScanUiState.Working)

--- a/server/tests/unit/test_auth_backend_config.py
+++ b/server/tests/unit/test_auth_backend_config.py
@@ -38,6 +38,18 @@ def _create_app():
     return create_app()
 
 
+def _mounted_paths(app) -> set[str]:
+    """Registered route paths, read from the OpenAPI schema.
+
+    Robust across FastAPI/Starlette versions: newer FastAPI no longer flattens
+    ``include_router`` children into ``app.routes`` (it wraps them in an internal
+    ``_IncludedRouter``), so scanning ``app.routes[].path`` misses every mounted
+    router. The OpenAPI schema lists every in-schema route regardless of how the
+    router tree is represented.
+    """
+    return set(app.openapi()["paths"])
+
+
 # ----------------------------------------------------------------------------
 # Default: CalibreWeb Basic
 # ----------------------------------------------------------------------------
@@ -53,8 +65,8 @@ def test_default_backend_is_calibreweb():
 def test_calibreweb_backend_does_not_mount_auth_router():
     """OSS deployments should not surface ``/auth/v1/*`` at all."""
     app = _create_app()
-    routes = [r.path for r in app.routes if hasattr(r, "path")]
-    assert not any(p.startswith("/auth/v1") for p in routes), routes
+    paths = _mounted_paths(app)
+    assert not any(p.startswith("/auth/v1") for p in paths), paths
 
 
 # ----------------------------------------------------------------------------
@@ -76,11 +88,11 @@ def test_native_backend_mounts_auth_router(monkeypatch):
     monkeypatch.setenv("QUIRE_SERVER_AUTH_BACKEND", "native")
     monkeypatch.setenv("QUIRE_SERVER_AI_ENABLED", "false")
     app = _create_app()
-    routes = [r.path for r in app.routes if hasattr(r, "path")]
-    assert any(p == "/auth/v1/login" for p in routes), routes
-    assert any(p == "/auth/v1/logout" for p in routes), routes
-    assert any(p == "/auth/v1/magic-link/request" for p in routes), routes
-    assert any(p == "/auth/v1/magic-link/consume" for p in routes), routes
+    paths = _mounted_paths(app)
+    assert "/auth/v1/login" in paths, paths
+    assert "/auth/v1/logout" in paths, paths
+    assert "/auth/v1/magic-link/request" in paths, paths
+    assert "/auth/v1/magic-link/consume" in paths, paths
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## 1. Stop duplicate CI runs (the original ask)

`android-ci` and `server-ci` triggered on **both** `push` and `pull_request`. A push to a branch with an open PR fired each workflow **twice** on the same commit; the `concurrency` group can't dedupe them (push ref `refs/heads/<branch>` vs PR ref `refs/pull/N/merge`). Scoped the `push` trigger to `branches: [main]` on both — the `push` trigger is only needed on `main` (version bump + `release`, already gated on `github.ref == 'refs/heads/main'`). Mirrors the already-correct `codeql.yaml`. No change to `main`'s release behavior.

## 2. Two pre-existing test failures surfaced by re-running server-ci

Re-running after the GitHub Actions outage recovered exposed two failures **unrelated to the trigger change** — both pre-existed on `main`:

- **`server/tests/unit/test_auth_backend_config.py`** — FastAPI 0.139 / Starlette 1.3 (which CI installs fresh, unpinned) stopped flattening `include_router` children into `app.routes`; they're wrapped in an internal `_IncludedRouter`. So the test's `app.routes[].path` scan found none of the mounted routers, even though the routes work (561 integration tests hit `/auth/v1` and passed). Fixed to read `app.openapi()["paths"]` — stable across FastAPI/Starlette versions. Latent since `server-ci` last ran on `main` (2026-05-31); this PR is the first to re-trigger it.
- **`app/.../ScanViewModelTest` › stale-scan** — `lookup()` hops through the real `Dispatchers.IO`, so the virtual test scheduler couldn't guarantee scan A parked before scan B was submitted (a race → intermittent hang). Made deterministic: A signals when it enters `runAffinity` and the test awaits that before submitting B. Test-only.

## Verification

- Server: 348 unit tests pass under the newer fastapi/starlette CI resolves; the fixed test passes under both the pinned (lock) and fresh deps.
- Android: the stale-scan test passes across 4 forced re-runs.
- This PR should now show a **single** run per workflow (dedupe) and go green.